### PR TITLE
fix(#68): Add TypeScript, Java, and C++ samples and fix tab UX

### DIFF
--- a/frontend/index.html
+++ b/frontend/index.html
@@ -1276,12 +1276,25 @@ document.body.addEventListener('drop', e => {
 ═══════════════════════════════════════════════════════════════ */
 function setLanguage(lang) {
   selectedLang = lang;
+  
+  // 1. Update the visual tabs
   document.querySelectorAll('.lang-tab').forEach(t => {
     const isActive = t.dataset.lang === lang;
     t.classList.toggle('active', isActive);
     t.setAttribute('aria-selected', isActive ? 'true' : 'false');
   });
+
+  // 2. Check if the editor currently contains one of the samples
+  const currentCode = editor.value.trim();
+  const isSample = Object.values(SAMPLES).map(s => s.trim()).includes(currentCode);
+  
+  // 3. If it is a sample, swap it to the new language's sample automatically
+  if (isSample) {
+    editor.value = SAMPLES[lang] || SAMPLES.python;
+    updateEditor();
+  }
 }
+
 document.querySelectorAll('.lang-tab').forEach(t => {
   t.addEventListener('click', () => setLanguage(t.dataset.lang));
 });
@@ -1761,7 +1774,8 @@ function renderMarkdown(s) {
    SAMPLE CODE LOADER
 ═══════════════════════════════════════════════════════════════ */
 const SAMPLES = {
-  python: `import os
+  python: `// Python Sample
+  import os
 
 # [!] Hardcoded secret - security risk
 password = "supersecret123"
@@ -1788,7 +1802,8 @@ from os import *  # [!] Wildcard import
 x = eval("1 + 2")  # [!] Unsafe eval
 
 calculate(10, 0)`,
-  javascript: `var counter = 0;
+  javascript: `// JavaScript Sample
+  var counter = 0;
 
 function loadUser(id) {
   // [!] Promise not awaited
@@ -1804,6 +1819,61 @@ function loadUser(id) {
 }
 
 loadUser(42);`,
+  typescript: `// TypeScript Sample
+interface User {
+  id: number;
+  name: string;
+  email?: string; 
+}
+
+function sendWelcomeEmail(user: User) {
+  // Anti-pattern: Non-null assertion operator (!) used dangerously
+  // If user.email is undefined, this will cause a runtime error in the compiled JS
+  console.log("Sending email to: " + user.email!.toLowerCase());
+}
+
+const newUser: User = { id: 1, name: "Alice" };
+sendWelcomeEmail(newUser);`,
+  java: `// Java Sample
+public class Main {
+    public static void main(String[] args) {
+        String name1 = new String("Vaibhav");
+        String name2 = new String("Vaibhav");
+
+        // Anti-pattern 1: Using == for string comparison instead of .equals()
+        if (name1 == name2) {
+            System.out.println("Names are the same");
+        } else {
+            System.out.println("Names are different (Reference comparison failed)");
+        }
+
+        // Anti-pattern 2: NullPointerException risk
+        String uninitializedString = null;
+        System.out.println(uninitializedString.length());
+    }
+}`,
+  cpp: `// C++ Sample
+#include <iostream>
+
+// Anti-pattern 1: using namespace std in global scope
+using namespace std; 
+
+void processData() {
+    // Anti-pattern 2: Memory Leak
+    // Allocating memory on the heap but never freeing it with 'delete'
+    int* dataBuffer = new int[100]; 
+    
+    dataBuffer[0] = 42;
+    cout << "Processing value: " << dataBuffer[0] << endl;
+    
+    // Memory leak occurs here when the function exits 
+    // because 'delete[] dataBuffer;' is missing.
+}
+
+int main() {
+    processData();
+    return 0;
+}`
 };
 
 function loadSample() {


### PR DESCRIPTION
## Summary

This PR resolves Issue #68. 

1. **New Samples:** Extended the `SAMPLES` object in `frontend/index.html` to include TypeScript, Java, and C++. Each snippet includes the exact anti-patterns requested in the issue (TypeScript non-null assertion `!`, Java NPE and `==` string comparison, C++ memory leak and global `std` namespace).
2. **UX Bug Fix:** Updated the `setLanguage(lang)` function. Previously, switching language tabs did not update the sample code in the editor. Now, clicking a language tab automatically loads that language's sample code (while safely ignoring this behavior if the user has manually entered their own code).

## Type of Change

- [x] Bug fix
- [x] New feature
- [ ] Documentation update
- [ ] Refactor

## Testing

- [ ] I ran backend tests (`pytest -q`) *(Note: Skipped as this is strictly a frontend HTML/JS change)*
- [x] I tested frontend behavior manually

## Checklist

- [x] Code is readable and beginner-friendly
- [x] No fake or placeholder behavior introduced
- [x] Documentation updated if needed *(N/A)*

<img width="1920" height="875" alt="2026-05-19_121217" src="https://github.com/user-attachments/assets/dcf37178-025f-4bda-a127-b26f49de78af" />
<img width="1916" height="854" alt="2026-05-19_121406" src="https://github.com/user-attachments/assets/4b883ad1-d49a-428f-86c8-46cb1807d6c2" />
<img width="1918" height="884" alt="2026-05-19_121418" src="https://github.com/user-attachments/assets/872ae885-8f3b-40e9-821e-c8c53681d6b0" />
<img width="1920" height="866" alt="2026-05-19_121430" src="https://github.com/user-attachments/assets/35b72899-0c75-4801-8869-2259c9b06f8f" />
<img width="1920" height="872" alt="2026-05-19_121452" src="https://github.com/user-attachments/assets/b7e2ab10-6356-45ff-b318-b21eeb5ea0ac" />
