### PR TITLE
fix: update dark mode toggle icon to switch between sun and moon

### DIFF
--- a/frontend/script.js
+++ b/frontend/script.js
@@ -29,6 +29,15 @@ themeToggle.addEventListener('click', () => {
   document.documentElement.setAttribute('data-theme', isLight ? 'dark' : 'light');
   localStorage.setItem('qyverix_theme', isLight ? 'dark' : 'light');
 
+  const icon = document.getElementById('themeIcon');
+  if (icon) {
+    if (isLight) {
+      icon.innerHTML = `<circle cx="12" cy="12" r="5"/><line x1="12" y1="1" x2="12" y2="3"/><line x1="12" y1="21" x2="12" y2="23"/>`;
+    } else {
+      icon.innerHTML = `<path d="M21 12.79A9 9 0 1 1 11.21 3 7 7 0 0 0 21 12.79z"/>`;
+    }
+  }
+
   const themeToggleBtn = document.getElementById('themeToggle');
   if (themeToggleBtn) {
     themeToggleBtn.setAttribute('aria-label', isLight ? 'Toggle dark mode' : 'Toggle light mode');


### PR DESCRIPTION
Fixes #158

## Problem
When dark mode toggle is clicked, the theme changes correctly but the icon (sun ☀️) does not update to moon 🌙 and vice versa.

## Fix
Added icon update logic in the themeToggle click event listener to dynamically switch between sun and moon SVG icons based on the current theme state.

## Changes
- frontend/script.js: Added icon innerHTML update on theme toggle click