### PR TITLE
Add backend formatting check to CI

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -37,7 +37,7 @@ jobs:
 
   lint:
     runs-on: ubuntu-latest
-    name: Lint
+    name: Lint and Format
 
     steps:
       - uses: actions/checkout@v4
@@ -51,3 +51,6 @@ jobs:
 
       - name: Lint backend
         run: ruff check backend/app --select E,W,F --ignore E501
+
+      - name: Check backend formatting
+        run: ruff format --check backend/app backend/tests

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -53,6 +53,16 @@ Include when opening a PR:
 - 4-space indentation, follow PEP 8
 - Type hints encouraged
 - Example: `def analyze(code: str) -> dict:`
+- Run the backend Ruff checks before opening a PR:
+  ```bash
+  pip install ruff
+  ruff check backend/app --select E,W,F --ignore E501
+  ruff format --check backend/app backend/tests
+  ```
+- To apply formatting locally, run:
+  ```bash
+  ruff format backend/app backend/tests
+  ```
 
 ### JavaScript
 - 2-space indentation

--- a/backend/app/database.py
+++ b/backend/app/database.py
@@ -4,7 +4,9 @@ from sqlalchemy.orm import declarative_base, sessionmaker
 from app.config import settings
 
 
-connect_args = {"check_same_thread": False} if settings.database_url.startswith("sqlite") else {}
+connect_args = (
+    {"check_same_thread": False} if settings.database_url.startswith("sqlite") else {}
+)
 
 engine = create_engine(settings.database_url, connect_args=connect_args)
 SessionLocal = sessionmaker(autocommit=False, autoflush=False, bind=engine)

--- a/backend/app/main.py
+++ b/backend/app/main.py
@@ -16,8 +16,7 @@ from app.routers import explanation, debugging, suggestions, analyze
 
 # ── Logging ──
 logging.basicConfig(
-    level=logging.INFO,
-    format="%(asctime)s [%(levelname)s] %(name)s: %(message)s"
+    level=logging.INFO, format="%(asctime)s [%(levelname)s] %(name)s: %(message)s"
 )
 logger = logging.getLogger("qyverix")
 
@@ -39,6 +38,7 @@ app.add_middleware(
     allow_headers=["*"],
 )
 
+
 # ── Request ID + Timing Middleware ──
 @app.middleware("http")
 async def request_middleware(request: Request, call_next):
@@ -48,8 +48,11 @@ async def request_middleware(request: Request, call_next):
     duration = round((time.time() - start) * 1000, 2)
     response.headers["X-Request-ID"] = request_id
     response.headers["X-Response-Time"] = f"{duration}ms"
-    logger.info(f"[{request_id}] {request.method} {request.url.path} → {response.status_code} ({duration}ms)")
+    logger.info(
+        f"[{request_id}] {request.method} {request.url.path} → {response.status_code} ({duration}ms)"
+    )
     return response
+
 
 # ── Exception Handler ──
 @app.exception_handler(Exception)
@@ -57,8 +60,9 @@ async def global_exception_handler(request: Request, exc: Exception):
     logger.error(f"Unhandled error: {exc}", exc_info=True)
     return JSONResponse(
         status_code=500,
-        content={"detail": "An internal server error occurred. Please try again."}
+        content={"detail": "An internal server error occurred. Please try again."},
     )
+
 
 # ── Routers ──
 app.include_router(explanation.router, prefix="/explanation", tags=["Explanation"])
@@ -69,19 +73,26 @@ app.include_router(analyze.router, prefix="/analyze", tags=["Full Analysis"])
 # ── Serve frontend if built ──
 # Try multiple possible paths (backend Dockerfile vs root Dockerfile context)
 possible_frontends = [
-    os.path.abspath(os.path.join(os.path.dirname(__file__), "..", "..", "frontend")),  # backend/Dockerfile build
-    os.path.abspath(os.path.join(os.path.dirname(__file__), "..", "frontend")),         # root Dockerfile build
-    "/app/frontend",                                                                     # root Dockerfile explicit
+    os.path.abspath(
+        os.path.join(os.path.dirname(__file__), "..", "..", "frontend")
+    ),  # backend/Dockerfile build
+    os.path.abspath(
+        os.path.join(os.path.dirname(__file__), "..", "frontend")
+    ),  # root Dockerfile build
+    "/app/frontend",  # root Dockerfile explicit
 ]
 FRONTEND_PATH = None
 for path in possible_frontends:
     if os.path.isdir(path):
         FRONTEND_PATH = path
         logger.info(f"Frontend mounted from: {FRONTEND_PATH}")
-        app.mount("/app", StaticFiles(directory=FRONTEND_PATH, html=True), name="frontend")
+        app.mount(
+            "/app", StaticFiles(directory=FRONTEND_PATH, html=True), name="frontend"
+        )
         break
 if not FRONTEND_PATH:
     logger.warning(f"Frontend directory not found. Checked: {possible_frontends}")
+
 
 # ── Root ──
 @app.get("/", include_in_schema=False)
@@ -93,6 +104,7 @@ def root():
 def ping():
     return {"message": "pong"}
 
+
 # ── Health ──
 @app.get("/health", tags=["System"])
 def health():
@@ -103,6 +115,7 @@ def health():
         "llm_enabled": os.getenv("LLM_ENABLED", "false").lower() == "true",
     }
 
+
 # ── Info ──
 @app.get("/info", tags=["System"])
 def info():
@@ -111,5 +124,5 @@ def info():
         "description": "Open-source AI Developer Assistant",
         "endpoints": ["/explanation/", "/debugging/", "/suggestions/", "/analyze/"],
         "docs": "/docs",
-        "github": "https://github.com/imDarshanGK/AI-dev-assistant"
+        "github": "https://github.com/imDarshanGK/AI-dev-assistant",
     }

--- a/backend/app/models.py
+++ b/backend/app/models.py
@@ -12,10 +12,16 @@ class User(Base):
     id: Mapped[int] = mapped_column(Integer, primary_key=True, index=True)
     email: Mapped[str] = mapped_column(String(320), unique=True, index=True)
     password_hash: Mapped[str] = mapped_column(String(256))
-    created_at: Mapped[datetime] = mapped_column(DateTime, default=lambda: datetime.now(UTC))
+    created_at: Mapped[datetime] = mapped_column(
+        DateTime, default=lambda: datetime.now(UTC)
+    )
 
-    histories = relationship("QueryHistory", back_populates="user", cascade="all, delete-orphan")
-    favorites = relationship("FavoriteResult", back_populates="user", cascade="all, delete-orphan")
+    histories = relationship(
+        "QueryHistory", back_populates="user", cascade="all, delete-orphan"
+    )
+    favorites = relationship(
+        "FavoriteResult", back_populates="user", cascade="all, delete-orphan"
+    )
 
 
 class QueryHistory(Base):
@@ -26,7 +32,9 @@ class QueryHistory(Base):
     action: Mapped[str] = mapped_column(String(50))
     code: Mapped[str] = mapped_column(Text)
     result_json: Mapped[str] = mapped_column(Text)
-    created_at: Mapped[datetime] = mapped_column(DateTime, default=lambda: datetime.now(UTC))
+    created_at: Mapped[datetime] = mapped_column(
+        DateTime, default=lambda: datetime.now(UTC)
+    )
 
     user = relationship("User", back_populates="histories")
 
@@ -40,7 +48,9 @@ class FavoriteResult(Base):
     action: Mapped[str] = mapped_column(String(50))
     code: Mapped[str] = mapped_column(Text)
     result_json: Mapped[str] = mapped_column(Text)
-    created_at: Mapped[datetime] = mapped_column(DateTime, default=lambda: datetime.now(UTC))
+    created_at: Mapped[datetime] = mapped_column(
+        DateTime, default=lambda: datetime.now(UTC)
+    )
 
     user = relationship("User", back_populates="favorites")
 
@@ -53,4 +63,6 @@ class SharedSnippet(Base):
     action: Mapped[str] = mapped_column(String(50))
     code: Mapped[str] = mapped_column(Text)
     result_json: Mapped[str] = mapped_column(Text)
-    created_at: Mapped[datetime] = mapped_column(DateTime, default=lambda: datetime.now(UTC))
+    created_at: Mapped[datetime] = mapped_column(
+        DateTime, default=lambda: datetime.now(UTC)
+    )

--- a/backend/app/routers/analyze.py
+++ b/backend/app/routers/analyze.py
@@ -8,7 +8,11 @@ logger = logging.getLogger("qyverix.analyze")
 router = APIRouter()
 
 
-@router.post("/", response_model=AnalyzeResponse, summary="Full code analysis — explain + debug + suggest")
+@router.post(
+    "/",
+    response_model=AnalyzeResponse,
+    summary="Full code analysis — explain + debug + suggest",
+)
 async def analyze_endpoint(request: CodeRequest):
     """
     One-shot full analysis. Returns all three sections:
@@ -36,4 +40,6 @@ async def analyze_endpoint(request: CodeRequest):
         raise HTTPException(status_code=422, detail=str(e))
     except Exception as e:
         logger.error(f"Analyze failed: {e}", exc_info=True)
-        raise HTTPException(status_code=500, detail="Analysis failed. Please try again.")
+        raise HTTPException(
+            status_code=500, detail="Analysis failed. Please try again."
+        )

--- a/backend/app/routers/auth.py
+++ b/backend/app/routers/auth.py
@@ -5,18 +5,30 @@ from sqlalchemy.orm import Session
 from app.database import get_db
 from app.models import User
 from app.schemas import AuthResponse, LoginRequest, SignupRequest, UserProfileResponse
-from app.security import create_access_token, get_current_user, hash_password, verify_password
+from app.security import (
+    create_access_token,
+    get_current_user,
+    hash_password,
+    verify_password,
+)
 
 router = APIRouter(prefix="/auth", tags=["Auth"])
 
 
 @router.post("/signup", response_model=AuthResponse)
 def signup(payload: SignupRequest, db: Session = Depends(get_db)):
-    existing = db.execute(select(User).where(User.email == payload.email.lower().strip())).scalar_one_or_none()
+    existing = db.execute(
+        select(User).where(User.email == payload.email.lower().strip())
+    ).scalar_one_or_none()
     if existing is not None:
-        raise HTTPException(status_code=status.HTTP_409_CONFLICT, detail="Email already exists")
+        raise HTTPException(
+            status_code=status.HTTP_409_CONFLICT, detail="Email already exists"
+        )
 
-    user = User(email=payload.email.lower().strip(), password_hash=hash_password(payload.password))
+    user = User(
+        email=payload.email.lower().strip(),
+        password_hash=hash_password(payload.password),
+    )
     db.add(user)
     db.commit()
     db.refresh(user)
@@ -27,9 +39,13 @@ def signup(payload: SignupRequest, db: Session = Depends(get_db)):
 
 @router.post("/login", response_model=AuthResponse)
 def login(payload: LoginRequest, db: Session = Depends(get_db)):
-    user = db.execute(select(User).where(User.email == payload.email.lower().strip())).scalar_one_or_none()
+    user = db.execute(
+        select(User).where(User.email == payload.email.lower().strip())
+    ).scalar_one_or_none()
     if user is None or not verify_password(payload.password, user.password_hash):
-        raise HTTPException(status_code=status.HTTP_401_UNAUTHORIZED, detail="Invalid credentials")
+        raise HTTPException(
+            status_code=status.HTTP_401_UNAUTHORIZED, detail="Invalid credentials"
+        )
 
     token = create_access_token(user.id)
     return AuthResponse(access_token=token, user_id=user.id, email=user.email)

--- a/backend/app/routers/chat.py
+++ b/backend/app/routers/chat.py
@@ -1,7 +1,12 @@
 from fastapi import APIRouter
 
 from app.config import settings
-from app.schemas import ChatMessageRequest, ChatMessageResponse, ChatRequest, ChatResponse
+from app.schemas import (
+    ChatMessageRequest,
+    ChatMessageResponse,
+    ChatRequest,
+    ChatResponse,
+)
 from app.services.code_assistant import chat_fallback_reply
 from app.services.llm_analysis import llm_analysis_client
 

--- a/backend/app/routers/debugging.py
+++ b/backend/app/routers/debugging.py
@@ -7,7 +7,9 @@ logger = logging.getLogger("qyverix.debugging")
 router = APIRouter()
 
 
-@router.post("/", response_model=DebuggingResponse, summary="Detect bugs and issues in code")
+@router.post(
+    "/", response_model=DebuggingResponse, summary="Detect bugs and issues in code"
+)
 async def debugging_endpoint(request: CodeRequest):
     """
     Scans the code for:
@@ -25,4 +27,6 @@ async def debugging_endpoint(request: CodeRequest):
         raise HTTPException(status_code=422, detail=str(e))
     except Exception as e:
         logger.error(f"Debugging failed: {e}", exc_info=True)
-        raise HTTPException(status_code=500, detail="Failed to debug code. Please try again.")
+        raise HTTPException(
+            status_code=500, detail="Failed to debug code. Please try again."
+        )

--- a/backend/app/routers/explanation.py
+++ b/backend/app/routers/explanation.py
@@ -7,7 +7,9 @@ logger = logging.getLogger("qyverix.explanation")
 router = APIRouter()
 
 
-@router.post("/", response_model=ExplanationResponse, summary="Explain code in plain English")
+@router.post(
+    "/", response_model=ExplanationResponse, summary="Explain code in plain English"
+)
 async def explanation_endpoint(request: CodeRequest):
     """
     Analyzes the provided code and returns:
@@ -23,4 +25,6 @@ async def explanation_endpoint(request: CodeRequest):
         raise HTTPException(status_code=422, detail=str(e))
     except Exception as e:
         logger.error(f"Explanation failed: {e}", exc_info=True)
-        raise HTTPException(status_code=500, detail="Failed to explain code. Please try again.")
+        raise HTTPException(
+            status_code=500, detail="Failed to explain code. Please try again."
+        )

--- a/backend/app/routers/share.py
+++ b/backend/app/routers/share.py
@@ -16,13 +16,18 @@ def create_share(payload: ShareCreateRequest, db: Session = Depends(get_db)):
     token = ""
     for _ in range(5):
         candidate = secrets.token_urlsafe(8)
-        exists = db.execute(select(SharedSnippet).where(SharedSnippet.token == candidate)).scalar_one_or_none()
+        exists = db.execute(
+            select(SharedSnippet).where(SharedSnippet.token == candidate)
+        ).scalar_one_or_none()
         if exists is None:
             token = candidate
             break
 
     if not token:
-        raise HTTPException(status_code=status.HTTP_500_INTERNAL_SERVER_ERROR, detail="Could not create share token")
+        raise HTTPException(
+            status_code=status.HTTP_500_INTERNAL_SERVER_ERROR,
+            detail="Could not create share token",
+        )
 
     record = SharedSnippet(
         token=token,
@@ -45,9 +50,13 @@ def create_share(payload: ShareCreateRequest, db: Session = Depends(get_db)):
 
 @router.get("/{token}", response_model=ShareRecord)
 def get_share(token: str, db: Session = Depends(get_db)):
-    record = db.execute(select(SharedSnippet).where(SharedSnippet.token == token)).scalar_one_or_none()
+    record = db.execute(
+        select(SharedSnippet).where(SharedSnippet.token == token)
+    ).scalar_one_or_none()
     if record is None:
-        raise HTTPException(status_code=status.HTTP_404_NOT_FOUND, detail="Shared result not found")
+        raise HTTPException(
+            status_code=status.HTTP_404_NOT_FOUND, detail="Shared result not found"
+        )
 
     return ShareRecord(
         token=record.token,

--- a/backend/app/routers/suggestions.py
+++ b/backend/app/routers/suggestions.py
@@ -7,7 +7,9 @@ logger = logging.getLogger("qyverix.suggestions")
 router = APIRouter()
 
 
-@router.post("/", response_model=SuggestionsResponse, summary="Get code improvement suggestions")
+@router.post(
+    "/", response_model=SuggestionsResponse, summary="Get code improvement suggestions"
+)
 async def suggestions_endpoint(request: CodeRequest):
     """
     Returns actionable improvement suggestions including:
@@ -24,4 +26,6 @@ async def suggestions_endpoint(request: CodeRequest):
         raise HTTPException(status_code=422, detail=str(e))
     except Exception as e:
         logger.error(f"Suggestions failed: {e}", exc_info=True)
-        raise HTTPException(status_code=500, detail="Failed to generate suggestions. Please try again.")
+        raise HTTPException(
+            status_code=500, detail="Failed to generate suggestions. Please try again."
+        )

--- a/backend/app/routers/user_data.py
+++ b/backend/app/routers/user_data.py
@@ -16,10 +16,19 @@ router = APIRouter(prefix="/user", tags=["User Data"])
 
 
 @router.get("/history", response_model=list[HistoryRecord])
-def list_history(current_user: User = Depends(get_current_user), db: Session = Depends(get_db)):
-    records = db.execute(
-        select(QueryHistory).where(QueryHistory.user_id == current_user.id).order_by(QueryHistory.id.desc()).limit(50)
-    ).scalars().all()
+def list_history(
+    current_user: User = Depends(get_current_user), db: Session = Depends(get_db)
+):
+    records = (
+        db.execute(
+            select(QueryHistory)
+            .where(QueryHistory.user_id == current_user.id)
+            .order_by(QueryHistory.id.desc())
+            .limit(50)
+        )
+        .scalars()
+        .all()
+    )
 
     return [
         HistoryRecord(
@@ -65,10 +74,14 @@ def delete_history(
     db: Session = Depends(get_db),
 ):
     record = db.execute(
-        select(QueryHistory).where(QueryHistory.id == history_id, QueryHistory.user_id == current_user.id)
+        select(QueryHistory).where(
+            QueryHistory.id == history_id, QueryHistory.user_id == current_user.id
+        )
     ).scalar_one_or_none()
     if record is None:
-        raise HTTPException(status_code=status.HTTP_404_NOT_FOUND, detail="History record not found")
+        raise HTTPException(
+            status_code=status.HTTP_404_NOT_FOUND, detail="History record not found"
+        )
 
     db.execute(delete(QueryHistory).where(QueryHistory.id == history_id))
     db.commit()
@@ -80,16 +93,27 @@ def clear_history(
     current_user: User = Depends(get_current_user),
     db: Session = Depends(get_db),
 ):
-    result = db.execute(delete(QueryHistory).where(QueryHistory.user_id == current_user.id))
+    result = db.execute(
+        delete(QueryHistory).where(QueryHistory.user_id == current_user.id)
+    )
     db.commit()
     return {"status": "cleared", "deleted": result.rowcount or 0}
 
 
 @router.get("/favorites", response_model=list[FavoriteRecord])
-def list_favorites(current_user: User = Depends(get_current_user), db: Session = Depends(get_db)):
-    records = db.execute(
-        select(FavoriteResult).where(FavoriteResult.user_id == current_user.id).order_by(FavoriteResult.id.desc()).limit(50)
-    ).scalars().all()
+def list_favorites(
+    current_user: User = Depends(get_current_user), db: Session = Depends(get_db)
+):
+    records = (
+        db.execute(
+            select(FavoriteResult)
+            .where(FavoriteResult.user_id == current_user.id)
+            .order_by(FavoriteResult.id.desc())
+            .limit(50)
+        )
+        .scalars()
+        .all()
+    )
 
     return [
         FavoriteRecord(
@@ -138,10 +162,14 @@ def delete_favorite(
     db: Session = Depends(get_db),
 ):
     record = db.execute(
-        select(FavoriteResult).where(FavoriteResult.id == favorite_id, FavoriteResult.user_id == current_user.id)
+        select(FavoriteResult).where(
+            FavoriteResult.id == favorite_id, FavoriteResult.user_id == current_user.id
+        )
     ).scalar_one_or_none()
     if record is None:
-        raise HTTPException(status_code=status.HTTP_404_NOT_FOUND, detail="Favorite not found")
+        raise HTTPException(
+            status_code=status.HTTP_404_NOT_FOUND, detail="Favorite not found"
+        )
 
     db.execute(delete(FavoriteResult).where(FavoriteResult.id == favorite_id))
     db.commit()
@@ -153,6 +181,8 @@ def clear_favorites(
     current_user: User = Depends(get_current_user),
     db: Session = Depends(get_db),
 ):
-    result = db.execute(delete(FavoriteResult).where(FavoriteResult.user_id == current_user.id))
+    result = db.execute(
+        delete(FavoriteResult).where(FavoriteResult.user_id == current_user.id)
+    )
     db.commit()
     return {"status": "cleared", "deleted": result.rowcount or 0}

--- a/backend/app/schemas.py
+++ b/backend/app/schemas.py
@@ -7,8 +7,12 @@ from typing import Optional
 
 
 class CodeRequest(BaseModel):
-    code: str = Field(..., min_length=1, max_length=50_000, description="Source code to analyze")
-    language: Optional[str] = Field(None, description="Optional language hint (python, javascript, java, etc.)")
+    code: str = Field(
+        ..., min_length=1, max_length=50_000, description="Source code to analyze"
+    )
+    language: Optional[str] = Field(
+        None, description="Optional language hint (python, javascript, java, etc.)"
+    )
 
     @field_validator("code")
     @classmethod

--- a/backend/app/security.py
+++ b/backend/app/security.py
@@ -35,13 +35,17 @@ def verify_password(password: str, encoded: str) -> bool:
 
 
 def create_access_token(user_id: int) -> str:
-    expires = datetime.now(timezone.utc) + timedelta(minutes=settings.access_token_minutes)
+    expires = datetime.now(timezone.utc) + timedelta(
+        minutes=settings.access_token_minutes
+    )
     payload = {"sub": str(user_id), "exp": expires}
     return jwt.encode(payload, settings.jwt_secret, algorithm=settings.jwt_algorithm)
 
 
 def decode_access_token(token: str) -> int:
-    payload = jwt.decode(token, settings.jwt_secret, algorithms=[settings.jwt_algorithm])
+    payload = jwt.decode(
+        token, settings.jwt_secret, algorithms=[settings.jwt_algorithm]
+    )
     return int(payload["sub"])
 
 
@@ -50,15 +54,21 @@ def get_current_user(
     db: Session = Depends(get_db),
 ) -> User:
     if credentials is None:
-        raise HTTPException(status_code=status.HTTP_401_UNAUTHORIZED, detail="Authentication required")
+        raise HTTPException(
+            status_code=status.HTTP_401_UNAUTHORIZED, detail="Authentication required"
+        )
 
     try:
         user_id = decode_access_token(credentials.credentials)
     except Exception:
-        raise HTTPException(status_code=status.HTTP_401_UNAUTHORIZED, detail="Invalid token")
+        raise HTTPException(
+            status_code=status.HTTP_401_UNAUTHORIZED, detail="Invalid token"
+        )
 
     user = db.get(User, user_id)
     if user is None:
-        raise HTTPException(status_code=status.HTTP_401_UNAUTHORIZED, detail="User not found")
+        raise HTTPException(
+            status_code=status.HTTP_401_UNAUTHORIZED, detail="User not found"
+        )
 
     return user

--- a/backend/app/services/ai_provider.py
+++ b/backend/app/services/ai_provider.py
@@ -45,12 +45,15 @@ async def llm_enhance(prompt: str) -> Optional[str]:
                 json={
                     "model": LLM_MODEL,
                     "messages": [
-                        {"role": "system", "content": "You are QyverixAI, a helpful AI assistant for beginner programmers. Keep explanations simple and encouraging."},
-                        {"role": "user", "content": prompt}
+                        {
+                            "role": "system",
+                            "content": "You are QyverixAI, a helpful AI assistant for beginner programmers. Keep explanations simple and encouraging.",
+                        },
+                        {"role": "user", "content": prompt},
                     ],
                     "max_tokens": 500,
                     "temperature": 0.3,
-                }
+                },
             )
             resp.raise_for_status()
             data = resp.json()

--- a/backend/app/services/cache.py
+++ b/backend/app/services/cache.py
@@ -66,7 +66,9 @@ class AppCache:
         key = self._make_key(namespace, code)
         if self._redis_client is not None:
             try:
-                self._redis_client.setex(key, settings.cache_ttl_seconds, json.dumps(payload))
+                self._redis_client.setex(
+                    key, settings.cache_ttl_seconds, json.dumps(payload)
+                )
                 return
             except Exception as exc:
                 logger.warning("redis_set_failed key=%s detail=%s", key, str(exc))

--- a/backend/app/services/code_assistant.py
+++ b/backend/app/services/code_assistant.py
@@ -8,8 +8,11 @@ import ast
 import logging
 from typing import Optional
 from app.schemas import (
-    ExplanationResponse, DebuggingResponse, DebugIssue,
-    SuggestionsResponse, SuggestionCard
+    ExplanationResponse,
+    DebuggingResponse,
+    DebugIssue,
+    SuggestionsResponse,
+    SuggestionCard,
 )
 
 logger = logging.getLogger("qyverix.assistant")
@@ -27,13 +30,15 @@ def _append_issue(
     key = (issue_type, line, description)
     if key in seen:
         return
-    issues.append(DebugIssue(
-        type=issue_type,
-        line=line,
-        description=description,
-        suggestion=suggestion,
-        severity=severity,
-    ))
+    issues.append(
+        DebugIssue(
+            type=issue_type,
+            line=line,
+            description=description,
+            suggestion=suggestion,
+            severity=severity,
+        )
+    )
     seen.add(key)
 
 
@@ -62,10 +67,18 @@ def _python_debug_issues(code: str) -> list[DebugIssue]:
     divide_param_index: dict[str, int] = {}
 
     for node in ast.walk(tree):
-        if isinstance(node, ast.Assign) and len(node.targets) == 1 and isinstance(node.targets[0], ast.Name):
+        if (
+            isinstance(node, ast.Assign)
+            and len(node.targets) == 1
+            and isinstance(node.targets[0], ast.Name)
+        ):
             target = node.targets[0].id
             value = node.value
-            if isinstance(value, ast.Call) and isinstance(value.func, ast.Name) and value.func.id == "input":
+            if (
+                isinstance(value, ast.Call)
+                and isinstance(value.func, ast.Name)
+                and value.func.id == "input"
+            ):
                 input_vars.add(target)
                 variable_kinds[target] = "str"
             elif isinstance(value, ast.Constant):
@@ -94,13 +107,21 @@ def _python_debug_issues(code: str) -> list[DebugIssue]:
         if isinstance(node, ast.FunctionDef):
             arg_names = [a.arg for a in node.args.args]
             for inner in ast.walk(node):
-                if isinstance(inner, ast.BinOp) and isinstance(inner.op, ast.Div) and isinstance(inner.right, ast.Name):
+                if (
+                    isinstance(inner, ast.BinOp)
+                    and isinstance(inner.op, ast.Div)
+                    and isinstance(inner.right, ast.Name)
+                ):
                     param = inner.right.id
                     if param in arg_names:
                         divide_param_index[node.name] = arg_names.index(param)
 
     for node in ast.walk(tree):
-        if isinstance(node, ast.Compare) and isinstance(node.left, ast.Name) and node.left.id in input_vars:
+        if (
+            isinstance(node, ast.Compare)
+            and isinstance(node.left, ast.Name)
+            and node.left.id in input_vars
+        ):
             has_numeric = any(
                 isinstance(comp, ast.Constant) and isinstance(comp.value, (int, float))
                 for comp in node.comparators
@@ -136,7 +157,11 @@ def _python_debug_issues(code: str) -> list[DebugIssue]:
                     "error",
                 )
 
-        if isinstance(node, ast.Call) and isinstance(node.func, ast.Name) and node.func.id in divide_param_index:
+        if (
+            isinstance(node, ast.Call)
+            and isinstance(node.func, ast.Name)
+            and node.func.id in divide_param_index
+        ):
             idx = divide_param_index[node.func.id]
             if idx < len(node.args):
                 arg = node.args[idx]
@@ -152,7 +177,9 @@ def _python_debug_issues(code: str) -> list[DebugIssue]:
                     )
 
         if isinstance(node, ast.BinOp) and isinstance(node.op, ast.Add):
-            left_is_str = isinstance(node.left, ast.Constant) and isinstance(node.left.value, str)
+            left_is_str = isinstance(node.left, ast.Constant) and isinstance(
+                node.left.value, str
+            )
             if left_is_str and isinstance(node.right, ast.Name):
                 kind = variable_kinds.get(node.right.id)
                 if kind != "str":
@@ -162,29 +189,35 @@ def _python_debug_issues(code: str) -> list[DebugIssue]:
                         "Type Error Risk",
                         node.lineno,
                         f"String concatenation uses '{node.right.id}', which may not be a string.",
-                        f"Wrap with str(...): \"...\" + str({node.right.id}) or use an f-string.",
+                        f'Wrap with str(...): "..." + str({node.right.id}) or use an f-string.',
                         "warning",
                     )
 
     return issues
 
+
 # ── Language Detection ──
 LANG_PATTERNS = {
-    "Python":     [r"\bdef \w+\(", r"\bimport \w+", r"\bprint\(", r"if __name__"],
+    "Python": [r"\bdef \w+\(", r"\bimport \w+", r"\bprint\(", r"if __name__"],
     "JavaScript": [r"\bconst \b", r"\blet \b", r"\bvar \b", r"=>\s*{", r"console\.log"],
-    "TypeScript": [r":\s*(string|number|boolean|any)\b", r"\binterface \w+", r"\btype \w+\s*="],
-    "Java":       [r"public class", r"System\.out\.println", r"\bvoid \w+\("],
-    "C++":        [r"#include\s*<", r"\bstd::", r"\bcout\b"],
-    "C":          [r"#include\s*<stdio\.h>", r"\bprintf\(", r"\bscanf\("],
-    "Go":         [r"\bfunc \w+\(", r"\bpackage \w+", r"\bfmt\.Println"],
-    "Rust":       [r"\bfn \w+\(", r"\blet mut\b", r"\bprintln!"],
-    "Ruby":       [r"\bdef \w+", r"\bend\b", r"\bputs\b"],
-    "PHP":        [r"<\?php", r"\$\w+\s*=", r"echo\s+"],
-    "SQL":        [r"\bSELECT\b", r"\bFROM\b", r"\bWHERE\b"],
-    "HTML":       [r"<!DOCTYPE html>", r"<html", r"<div\b"],
-    "CSS":        [r"\{[\s\S]*?:\s*[\s\S]*?;", r"\.\w+\s*\{", r"#\w+\s*\{"],
-    "Bash":       [r"#!/bin/bash", r"\becho\b", r"\$\("],
+    "TypeScript": [
+        r":\s*(string|number|boolean|any)\b",
+        r"\binterface \w+",
+        r"\btype \w+\s*=",
+    ],
+    "Java": [r"public class", r"System\.out\.println", r"\bvoid \w+\("],
+    "C++": [r"#include\s*<", r"\bstd::", r"\bcout\b"],
+    "C": [r"#include\s*<stdio\.h>", r"\bprintf\(", r"\bscanf\("],
+    "Go": [r"\bfunc \w+\(", r"\bpackage \w+", r"\bfmt\.Println"],
+    "Rust": [r"\bfn \w+\(", r"\blet mut\b", r"\bprintln!"],
+    "Ruby": [r"\bdef \w+", r"\bend\b", r"\bputs\b"],
+    "PHP": [r"<\?php", r"\$\w+\s*=", r"echo\s+"],
+    "SQL": [r"\bSELECT\b", r"\bFROM\b", r"\bWHERE\b"],
+    "HTML": [r"<!DOCTYPE html>", r"<html", r"<div\b"],
+    "CSS": [r"\{[\s\S]*?:\s*[\s\S]*?;", r"\.\w+\s*\{", r"#\w+\s*\{"],
+    "Bash": [r"#!/bin/bash", r"\becho\b", r"\$\("],
 }
+
 
 def detect_language(code: str) -> str:
     scores = {}
@@ -192,6 +225,7 @@ def detect_language(code: str) -> str:
         scores[lang] = sum(1 for p in patterns if re.search(p, code))
     best = max(scores, key=scores.get)
     return best if scores[best] > 0 else "Unknown"
+
 
 # ── Complexity ──
 def estimate_complexity(code: str) -> str:
@@ -203,6 +237,7 @@ def estimate_complexity(code: str) -> str:
         return "Intermediate"
     return "Advanced"
 
+
 # ── Explanation Service ──
 def explain_code(code: str, language: Optional[str] = None) -> ExplanationResponse:
     lang = language or detect_language(code)
@@ -211,7 +246,9 @@ def explain_code(code: str, language: Optional[str] = None) -> ExplanationRespon
     complexity = estimate_complexity(code)
 
     # Build key points
-    points = [f"The code is written in {lang} with {line_count} line{'s' if line_count != 1 else ''}."]
+    points = [
+        f"The code is written in {lang} with {line_count} line{'s' if line_count != 1 else ''}."
+    ]
 
     func_names = re.findall(r"def (\w+)\(|function (\w+)\(|func (\w+)\(", code)
     if func_names:
@@ -238,27 +275,122 @@ def explain_code(code: str, language: Optional[str] = None) -> ExplanationRespon
         f"and {'includes control flow logic' if re.search(r'if|for|while', code) else 'performs direct operations'}."
     )
 
-    return ExplanationResponse(language=lang, summary=summary, key_points=points, complexity=complexity)
+    return ExplanationResponse(
+        language=lang, summary=summary, key_points=points, complexity=complexity
+    )
+
 
 # ── Debugging Rules ──
 DEBUG_RULES = [
     # Python
-    {"pattern": r"\/\s*0\b|\/0\b",            "lang": None, "type": "ZeroDivisionError",    "severity": "error",   "desc": "Possible division by zero detected.",            "fix": "Check if the denominator is zero before dividing."},
-    {"pattern": r"\bprint\s+['\"]",            "lang": "Python", "type": "Syntax (Python 2)","severity": "warning", "desc": "Looks like Python 2 print statement.",           "fix": "Use print() function: print('...')"},
-    {"pattern": r"==\s*None\b",                "lang": "Python", "type": "Style Warning",    "severity": "warning", "desc": "Comparison to None using '==' instead of 'is'.", "fix": "Use `is None` instead of `== None`."},
-    {"pattern": r"\bexcept:\s*$",              "lang": None, "type": "Bare Except",          "severity": "warning", "desc": "Bare except clause catches all exceptions.",      "fix": "Specify the exception type: except ValueError:"},
-    {"pattern": r"[a-z]\s*=\s*[a-z]\s*=",     "lang": None, "type": "Chained Assignment",   "severity": "info",    "desc": "Chained assignment detected.",                   "fix": "Ensure this is intentional and variables are correctly set."},
+    {
+        "pattern": r"\/\s*0\b|\/0\b",
+        "lang": None,
+        "type": "ZeroDivisionError",
+        "severity": "error",
+        "desc": "Possible division by zero detected.",
+        "fix": "Check if the denominator is zero before dividing.",
+    },
+    {
+        "pattern": r"\bprint\s+['\"]",
+        "lang": "Python",
+        "type": "Syntax (Python 2)",
+        "severity": "warning",
+        "desc": "Looks like Python 2 print statement.",
+        "fix": "Use print() function: print('...')",
+    },
+    {
+        "pattern": r"==\s*None\b",
+        "lang": "Python",
+        "type": "Style Warning",
+        "severity": "warning",
+        "desc": "Comparison to None using '==' instead of 'is'.",
+        "fix": "Use `is None` instead of `== None`.",
+    },
+    {
+        "pattern": r"\bexcept:\s*$",
+        "lang": None,
+        "type": "Bare Except",
+        "severity": "warning",
+        "desc": "Bare except clause catches all exceptions.",
+        "fix": "Specify the exception type: except ValueError:",
+    },
+    {
+        "pattern": r"[a-z]\s*=\s*[a-z]\s*=",
+        "lang": None,
+        "type": "Chained Assignment",
+        "severity": "info",
+        "desc": "Chained assignment detected.",
+        "fix": "Ensure this is intentional and variables are correctly set.",
+    },
     # JS / TS
-    {"pattern": r"===\s*null\s*\|\|\s*===\s*undefined", "lang": None, "type": "Nullish Check", "severity": "info", "desc": "Verbose nullish check.",                        "fix": "Consider using ?? (nullish coalescing) operator."},
-    {"pattern": r"\bvar\b",                    "lang": "JavaScript", "type": "Style Warning", "severity": "info",  "desc": "'var' is function-scoped and can cause bugs.",    "fix": "Use 'const' or 'let' instead."},
-    {"pattern": r"eval\(",                     "lang": None, "type": "Security Risk",        "severity": "error",  "desc": "eval() can execute arbitrary code.",              "fix": "Avoid eval(). Use safer alternatives."},
+    {
+        "pattern": r"===\s*null\s*\|\|\s*===\s*undefined",
+        "lang": None,
+        "type": "Nullish Check",
+        "severity": "info",
+        "desc": "Verbose nullish check.",
+        "fix": "Consider using ?? (nullish coalescing) operator.",
+    },
+    {
+        "pattern": r"\bvar\b",
+        "lang": "JavaScript",
+        "type": "Style Warning",
+        "severity": "info",
+        "desc": "'var' is function-scoped and can cause bugs.",
+        "fix": "Use 'const' or 'let' instead.",
+    },
+    {
+        "pattern": r"eval\(",
+        "lang": None,
+        "type": "Security Risk",
+        "severity": "error",
+        "desc": "eval() can execute arbitrary code.",
+        "fix": "Avoid eval(). Use safer alternatives.",
+    },
     # General
-    {"pattern": r"TODO|FIXME|HACK|XXX",        "lang": None, "type": "Incomplete Code",      "severity": "info",   "desc": "TODO/FIXME comment found — unfinished logic.",    "fix": "Address the TODO before shipping to production."},
-    {"pattern": r"password\s*=\s*['\"].+['\"]","lang": None, "type": "Hardcoded Secret",    "severity": "error",  "desc": "Hardcoded password or secret found in code.",     "fix": "Use environment variables: os.getenv('PASSWORD')"},
-    {"pattern": r"http://",                    "lang": None, "type": "Insecure URL",         "severity": "warning", "desc": "HTTP (not HTTPS) URL detected.",                 "fix": "Use HTTPS URLs for secure communication."},
-    {"pattern": r"\bsleep\(\d+\)",             "lang": None, "type": "Blocking Call",        "severity": "info",   "desc": "Synchronous sleep() blocks execution.",           "fix": "Consider async alternatives if this is in a loop or server."},
-    {"pattern": r"catch\s*\(\w+\)\s*\{\s*\}", "lang": None, "type": "Empty Catch",          "severity": "warning", "desc": "Empty catch block swallows errors silently.",     "fix": "Log or handle the exception inside the catch block."},
+    {
+        "pattern": r"TODO|FIXME|HACK|XXX",
+        "lang": None,
+        "type": "Incomplete Code",
+        "severity": "info",
+        "desc": "TODO/FIXME comment found — unfinished logic.",
+        "fix": "Address the TODO before shipping to production.",
+    },
+    {
+        "pattern": r"password\s*=\s*['\"].+['\"]",
+        "lang": None,
+        "type": "Hardcoded Secret",
+        "severity": "error",
+        "desc": "Hardcoded password or secret found in code.",
+        "fix": "Use environment variables: os.getenv('PASSWORD')",
+    },
+    {
+        "pattern": r"http://",
+        "lang": None,
+        "type": "Insecure URL",
+        "severity": "warning",
+        "desc": "HTTP (not HTTPS) URL detected.",
+        "fix": "Use HTTPS URLs for secure communication.",
+    },
+    {
+        "pattern": r"\bsleep\(\d+\)",
+        "lang": None,
+        "type": "Blocking Call",
+        "severity": "info",
+        "desc": "Synchronous sleep() blocks execution.",
+        "fix": "Consider async alternatives if this is in a loop or server.",
+    },
+    {
+        "pattern": r"catch\s*\(\w+\)\s*\{\s*\}",
+        "lang": None,
+        "type": "Empty Catch",
+        "severity": "warning",
+        "desc": "Empty catch block swallows errors silently.",
+        "fix": "Log or handle the exception inside the catch block.",
+    },
 ]
+
 
 def debug_code(code: str, language: Optional[str] = None) -> DebuggingResponse:
     lang = language or detect_language(code)
@@ -295,29 +427,106 @@ def debug_code(code: str, language: Optional[str] = None) -> DebuggingResponse:
 
     clean = len(issues) == 0
     summary = (
-        "✓ No issues detected. Code looks clean!" if clean
+        "✓ No issues detected. Code looks clean!"
+        if clean
         else f"Found {len(issues)} issue(s). {len([i for i in issues if i.severity == 'error'])} error(s), "
-             f"{len([i for i in issues if i.severity == 'warning'])} warning(s)."
+        f"{len([i for i in issues if i.severity == 'warning'])} warning(s)."
     )
     return DebuggingResponse(issues=issues, summary=summary, clean=clean)
 
+
 # ── Suggestions ──
 SUGGESTION_RULES = [
-    {"pattern": r"(?<!\w)(\w+)\s*=\s*\1\b",    "cat": "Redundant Assignment", "desc": "Self-assignment detected. Remove the line.",                               "example": "# x = x  ← remove this",            "priority": "high"},
-    {"pattern": r"#[^\n]{0,5}$",               "cat": "Comment Quality",      "desc": "Short comment found. Add more context to explain the 'why'.",              "example": "# increments counter by 1 each loop", "priority": "low"},
-    {"pattern": r"print\(|console\.log\(",     "cat": "Debug Statement",      "desc": "Debug print/log found. Remove before production.",                         "example": "# Remove or use a proper logger",     "priority": "medium"},
-    {"pattern": r"^(\s{2}|\t)[^\s]",           "cat": "Indentation",          "desc": "Inconsistent or 2-space indentation. Python PEP8 recommends 4 spaces.",   "example": "Use 4 spaces consistently",           "priority": "low"},
-    {"pattern": r"range\(len\(",               "cat": "Pythonic Code",        "desc": "range(len()) is not Pythonic.",                                            "example": "for item in my_list:",                "priority": "medium"},
-    {"pattern": r"\[\]$|\{\}$",               "cat": "Empty Collection",     "desc": "Initializing empty collection. Consider if this is intentional.",          "example": "items: list[str] = []",               "priority": "info"},
-    {"pattern": r"def \w+\([^)]{60,}\)",      "cat": "Function Signature",   "desc": "Function has many parameters. Consider using a dataclass or dict.",        "example": "def process(config: Config):",         "priority": "medium"},
-    {"pattern": r"if True:|if False:",         "cat": "Dead Code",            "desc": "'if True/False' is dead code. Remove or replace with the real condition.", "example": "if is_enabled:",                      "priority": "high"},
-    {"pattern": r"(\w+)\s*==\s*True\b",       "cat": "Bool Comparison",      "desc": "Comparing to True/False explicitly. Just use the variable.",               "example": "if is_valid: instead of == True",     "priority": "low"},
-    {"pattern": r"global \w+",                "cat": "Global Variable",      "desc": "Avoid global variables — they make code harder to test and debug.",         "example": "Pass as function argument instead",   "priority": "medium"},
-    {"pattern": r"lambda.*lambda",             "cat": "Lambda Complexity",    "desc": "Nested lambdas reduce readability.",                                        "example": "Use a named function instead",        "priority": "medium"},
-    {"pattern": r"string\.join|\.join\(",     "cat": "String Building",      "desc": "Good use of .join() for string concatenation — efficient!",                 "example": "', '.join(items)",                    "priority": "info"},
+    {
+        "pattern": r"(?<!\w)(\w+)\s*=\s*\1\b",
+        "cat": "Redundant Assignment",
+        "desc": "Self-assignment detected. Remove the line.",
+        "example": "# x = x  ← remove this",
+        "priority": "high",
+    },
+    {
+        "pattern": r"#[^\n]{0,5}$",
+        "cat": "Comment Quality",
+        "desc": "Short comment found. Add more context to explain the 'why'.",
+        "example": "# increments counter by 1 each loop",
+        "priority": "low",
+    },
+    {
+        "pattern": r"print\(|console\.log\(",
+        "cat": "Debug Statement",
+        "desc": "Debug print/log found. Remove before production.",
+        "example": "# Remove or use a proper logger",
+        "priority": "medium",
+    },
+    {
+        "pattern": r"^(\s{2}|\t)[^\s]",
+        "cat": "Indentation",
+        "desc": "Inconsistent or 2-space indentation. Python PEP8 recommends 4 spaces.",
+        "example": "Use 4 spaces consistently",
+        "priority": "low",
+    },
+    {
+        "pattern": r"range\(len\(",
+        "cat": "Pythonic Code",
+        "desc": "range(len()) is not Pythonic.",
+        "example": "for item in my_list:",
+        "priority": "medium",
+    },
+    {
+        "pattern": r"\[\]$|\{\}$",
+        "cat": "Empty Collection",
+        "desc": "Initializing empty collection. Consider if this is intentional.",
+        "example": "items: list[str] = []",
+        "priority": "info",
+    },
+    {
+        "pattern": r"def \w+\([^)]{60,}\)",
+        "cat": "Function Signature",
+        "desc": "Function has many parameters. Consider using a dataclass or dict.",
+        "example": "def process(config: Config):",
+        "priority": "medium",
+    },
+    {
+        "pattern": r"if True:|if False:",
+        "cat": "Dead Code",
+        "desc": "'if True/False' is dead code. Remove or replace with the real condition.",
+        "example": "if is_enabled:",
+        "priority": "high",
+    },
+    {
+        "pattern": r"(\w+)\s*==\s*True\b",
+        "cat": "Bool Comparison",
+        "desc": "Comparing to True/False explicitly. Just use the variable.",
+        "example": "if is_valid: instead of == True",
+        "priority": "low",
+    },
+    {
+        "pattern": r"global \w+",
+        "cat": "Global Variable",
+        "desc": "Avoid global variables — they make code harder to test and debug.",
+        "example": "Pass as function argument instead",
+        "priority": "medium",
+    },
+    {
+        "pattern": r"lambda.*lambda",
+        "cat": "Lambda Complexity",
+        "desc": "Nested lambdas reduce readability.",
+        "example": "Use a named function instead",
+        "priority": "medium",
+    },
+    {
+        "pattern": r"string\.join|\.join\(",
+        "cat": "String Building",
+        "desc": "Good use of .join() for string concatenation — efficient!",
+        "example": "', '.join(items)",
+        "priority": "info",
+    },
 ]
 
-def suggest_improvements(code: str, language: Optional[str] = None) -> SuggestionsResponse:
+
+def suggest_improvements(
+    code: str, language: Optional[str] = None
+) -> SuggestionsResponse:
     cards: list[SuggestionCard] = []
     seen_cats = set()
     lines_list = code.splitlines()
@@ -325,30 +534,36 @@ def suggest_improvements(code: str, language: Optional[str] = None) -> Suggestio
     for rule in SUGGESTION_RULES:
         for line in lines_list:
             if re.search(rule["pattern"], line) and rule["cat"] not in seen_cats:
-                cards.append(SuggestionCard(
-                    category=rule["cat"],
-                    description=rule["desc"],
-                    example=rule.get("example"),
-                    priority=rule["priority"]
-                ))
+                cards.append(
+                    SuggestionCard(
+                        category=rule["cat"],
+                        description=rule["desc"],
+                        example=rule.get("example"),
+                        priority=rule["priority"],
+                    )
+                )
                 seen_cats.add(rule["cat"])
                 break
 
     # Always add docstring tip if no docstring present
     if not re.search(r'"""[\s\S]*?"""|\'\'\'[\s\S]*?\'\'\'', code):
-        cards.append(SuggestionCard(
-            category="Documentation",
-            description="Add docstrings to your functions to describe their purpose, parameters, and return value.",
-            example='def greet(name: str) -> str:\n    """Return a greeting string."""',
-            priority="medium"
-        ))
+        cards.append(
+            SuggestionCard(
+                category="Documentation",
+                description="Add docstrings to your functions to describe their purpose, parameters, and return value.",
+                example='def greet(name: str) -> str:\n    """Return a greeting string."""',
+                priority="medium",
+            )
+        )
 
     # Score: start at 100, deduct per issue
     score = max(0, 100 - len(cards) * 10)
     next_step = (
-        "Great code! Consider adding tests next." if score >= 80
+        "Great code! Consider adding tests next."
+        if score >= 80
         else "Focus on fixing high-priority issues first, then add tests."
     )
 
-    return SuggestionsResponse(suggestions=cards, overall_score=score, next_step=next_step)
-
+    return SuggestionsResponse(
+        suggestions=cards, overall_score=score, next_step=next_step
+    )

--- a/backend/app/services/llm_analysis.py
+++ b/backend/app/services/llm_analysis.py
@@ -23,7 +23,9 @@ class LLMAnalysisClient:
     def enabled(self) -> bool:
         return bool(settings.llm_enabled and self.api_key)
 
-    async def _chat_completion(self, messages: list[dict], temperature: float = 0.2) -> str:
+    async def _chat_completion(
+        self, messages: list[dict], temperature: float = 0.2
+    ) -> str:
         if not self.enabled:
             raise LLMAnalysisError("llm_disabled")
 
@@ -96,11 +98,11 @@ class LLMAnalysisClient:
             "You are a senior software engineer assistant. "
             "Analyze the code deeply and respond ONLY JSON with this shape: "
             "{"
-            "\"explanation\":{\"summary\":string,\"key_points\":string[],\"beginner_tip\":string},"
-            "\"debugging\":{\"issues\":[{\"line\":number|null,\"issue_type\":string,\"message\":string,\"why_it_happens\":string,\"fix_suggestion\":string}],\"quick_checks\":string[]},"
-            "\"suggestions\":{\"suggestions\":[{\"title\":string,\"reason\":string,\"before\":string,\"after\":string}],\"next_steps\":string[]},"
-            "\"complexity\":{\"time\":string,\"space\":string},"
-            "\"optimized_version\":string"
+            '"explanation":{"summary":string,"key_points":string[],"beginner_tip":string},'
+            '"debugging":{"issues":[{"line":number|null,"issue_type":string,"message":string,"why_it_happens":string,"fix_suggestion":string}],"quick_checks":string[]},'
+            '"suggestions":{"suggestions":[{"title":string,"reason":string,"before":string,"after":string}],"next_steps":string[]},'
+            '"complexity":{"time":string,"space":string},'
+            '"optimized_version":string'
             "}. "
             "Keep suggestions practical and include recursion/loop insights when present."
         )
@@ -121,7 +123,9 @@ class LLMAnalysisClient:
             logger.warning("llm_structured_analysis_failed detail=%s", str(exc))
             raise LLMAnalysisError(str(exc)) from exc
 
-    async def chat_reply(self, message: str, code: str | None, history: list[str], level: str) -> str:
+    async def chat_reply(
+        self, message: str, code: str | None, history: list[str], level: str
+    ) -> str:
         prompt = (
             "You are QyverixAI coding assistant in chat mode. "
             f"Explain at {level} level, be clear and concrete, and avoid generic text."

--- a/backend/tests/test_endpoints.py
+++ b/backend/tests/test_endpoints.py
@@ -9,6 +9,7 @@ from app.main import app
 
 client = TestClient(app)
 
+
 # ── Health ──
 def test_health():
     r = client.get("/health")
@@ -17,12 +18,15 @@ def test_health():
     assert data["status"] == "ok"
     assert "version" in data
 
+
 def test_info():
     r = client.get("/info")
     assert r.status_code == 200
 
+
 # ── Explanation ──
 SAMPLE_PYTHON = "def add(a, b):\n    return a + b\n"
+
 
 def test_explanation_basic():
     r = client.post("/explanation/", json={"code": SAMPLE_PYTHON})
@@ -33,17 +37,21 @@ def test_explanation_basic():
     assert isinstance(data["key_points"], list)
     assert data["complexity"] in ("Beginner", "Intermediate", "Advanced")
 
+
 def test_explanation_empty_code():
     r = client.post("/explanation/", json={"code": "   "})
     assert r.status_code == 422
+
 
 def test_explanation_with_language_hint():
     r = client.post("/explanation/", json={"code": SAMPLE_PYTHON, "language": "Python"})
     assert r.status_code == 200
     assert r.json()["language"] == "Python"
 
+
 # ── Debugging ──
 BROKEN_CODE = "def broken(:\n    pass\n# TODO: fix this\npassword = 'secret123'\n"
+
 
 def test_debugging_basic():
     r = client.post("/debugging/", json={"code": BROKEN_CODE})
@@ -54,6 +62,7 @@ def test_debugging_basic():
     assert "summary" in data
     assert isinstance(data["clean"], bool)
 
+
 def test_debugging_clean_code():
     r = client.post("/debugging/", json={"code": SAMPLE_PYTHON})
     assert r.status_code == 200
@@ -61,15 +70,18 @@ def test_debugging_clean_code():
     assert data["clean"] is True
     assert len(data["issues"]) == 0
 
+
 def test_debugging_detects_hardcoded_secret():
     r = client.post("/debugging/", json={"code": "password = 'hunter2'"})
     assert r.status_code == 200
     types = [i["type"] for i in r.json()["issues"]]
     assert "Hardcoded Secret" in types
 
+
 def test_debugging_empty_code():
     r = client.post("/debugging/", json={"code": ""})
     assert r.status_code == 422
+
 
 # ── Suggestions ──
 def test_suggestions_basic():
@@ -81,11 +93,13 @@ def test_suggestions_basic():
     assert 0 <= data["overall_score"] <= 100
     assert "next_step" in data
 
+
 def test_suggestions_always_includes_docstring():
     r = client.post("/suggestions/", json={"code": SAMPLE_PYTHON})
     assert r.status_code == 200
     cats = [s["category"] for s in r.json()["suggestions"]]
     assert "Documentation" in cats
+
 
 # ── Analyze ──
 def test_analyze_all_in_one():
@@ -97,14 +111,17 @@ def test_analyze_all_in_one():
     assert "suggestions" in data
     assert "provider" in data
 
+
 def test_analyze_returns_provider():
     r = client.post("/analyze/", json={"code": SAMPLE_PYTHON})
     assert r.status_code == 200
     assert r.json()["provider"] is not None
 
+
 def test_analyze_empty_code():
     r = client.post("/analyze/", json={"code": ""})
     assert r.status_code == 422
+
 
 def test_analyze_javascript():
     js = "const greet = (name) => {\n  console.log('Hello, ' + name);\n};\n"

--- a/backend/tests/test_ping.py
+++ b/backend/tests/test_ping.py
@@ -3,6 +3,7 @@ from app.main import app
 
 client = TestClient(app)
 
+
 def test_ping():
     response = client.get("/ping")
     assert response.status_code == 200


### PR DESCRIPTION
## Summary
- Extend the existing Ruff CI job with `ruff format --check` for backend app and test files.
- Normalize the current backend Python files with `ruff format` so the new formatting check passes immediately.
- Document the same local Ruff lint and format commands in `CONTRIBUTING.md`.

## Testing
- `ruff check backend/app --select E,W,F --ignore E501`
- `ruff format --check backend/app backend/tests`
- `ruby -e 'require "yaml"; YAML.load_file(".github/workflows/ci.yml")'`
- `git diff --check`
- `cd backend && pytest -q` (`16 passed`)

Fixes #13