### PR TITLE
fix(frontend): improve editor indentation and smart backspace behavior (#20)

### DIFF
--- a/frontend/index.html
+++ b/frontend/index.html
@@ -1088,20 +1088,132 @@ editor.addEventListener('scroll', () => {
 
 // Tab key support
 editor.addEventListener('keydown', e => {
+
+  // TAB SUPPORT
   if (e.key === 'Tab') {
+
     e.preventDefault();
-    const s = editor.selectionStart, end = editor.selectionEnd;
-    editor.value = editor.value.substring(0, s) + '  ' + editor.value.substring(end);
-    editor.selectionStart = editor.selectionEnd = s + 2;
+
+    const start = editor.selectionStart;
+    const end = editor.selectionEnd;
+
+    editor.value =
+      editor.value.substring(0, start) +
+      '    ' +
+      editor.value.substring(end);
+
+    editor.selectionStart =
+      editor.selectionEnd =
+      start + 4;
+
     updateEditor();
   }
-  if (e.key === 'Enter' && (e.ctrlKey || e.metaKey)) {
+
+  // AUTO INDENT ON ENTER
+  else if (e.key === 'Enter' && !e.ctrlKey && !e.metaKey) {
+
+    e.preventDefault();
+
+    const start = editor.selectionStart;
+    const end = editor.selectionEnd;
+
+    const value = editor.value;
+
+    // Find current line
+    const lineStart =
+      value.lastIndexOf('\n', start - 1) + 1;
+
+    const currentLine =
+      value.substring(lineStart, start);
+
+    // Preserve existing indentation
+    const indentMatch = currentLine.match(/^\s*/);
+
+    let indent = indentMatch
+      ? indentMatch[0]
+      : '';
+
+    const trimmed = currentLine.trim();
+
+    // Python indentation
+    if (
+      selectedLang === 'python' &&
+      trimmed.endsWith(':')
+    ) {
+      indent += '    ';
+    }
+
+    // JavaScript / TypeScript / Java / C++
+    else if (
+      ['javascript', 'typescript', 'java', 'cpp']
+        .includes(selectedLang) &&
+      trimmed.endsWith('{')
+    ) {
+      indent += '    ';
+    }
+
+    editor.value =
+      value.substring(0, start) +
+      '\n' + indent +
+      value.substring(end);
+
+    editor.selectionStart =
+      editor.selectionEnd =
+      start + 1 + indent.length;
+
+    updateEditor();
+  }
+
+  // SMART BACKSPACE
+  else if (e.key === 'Backspace') {
+
+    const start = editor.selectionStart;
+    const end = editor.selectionEnd;
+
+    // Only if no text selected
+    if (start === end) {
+
+      const value = editor.value;
+
+      // Text before cursor
+      const beforeCursor =
+        value.substring(0, start);
+
+      // Current line
+      const lineStart =
+        beforeCursor.lastIndexOf('\n') + 1;
+
+      const currentLine =
+        beforeCursor.substring(lineStart);
+
+      // Remove full indentation level
+      if (currentLine.endsWith('    ')) {
+
+        e.preventDefault();
+
+        editor.value =
+          value.substring(0, start - 4) +
+          value.substring(end);
+
+        editor.selectionStart =
+          editor.selectionEnd =
+          start - 4;
+
+        updateEditor();
+      }
+    }
+  }
+
+  // CTRL + ENTER
+  else if (
+    e.key === 'Enter' &&
+    (e.ctrlKey || e.metaKey)
+  ) {
+
     e.preventDefault();
     doAnalyze();
   }
 });
-
-updateEditor();
 
 /* ═══════════════════════════════════════════════════════════════
    FILE UPLOAD


### PR DESCRIPTION
###  **Summary**

**Closes and enhances #20** by improving the in-browser code editor experience with language-aware indentation support.

This PR adds automatic indentation behavior for the editor used in QyverixAI, making code writing significantly smoother and more IDE-like across all supported languages.

### **Original Status**

https://github.com/user-attachments/assets/bfaf9398-fa97-4efe-aa8b-16f7801fe027


### **Changes Made**

**Smart Auto-Indentation**

Added automatic indentation when pressing Enter:

* Python:

  1. Automatically indents after lines ending with ':'
   Example:

https://github.com/user-attachments/assets/19e73cb1-40f5-4332-90bf-bb1053b7687a


   

* JavaScript / TypeScript / Java / C++:

  1. Automatically indents after lines ending with '{'
   Example:


https://github.com/user-attachments/assets/dcf2e533-23f3-409e-a574-715eb2747c30



### **Smart Backspace Support**

Improved Backspace behavior so indentation levels are removed intelligently.

Instead of deleting spaces one-by-one, pressing backspace removes the full indentation level (4 spaces) at once when applicable.

**### Improved Tab Handling**

Enhanced 'Tab' key behavior:

* Inserts 4 spaces directly into the editor
* Prevents focus from leaving the textarea
* Makes indentation more consistent across languages

### ** Language-Aware Indentation Logic**

Implemented indentation rules based on the selected editor language:

* Python → :
* JavaScript / TypeScript / Java / C++ → {

This ensures indentation behaves correctly for each supported language.

### **Testing**

Manually tested:

* Python
* JavaScript
* TypeScript
* Java
* C++

Verified:

* Auto-indent works correctly
* Nested indentation behaves properly
* Smart backspace removes full indent levels
* Tab inserts indentation correctly

Also attached a screen recording demonstrating the updated editor behavior.


## Testing

* [ x] I ran backend tests (pytest -q)
* [x] I tested frontend behavior manually

## Checklist
* [x] No fake or placeholder behavior introduced

