### PR TITLE
feat: add PHP language detection with regex patterns and debugging test

### DIFF
--- a/backend/app/services/code_assistant.py
+++ b/backend/app/services/code_assistant.py
@@ -33,6 +33,14 @@ LANG_SIGNATURES: dict[str, list[str]] = {
         r"#include\s*<", r"\bstd::\w+", r"\bcout\s*<<",
         r"\bint\s+main\s*\(", r"::\w+",
     ],
+    "PHP": [
+    r"<\?php",
+    r"\$\w+\s*=",
+    r"\becho\s+",
+    r"\bfunction\s+\w+\s*\(",
+    r"\barray\s*\(",
+    r"->\\w+",
+],
 }
 
 

--- a/backend/app/services/code_assistant.py
+++ b/backend/app/services/code_assistant.py
@@ -39,7 +39,7 @@ LANG_SIGNATURES: dict[str, list[str]] = {
     r"\becho\s+",
     r"\bfunction\s+\w+\s*\(",
     r"\barray\s*\(",
-    r"->\\w+",
+    r"->\w+",
 ],
 }
 

--- a/backend/tests/test_endpoints.py
+++ b/backend/tests/test_endpoints.py
@@ -13,6 +13,18 @@ client = TestClient(app)
 
 
 # ── Fixtures ──────────────────────────────────────────────────────────────────
+PHP_CODE = """
+<?php
+$name = "Srija";
+echo $name;
+function greet($user) {
+    return "Hello " . $user;
+}
+$arr = array(1, 2, 3);
+$obj->method();
+?>
+"""
+
 PYTHON_BUGGY = """
 import os
 password = "supersecret123"
@@ -169,6 +181,12 @@ def test_debug_cpp():
     assert r.status_code == 200
     d = r.json()
     assert len(d["issues"]) > 0
+
+def test_debug_php():
+    r = client.post("/debugging/", json={"code": PHP_CODE, "language": "php"})
+    assert r.status_code == 200
+    d = r.json()
+    assert d is not None
 
 def test_debug_issue_has_required_fields():
     r = client.post("/debugging/", json={"code": PYTHON_BUGGY})


### PR DESCRIPTION
Closes #60 
## Summary

Added PHP language detection to `LANG_SIGNATURES` in `code_assistant.py` 
with 6 regex patterns. Added `PHP_CODE` fixture and `test_debug_php()` 
test case in `test_endpoints.py`.

## Type of Change

- [ ] Bug fix
- [x] New feature
- [ ] Documentation update
- [ ] Refactor

## Testing

- [x] I ran backend tests (`pytest -q`)
- [ ] I tested frontend behavior manually

## Checklist

- [x] Code is readable and beginner-friendly
- [x] No fake or placeholder behavior introduced
- [ ] Documentation updated if needed
