### PR TITLE
feat: add formatting check to CI

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -51,3 +51,20 @@ jobs:
 
       - name: Lint backend
         run: ruff check backend/app --select E,W,F --ignore E501
+
+  format:
+    runs-on: ubuntu-latest
+    name: Check Formatting
+
+    steps:
+      - uses: actions/checkout@v4
+      - uses: actions/setup-python@v5
+        with:
+          python-version: "3.12"
+          cache: pip
+
+      - name: Install ruff
+        run: pip install ruff
+
+      - name: Check code formatting with ruff
+        run: ruff format --check backend/

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -58,8 +58,28 @@ Include when opening a PR:
 - 2-space indentation
 - Use `const`/`let`, prefer async/await
 
-## Testing
+## Code Formatting
 
+We use [Ruff](https://docs.astral.sh/ruff/) to enforce code formatting automatically.
+
+**Before submitting a PR**, ensure your code is properly formatted:
+
+```bash
+# Install ruff if you haven't already (already in CI)
+pip install ruff
+
+# Check formatting (will exit with non-zero if issues found)
+ruff format --check backend/
+
+# Auto-format your code (optional but recommended)
+ruff format backend/
+```
+
+The CI runs `ruff format --check` on every pull request. If formatting checks fail, you can either:
+1. Run `ruff format backend/` locally and commit the changes
+2. Or fix the formatting manually
+
+## Testing
 ```bash
 cd backend && pytest -q  # Run all tests
 ```


### PR DESCRIPTION
This PR adds a formatting validation step to the CI pipeline using `ruff format --check`.

**Changes:**
- Added `format` job to `.github/workflows/ci.yml` that runs `ruff format --check backend/`
- Updated `CONTRIBUTING.md` with instructions for running formatting checks locally

**Why:**
Ensures consistent code style across all contributions and catches formatting issues before merge.

**Acceptance:**
- [x] Formatting check runs automatically on every PR
- [x] Misformatted code fails CI
- [x] Contributors have clear local instructions

Fixes #13

---
*Automated PR submitted via Hermes Agent*