### PR TITLE
feat: add Rust language detection to explanation engine (Fixes #56)

### DIFF
--- a/backend/app/services/code_assistant.py
+++ b/backend/app/services/code_assistant.py
@@ -1,6 +1,6 @@
 """
 QyverixAI — Rule-Based Code Analysis Engine
-Covers 40+ patterns across Python, JavaScript, TypeScript, Java, C++.
+Covers 40+ patterns across Python, JavaScript, TypeScript, Java, C++, PHP and Rust.
 """
 
 from __future__ import annotations
@@ -34,13 +34,21 @@ LANG_SIGNATURES: dict[str, list[str]] = {
         r"\bint\s+main\s*\(", r"::\w+",
     ],
     "PHP": [
-    r"<\?php",
-    r"\$\w+\s*=",
-    r"\becho\s+",
-    r"\bfunction\s+\w+\s*\(",
-    r"\barray\s*\(",
-    r"->\w+",
-],
+        r"<\?php",
+        r"\$\w+\s*=",
+        r"\becho\s+",
+        r"\bfunction\s+\w+\s*\(",
+        r"\barray\s*\(",
+        r"->\w+",
+    ],
+    "Rust": [
+        r"\bfn\s+\w+\s*\(",
+        r"\blet\s+mut\b",
+        r"\buse\s+std::",
+        r"println!\(",
+        r"\bimpl\b",
+        r"\bOption<\w+>",
+    ],
 }
 
 
@@ -53,6 +61,7 @@ def detect_language(code: str, hint: str | None = None) -> str:
             "typescript": "TypeScript", "ts": "TypeScript",
             "java": "Java",
             "cpp": "C++", "c++": "C++", "cxx": "C++",
+            "rust": "Rust", "rs": "Rust",
         }
         if normalized in mapping:
             return mapping[normalized]
@@ -72,7 +81,7 @@ def estimate_complexity(code: str) -> str:
     lines = [line for line in code.splitlines() if line.strip() and not line.strip().startswith("#")]
     n = len(lines)
     branches = len(re.findall(r"\b(if|elif|else|for|while|switch|case|try|catch|except)\b", code))
-    funcs = len(re.findall(r"\bdef\b|\bfunction\b|\bfunc\b", code))
+    funcs = len(re.findall(r"\bdef\b|\bfunction\b|\bfunc\b|\bfn\b", code))
 
     if n <= 20 and branches <= 3 and funcs <= 2:
         return "Beginner"
@@ -91,7 +100,7 @@ class BugPattern:
     description: str
     suggestion: str
     severity: str
-    languages: list[str] = field(default_factory=lambda: ["Python", "JavaScript", "TypeScript", "Java", "C++"])
+    languages: list[str] = field(default_factory=lambda: ["Python", "JavaScript", "TypeScript", "Java", "C++", "Rust"])
 
 
 BUG_PATTERNS: list[BugPattern] = [
@@ -230,6 +239,28 @@ BUG_PATTERNS: list[BugPattern] = [
                "Comparing signed `int` with unsigned `.size()` — undefined behavior on overflow.",
                "Cast to `(int)` or use `std::ssize()` (C++20).",
                "warning", ["C++"]),
+
+    # ── Rust ──
+    BugPattern("Unwrap Usage", r"\.unwrap\s*\(\s*\)",
+               "`.unwrap()` panics if the value is `None` or `Err` — unsafe in production.",
+               "Use `match`, `if let`, `unwrap_or`, or the `?` operator for safe error handling.",
+               "warning", ["Rust"]),
+    BugPattern("Unsafe Block", r"\bunsafe\s*\{",
+               "`unsafe` block bypasses Rust's memory safety guarantees.",
+               "Isolate unsafe code, document why it is safe, and minimise its scope.",
+               "warning", ["Rust"]),
+    BugPattern("Panic Usage", r"\bpanic!\s*\(",
+               "`panic!()` crashes the thread — avoid in library code.",
+               "Return a `Result<T, E>` instead so callers can handle the error.",
+               "warning", ["Rust"]),
+    BugPattern("Expect Usage", r"\.expect\s*\(\s*['\"]",
+               "`.expect()` panics with a message but still crashes on `None`/`Err`.",
+               "Use `?` or explicit `match`/`unwrap_or_else` for recoverable error handling.",
+               "info", ["Rust"]),
+    BugPattern("Clone Overuse", r"\.clone\s*\(\s*\)",
+               "Excessive `.clone()` calls can hurt performance by copying heap data.",
+               "Consider borrowing (`&T`) or using `Rc`/`Arc` for shared ownership instead.",
+               "info", ["Rust"]),
 ]
 
 
@@ -392,7 +423,7 @@ def run_suggestions(code: str, language: str) -> dict:
     # ─────────────────────────────────────────────────────────────
     # SUGGESTION 6: Tests
     # ─────────────────────────────────────────────────────────────
-    if not re.search(r"\btest_\w+|\bdef test|\bunittest\b|\bpytest\b", code):
+    if not re.search(r"\btest_\w+|\bdef test|\bunittest\b|\bpytest\b|#\[test\]", code):
         suggestions.append({
             "category": "Testing",
             "description": "No tests detected. Unit tests catch regressions early.",
@@ -464,12 +495,15 @@ def run_explanation(code: str, language: str) -> dict:
     non_blank = [line for line in lines if line.strip()]
     complexity = estimate_complexity(code)
 
-    func_names = re.findall(r"def\s+(\w+)\s*\(|function\s+(\w+)\s*\(|(\w+)\s*=\s*\(.*\)\s*=>", code)
+    func_names = re.findall(
+        r"def\s+(\w+)\s*\(|function\s+(\w+)\s*\(|(\w+)\s*=\s*\(.*\)\s*=>|\bfn\s+(\w+)\s*\(",
+        code,
+    )
     funcs = [next(n for n in grp if n) for grp in func_names]
 
     class_names = re.findall(r"class\s+(\w+)", code)
 
-    imports = re.findall(r"import\s+([\w,\s]+)|from\s+(\w+)\s+import", code)
+    imports = re.findall(r"import\s+([\w,\s]+)|from\s+(\w+)\s+import|\buse\s+([\w:]+)", code)
     import_count = len(imports)
 
     has_loops = bool(re.search(r"\bfor\b|\bwhile\b", code))

--- a/backend/tests/test_endpoints.py
+++ b/backend/tests/test_endpoints.py
@@ -88,6 +88,34 @@ int main() {
 }
 """
 
+RUST_CODE = """
+use std::collections::HashMap;
+
+fn main() {
+    let mut scores: HashMap<String, i32> = HashMap::new();
+    println!("Hello, world!");
+}
+
+impl MyStruct {
+    fn new() -> Option<MyStruct> {
+        None
+    }
+}
+"""
+
+RUST_BUGGY = """
+fn main() {
+    let v: Vec<i32> = vec![1, 2, 3];
+    let x = v.get(0).unwrap();
+    let s = String::from("hello").clone();
+    unsafe {
+        println!("{}", x);
+    }
+    panic!("something went wrong");
+    let y: Option<i32> = None;
+    let z = y.expect("no value");
+}
+"""
 
 # ── Health ────────────────────────────────────────────────────────────────────
 def test_root():
@@ -119,6 +147,24 @@ def test_explanation_no_language_hint():
     assert r.status_code == 200
     d = r.json()
     assert d["language"] in ("JavaScript", "TypeScript")
+
+def test_explanation_rust():
+    r = client.post("/explanation/", json={"code": RUST_CODE, "language": "rust"})
+    assert r.status_code == 200
+    d = r.json()
+    assert d["language"] == "Rust"
+
+def test_explanation_detects_rust_without_hint():
+    r = client.post("/explanation/", json={"code": RUST_CODE})
+    assert r.status_code == 200
+    d = r.json()
+    assert d["language"] == "Rust"
+    assert d["function_count"] >= 2
+
+def test_explanation_accepts_rust_hint_alias():
+    r = client.post("/explanation/", json={"code": "fn main() {}", "language": "rs"})
+    assert r.status_code == 200
+    assert r.json()["language"] == "Rust"
 
 def test_explanation_empty_code():
     r = client.post("/explanation/", json={"code": "   "})
@@ -188,6 +234,21 @@ def test_debug_php():
     d = r.json()
     assert d is not None
 
+def test_debug_rust():
+    r = client.post("/debugging/", json={"code": RUST_CODE, "language": "rust"})
+    assert r.status_code == 200
+    assert r.json() is not None
+
+def test_debug_rust_buggy_patterns():
+    r = client.post("/debugging/", json={"code": RUST_BUGGY, "language": "rust"})
+    assert r.status_code == 200
+    types = [i["type"] for i in r.json()["issues"]]
+    assert "Unwrap Usage" in types
+    assert "Unsafe Block" in types
+    assert "Panic Usage" in types
+    assert "Expect Usage" in types
+    assert "Clone Overuse" in types
+
 def test_debug_issue_has_required_fields():
     r = client.post("/debugging/", json={"code": PYTHON_BUGGY})
     assert r.status_code == 200
@@ -243,6 +304,7 @@ def test_full_analyze_all_languages():
         (TS_CODE, "typescript"),
         (JAVA_CODE, "java"),
         (CPP_CODE, "cpp"),
+        (RUST_CODE, "rust"),
     ]:
         r = client.post("/analyze/", json={"code": code, "language": lang})
         assert r.status_code == 200, f"Failed for {lang}"


### PR DESCRIPTION
## Summary

This PR fixes issue #56 

- Added `"Rust"` entry to `LANG_SIGNATURES` with 6 detection patterns: `fn`, `let mut`, `use std::`, `println!`, `impl`, and `Option<T>`
- Added `"rust"` and `"rs"` to the `detect_language` hint mapping
- Added `"Rust"` to the `BugPattern` default languages list so cross-language patterns apply to Rust code
- Added `\bfn\b` to `estimate_complexity` so Rust functions are counted correctly
- Added Rust `fn` pattern to `func_names` regex in the explanation engine so Rust functions appear in key points
- Added `use` statement detection to imports regex so Rust imports are counted
- Added `#[test]` to test detection in the suggestion engine so Rust test functions are recognised
- Added 5 Rust-specific bug detection rules: `Unwrap Usage`, `Unsafe Block`, `Panic Usage`, `Expect Usage`, `Clone Overuse`
- Updated module docstring to include Rust
- Added `RUST_CODE` and `RUST_BUGGY` fixtures and full test coverage in `test_endpoints.py`
- Added Rust to `test_full_analyze_all_languages`

## Type of Change

- [ ] Bug fix
- [x] New feature
- [ ] Documentation update
- [ ] Refactor

## Testing

- [x] I ran backend tests (`pytest -q`)
- [ ] I tested frontend behavior manually

## Checklist

- [x] Code is readable and beginner-friendly
- [ ] No fake or placeholder behavior introduced
- [ ] Documentation updated if needed
