### PR TITLE
fix: limit docstring suggestions to functions and classes

### DIFF
--- a/backend/app/services/code_assistant.py
+++ b/backend/app/services/code_assistant.py
@@ -333,9 +333,11 @@ def suggest_improvements(code: str, language: Optional[str] = None) -> Suggestio
                 ))
                 seen_cats.add(rule["cat"])
                 break
+    # Suggest docstrings only when functions/classes exist
+    has_docstring = re.search(r'"""[\s\S]*?"""|\'\'\'[\s\S]*?\'\'\'', code)
+    has_function_or_class = re.search(r"\bdef\b|\bclass\b", code)
 
-    # Always add docstring tip if no docstring present
-    if not re.search(r'"""[\s\S]*?"""|\'\'\'[\s\S]*?\'\'\'', code):
+    if has_function_or_class and not has_docstring:
         cards.append(SuggestionCard(
             category="Documentation",
             description="Add docstrings to your functions to describe their purpose, parameters, and return value.",


### PR DESCRIPTION
## Summary
closes #19 
.## Description

Fixes overly broad documentation suggestions in the suggestion engine.

Previously, the analyzer suggested adding docstrings even for small procedural scripts without any functions or classes.

## Changes Made

* Added a check to ensure documentation suggestions are only shown when:

  * a function (`def`) exists
  * or a class (`class`) exists
* Preserved existing docstring detection behavior.

Fixes #19

## Testing

### No longer suggests docstrings unnecessarily

```python id="h8q2m5"
x = input()

if x > 5:
    print(x)
```

### Still suggests docstrings correctly

```python id="v4m9q1"
def greet(name):
    return f"Hello {name}"
```


## Type of Change

- [ ] Bug fix
- [ ] New feature
- [ ] Documentation update
- [ ] Refactor

## Testing

- [ ] I ran backend tests (`pytest -q`)
- [ ] I tested frontend behavior manually

## Checklist

- [ ] Code is readable and beginner-friendly
- [ ] No fake or placeholder behavior introduced
- [ ] Documentation updated if needed
