### PR TITLE
feat: add Rust language detection

### DIFF
--- a/backend/app/services/code_assistant.py
+++ b/backend/app/services/code_assistant.py
@@ -33,6 +33,14 @@ LANG_SIGNATURES: dict[str, list[str]] = {
         r"#include\s*<", r"\bstd::\w+", r"\bcout\s*<<",
         r"\bint\s+main\s*\(", r"::\w+",
     ],
+    "Rust": [
+        r"\bfn\s+\w+\s*\(",
+        r"\blet\s+mut\b",
+        r"\buse\s+std::",
+        r"println!\s*\(",
+        r"\bimpl\b",
+        r"\bOption<\w+>",
+    ],
 }
 
 
@@ -45,6 +53,7 @@ def detect_language(code: str, hint: str | None = None) -> str:
             "typescript": "TypeScript", "ts": "TypeScript",
             "java": "Java",
             "cpp": "C++", "c++": "C++", "cxx": "C++",
+            "rust": "Rust", "rs": "Rust",
         }
         if normalized in mapping:
             return mapping[normalized]
@@ -83,7 +92,7 @@ class BugPattern:
     description: str
     suggestion: str
     severity: str
-    languages: list[str] = field(default_factory=lambda: ["Python", "JavaScript", "TypeScript", "Java", "C++"])
+    languages: list[str] = field(default_factory=lambda: ["Python", "JavaScript", "TypeScript", "Java", "C++", "Rust"])
 
 
 BUG_PATTERNS: list[BugPattern] = [
@@ -370,7 +379,10 @@ def run_explanation(code: str, language: str) -> dict:
     non_blank = [line for line in lines if line.strip()]
     complexity = estimate_complexity(code)
 
-    func_names = re.findall(r"def\s+(\w+)\s*\(|function\s+(\w+)\s*\(|(\w+)\s*=\s*\(.*\)\s*=>", code)
+    func_names = re.findall(
+        r"def\s+(\w+)\s*\(|function\s+(\w+)\s*\(|(\w+)\s*=\s*\(.*\)\s*=>|\bfn\s+(\w+)\s*\(",
+        code,
+    )
     funcs = [next(n for n in grp if n) for grp in func_names]
 
     class_names = re.findall(r"class\s+(\w+)", code)

--- a/backend/tests/test_endpoints.py
+++ b/backend/tests/test_endpoints.py
@@ -76,6 +76,22 @@ int main() {
 }
 """
 
+RUST_CODE = """
+use std::collections::HashMap;
+
+fn main() {
+    let mut counts: HashMap<String, i32> = HashMap::new();
+    counts.insert(String::from("dailyforge"), 1);
+    println!("{:?}", counts.get("dailyforge"));
+}
+
+impl Score {
+    fn value(&self) -> Option<i32> {
+        Some(self.total)
+    }
+}
+"""
+
 
 # ── Health ────────────────────────────────────────────────────────────────────
 def test_root():
@@ -107,6 +123,18 @@ def test_explanation_no_language_hint():
     assert r.status_code == 200
     d = r.json()
     assert d["language"] in ("JavaScript", "TypeScript")
+
+def test_explanation_detects_rust_without_hint():
+    r = client.post("/explanation/", json={"code": RUST_CODE})
+    assert r.status_code == 200
+    d = r.json()
+    assert d["language"] == "Rust"
+    assert d["function_count"] >= 2
+
+def test_explanation_accepts_rust_hint_alias():
+    r = client.post("/explanation/", json={"code": "fn main() {}", "language": "rs"})
+    assert r.status_code == 200
+    assert r.json()["language"] == "Rust"
 
 def test_explanation_empty_code():
     r = client.post("/explanation/", json={"code": "   "})
@@ -225,6 +253,7 @@ def test_full_analyze_all_languages():
         (TS_CODE, "typescript"),
         (JAVA_CODE, "java"),
         (CPP_CODE, "cpp"),
+        (RUST_CODE, "rust"),
     ]:
         r = client.post("/analyze/", json={"code": code, "language": lang})
         assert r.status_code == 200, f"Failed for {lang}"


### PR DESCRIPTION
## Summary
- Add Rust signatures to the rule-based language detector (`fn`, `let mut`, `use std::`, `println!`, `impl`, `Option<T>`)
- Support `rust` and `rs` language hints
- Include Rust in the generic bug-pattern language set
- Extend explanation tests and full-analysis language coverage for Rust

## Validation
- `PYTHONPATH=backend /Users/saurabhkumarbajpaiai/.cache/codex-runtimes/codex-primary-runtime/dependencies/python/bin/python3 -m pytest backend/tests/test_endpoints.py -q` ✅ 24 passed
- `/Users/saurabhkumarbajpaiai/.cache/codex-runtimes/codex-primary-runtime/dependencies/python/bin/python3 -m py_compile backend/app/services/code_assistant.py backend/tests/test_endpoints.py` ✅
- `git diff --check` ✅

Fixes #56
