### PR TITLE
fix: detect undefined Python names in debugger

### DIFF
--- a/backend/app/services/code_assistant.py
+++ b/backend/app/services/code_assistant.py
@@ -5,6 +5,7 @@ Rule-based engine with optional LLM integration.
 
 import re
 import ast
+import builtins
 import logging
 from typing import Optional
 from app.schemas import (
@@ -37,6 +38,26 @@ def _append_issue(
     seen.add(key)
 
 
+def _collect_defined_python_names(tree: ast.AST) -> set[str]:
+    defined = set(builtins.__dict__)
+    defined.update({"__builtins__", "__doc__", "__file__", "__loader__", "__name__", "__package__", "__spec__"})
+
+    for node in ast.walk(tree):
+        if isinstance(node, ast.Name) and isinstance(node.ctx, ast.Store):
+            defined.add(node.id)
+        elif isinstance(node, (ast.FunctionDef, ast.AsyncFunctionDef, ast.ClassDef)):
+            defined.add(node.name)
+        elif isinstance(node, (ast.Import, ast.ImportFrom)):
+            for alias in node.names:
+                defined.add((alias.asname or alias.name).split(".")[0])
+        elif isinstance(node, ast.arg):
+            defined.add(node.arg)
+        elif isinstance(node, ast.ExceptHandler) and node.name:
+            defined.add(node.name)
+
+    return defined
+
+
 def _python_debug_issues(code: str) -> list[DebugIssue]:
     issues: list[DebugIssue] = []
     seen: set[tuple[str, Optional[int], str]] = set()
@@ -56,6 +77,7 @@ def _python_debug_issues(code: str) -> list[DebugIssue]:
         return issues
 
     input_vars: set[str] = set()
+    defined_names = _collect_defined_python_names(tree)
     list_lengths: dict[str, int] = {}
     range_limits: dict[str, int] = {}
     variable_kinds: dict[str, str] = {}
@@ -150,6 +172,17 @@ def _python_debug_issues(code: str) -> list[DebugIssue]:
                         "Avoid passing 0 as denominator; add a guard clause before dividing.",
                         "error",
                     )
+
+        if isinstance(node, ast.Name) and isinstance(node.ctx, ast.Load) and node.id not in defined_names:
+            _append_issue(
+                issues,
+                seen,
+                "NameError Risk",
+                node.lineno,
+                f"Variable '{node.id}' is not defined before use.",
+                f"Define '{node.id}' before using it, import it, or fix the variable name.",
+                "error",
+            )
 
         if isinstance(node, ast.BinOp) and isinstance(node.op, ast.Add):
             left_is_str = isinstance(node.left, ast.Constant) and isinstance(node.left.value, str)

--- a/backend/tests/test_endpoints.py
+++ b/backend/tests/test_endpoints.py
@@ -67,6 +67,16 @@ def test_debugging_detects_hardcoded_secret():
     types = [i["type"] for i in r.json()["issues"]]
     assert "Hardcoded Secret" in types
 
+def test_debugging_detects_undefined_python_name():
+    r = client.post("/debugging/", json={"code": "print(Hello)\n", "language": "Python"})
+    assert r.status_code == 200
+    issues = r.json()["issues"]
+    assert any(
+        issue["type"] == "NameError Risk" and "Hello" in issue["description"]
+        for issue in issues
+    )
+    assert r.json()["clean"] is False
+
 def test_debugging_empty_code():
     r = client.post("/debugging/", json={"code": ""})
     assert r.status_code == 422


### PR DESCRIPTION
## Summary
- add AST-based undefined Python name detection to the rule-based debugger
- include Python builtins, imports, assignments, definitions, and function arguments in the defined-name set
- add a regression test for `print(Hello)` reporting a `NameError Risk` instead of a clean result

Closes #46

## Tests
- `PYTHONPATH=. pytest tests/test_endpoints.py::test_debugging_detects_undefined_python_name -q`
- `PYTHONPATH=. pytest tests/test_endpoints.py -q`
- `PYTHONPATH=. pytest tests -q`
- `ruff check app --select E,W,F --ignore E501`
