### PR TITLE
fix: confirm before clearing saved items

### DIFF
--- a/frontend/index.html
+++ b/frontend/index.html
@@ -1642,6 +1642,8 @@ function loadEntry(id) {
 }
 
 document.getElementById('clearHistoryBtn').addEventListener('click', () => {
+  if (!history.length) return;
+  if (!window.confirm('Clear all history? This cannot be undone.')) return;
   history = [];
   localStorage.removeItem('qyx_history');
   renderHistory();
@@ -1692,6 +1694,8 @@ function loadFav(id) {
 }
 
 document.getElementById('clearFavsBtn').addEventListener('click', () => {
+  if (!favorites.length) return;
+  if (!window.confirm('Clear all favorites? This cannot be undone.')) return;
   favorites = [];
   localStorage.removeItem('qyx_favorites');
   renderFavorites();


### PR DESCRIPTION
## Summary
- Add a confirmation dialog before clearing analysis history
- Add a confirmation dialog before clearing saved favorites
- Skip the prompt when the relevant list is already empty

## Validation
- `git diff --check` ✅
- Static guard check confirmed both confirmation messages are present in `frontend/index.html` ✅

Fixes #75
