### PR TITLE
feat: add Kotlin language detection

### DIFF
--- a/backend/app/services/code_assistant.py
+++ b/backend/app/services/code_assistant.py
@@ -1,6 +1,6 @@
 """
 QyverixAI — Rule-Based Code Analysis Engine
-Covers 40+ patterns across Python, JavaScript, TypeScript, Java, C++.
+Covers 40+ patterns across Python, JavaScript, TypeScript, Java, C++, Kotlin.
 """
 
 from __future__ import annotations
@@ -29,6 +29,10 @@ LANG_SIGNATURES: dict[str, list[str]] = {
         r"\bpublic\s+(class|void|static)\b", r"\bSystem\.out\.print",
         r"\bimport\s+java\.", r"@Override", r"\bnew\s+\w+\s*\(",
     ],
+    "Kotlin": [
+        r"\bfun\s+\w+\s*\(", r"\bval\s+\w+", r"\bvar\s+\w+",
+        r"println\s*\(", r"\bdata\s+class\s+\w+", r":\s*\w+\s*\?",
+    ],
     "C++": [
         r"#include\s*<", r"\bstd::\w+", r"\bcout\s*<<",
         r"\bint\s+main\s*\(", r"::\w+",
@@ -44,6 +48,7 @@ def detect_language(code: str, hint: str | None = None) -> str:
             "javascript": "JavaScript", "js": "JavaScript",
             "typescript": "TypeScript", "ts": "TypeScript",
             "java": "Java",
+            "kotlin": "Kotlin", "kt": "Kotlin", "kts": "Kotlin",
             "cpp": "C++", "c++": "C++", "cxx": "C++",
         }
         if normalized in mapping:
@@ -83,7 +88,7 @@ class BugPattern:
     description: str
     suggestion: str
     severity: str
-    languages: list[str] = field(default_factory=lambda: ["Python", "JavaScript", "TypeScript", "Java", "C++"])
+    languages: list[str] = field(default_factory=lambda: ["Python", "JavaScript", "TypeScript", "Java", "C++", "Kotlin"])
 
 
 BUG_PATTERNS: list[BugPattern] = [
@@ -370,7 +375,7 @@ def run_explanation(code: str, language: str) -> dict:
     non_blank = [line for line in lines if line.strip()]
     complexity = estimate_complexity(code)
 
-    func_names = re.findall(r"def\s+(\w+)\s*\(|function\s+(\w+)\s*\(|(\w+)\s*=\s*\(.*\)\s*=>", code)
+    func_names = re.findall(r"def\s+(\w+)\s*\(|function\s+(\w+)\s*\(|(\w+)\s*=\s*\(.*\)\s*=>|\bfun\s+(\w+)\s*\(", code)
     funcs = [next(n for n in grp if n) for grp in func_names]
 
     class_names = re.findall(r"class\s+(\w+)", code)

--- a/backend/tests/test_endpoints.py
+++ b/backend/tests/test_endpoints.py
@@ -76,6 +76,16 @@ int main() {
 }
 """
 
+KOTLIN_CODE = """
+data class User(val name: String?, var score: Int)
+
+fun main() {
+    val user = User(null, 1)
+    var total = user.score
+    println(total)
+}
+"""
+
 
 # ── Health ────────────────────────────────────────────────────────────────────
 def test_root():
@@ -107,6 +117,19 @@ def test_explanation_no_language_hint():
     assert r.status_code == 200
     d = r.json()
     assert d["language"] in ("JavaScript", "TypeScript")
+
+def test_explanation_detects_kotlin_without_hint():
+    r = client.post("/explanation/", json={"code": KOTLIN_CODE})
+    assert r.status_code == 200
+    d = r.json()
+    assert d["language"] == "Kotlin"
+    assert d["function_count"] >= 1
+    assert d["class_count"] >= 1
+
+def test_explanation_accepts_kotlin_hint_alias():
+    r = client.post("/explanation/", json={"code": "fun main() {}", "language": "kt"})
+    assert r.status_code == 200
+    assert r.json()["language"] == "Kotlin"
 
 def test_explanation_empty_code():
     r = client.post("/explanation/", json={"code": "   "})
@@ -225,6 +248,7 @@ def test_full_analyze_all_languages():
         (TS_CODE, "typescript"),
         (JAVA_CODE, "java"),
         (CPP_CODE, "cpp"),
+        (KOTLIN_CODE, "kotlin"),
     ]:
         r = client.post("/analyze/", json={"code": code, "language": lang})
         assert r.status_code == 200, f"Failed for {lang}"


### PR DESCRIPTION
## Summary
- add Kotlin signatures to the rule-based language detector
- support `kotlin`, `kt`, and `kts` language hints
- include Kotlin in explanation/full-analysis endpoint coverage

## Validation
- `PYTHONPATH=backend python -m pytest backend/tests/test_endpoints.py -q` → 24 passed
- `python -m py_compile backend/app/services/code_assistant.py backend/tests/test_endpoints.py`
- `git diff --check`

Fixes #73

For GSSoC scoring, please consider labels: `gssoc:approved`, `level:beginner`, `type:feature`.
