### PR TITLE
feat: add Kotlin language detection with regex patterns and test

### DIFF
--- a/backend/app/services/code_assistant.py
+++ b/backend/app/services/code_assistant.py
@@ -33,6 +33,15 @@ LANG_SIGNATURES: dict[str, list[str]] = {
         r"#include\s*<", r"\bstd::\w+", r"\bcout\s*<<",
         r"\bint\s+main\s*\(", r"::\w+",
     ],
+
+    "Kotlin": [
+    r"\bfun\s+\w+\s*\(",
+    r"\bval\s+\w+",
+    r"\bvar\s+\w+",
+    r"println\s*\(",
+    r"data\s+class\s+\w+",
+    r":\s*\w+\s*\?",
+],
 }
 
 

--- a/backend/tests/test_endpoints.py
+++ b/backend/tests/test_endpoints.py
@@ -13,6 +13,17 @@ client = TestClient(app)
 
 
 # ── Fixtures ──────────────────────────────────────────────────────────────────
+
+KOTLIN_CODE = """
+fun greet(name: String): String {
+    return "Hello $name"
+}
+val message: String? = null
+var count = 0
+data class User(val name: String, val age: Int)
+println("Hello World")
+"""
+
 PYTHON_BUGGY = """
 import os
 password = "supersecret123"
@@ -169,6 +180,12 @@ def test_debug_cpp():
     assert r.status_code == 200
     d = r.json()
     assert len(d["issues"]) > 0
+
+def test_debug_kotlin():
+    r = client.post("/debugging/", json={"code": KOTLIN_CODE, "language": "kotlin"})
+    assert r.status_code == 200
+    d = r.json()
+    assert d is not None
 
 def test_debug_issue_has_required_fields():
     r = client.post("/debugging/", json={"code": PYTHON_BUGGY})


### PR DESCRIPTION
Closes #73 
## Summary

Added Kotlin language detection to `LANG_SIGNATURES` in `code_assistant.py`
with 6 regex patterns. Added `KOTLIN_CODE` fixture and `test_debug_kotlin()`
test case in `test_endpoints.py`.

## Type of Change

- [ ] Bug fix
- [x] New feature
- [ ] Documentation update
- [ ] Refactor

## Testing

- [x] I ran backend tests (`pytest -q`)
- [ ] I tested frontend behavior manually

## Checklist

- [x] Code is readable and beginner-friendly
- [x] No fake or placeholder behavior introduced
- [ ] Documentation updated if needed
