### PR TITLE
feat: add weekly progress report

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -13,3 +13,14 @@ LLM_API_KEY=
 LLM_BASE_URL=https://api.openai.com/v1
 LLM_MODEL=gpt-4o-mini
 LLM_TIMEOUT_SECONDS=30
+
+# ── Weekly Email Digest ──────────────────────────────────────
+# Set DIGEST_ENABLED=true and configure SMTP to activate the
+# weekly Sunday email digest with analysis stats.
+DIGEST_ENABLED=false
+SMTP_HOST=
+SMTP_PORT=587
+SMTP_USER=
+SMTP_PASS=
+EMAIL_FROM=noreply@qyverixai.app
+DIGEST_BASE_URL=https://qyverixai.onrender.com

--- a/backend/app/config.py
+++ b/backend/app/config.py
@@ -68,5 +68,14 @@ class Settings:
     llm_model: str = os.getenv("LLM_MODEL", "gpt-4o-mini")
     llm_timeout_seconds: int = _int_env("LLM_TIMEOUT_SECONDS", 30)
 
+    # ── Email / Digest ──────────────────────────────────────────
+    smtp_host: str = os.getenv("SMTP_HOST", "")
+    smtp_port: int = _int_env("SMTP_PORT", 587)
+    smtp_user: str = os.getenv("SMTP_USER", "")
+    smtp_pass: str = os.getenv("SMTP_PASS", "")
+    email_from: str = os.getenv("EMAIL_FROM", "noreply@qyverixai.app")
+    digest_enabled: bool = _bool_env("DIGEST_ENABLED", False)
+    digest_base_url: str = os.getenv("DIGEST_BASE_URL", "https://qyverixai.onrender.com")
+
 
 settings = Settings()

--- a/backend/app/main.py
+++ b/backend/app/main.py
@@ -13,7 +13,8 @@ import os
 from collections import defaultdict
 from contextlib import asynccontextmanager
 
-from .routers import explanation, debugging, suggestions, analyze
+from .routers import explanation, debugging, suggestions, analyze, subscribe
+from .services.scheduler import start_scheduler, stop_scheduler
 from .schemas import HealthResponse
 
 
@@ -38,7 +39,9 @@ def check_rate_limit(ip: str) -> None:
 @asynccontextmanager
 async def lifespan(app: FastAPI):
     print("🚀 QyverixAI backend starting…")
+    start_scheduler()
     yield
+    stop_scheduler()
     print("🛑 QyverixAI backend shutting down…")
 
 
@@ -84,6 +87,7 @@ app.include_router(explanation.router, prefix="/explanation", tags=["Explanation
 app.include_router(debugging.router,   prefix="/debugging",   tags=["Debugging"])
 app.include_router(suggestions.router, prefix="/suggestions", tags=["Suggestions"])
 app.include_router(analyze.router,     prefix="/analyze",     tags=["Full Analysis"])
+app.include_router(subscribe.router,   prefix="/subscribe",   tags=["Subscription"])
 
 
 # ── Core Endpoints ────────────────────────────────────────────────────────────

--- a/backend/app/models.py
+++ b/backend/app/models.py
@@ -45,6 +45,17 @@ class FavoriteResult(Base):
     user = relationship("User", back_populates="favorites")
 
 
+class DigestSubscription(Base):
+    __tablename__ = "digest_subscriptions"
+
+    id: Mapped[int] = mapped_column(Integer, primary_key=True, index=True)
+    email: Mapped[str] = mapped_column(String(320), unique=True, index=True)
+    is_active: Mapped[bool] = mapped_column(default=True)
+    unsubscribe_token: Mapped[str] = mapped_column(String(64), unique=True, index=True)
+    subscribed_at: Mapped[datetime] = mapped_column(DateTime, default=lambda: datetime.now(UTC))
+    last_sent_at: Mapped[datetime | None] = mapped_column(DateTime, nullable=True)
+
+
 class SharedSnippet(Base):
     __tablename__ = "shared_snippets"
 

--- a/backend/app/routers/subscribe.py
+++ b/backend/app/routers/subscribe.py
@@ -10,7 +10,7 @@ from ..schemas import SubscribeRequest, SubscribeResponse, UnsubscribeRequest
 from ..services.email_service import _generate_token
 from ..models import DigestSubscription
 
-router = APIRouter(prefix="/subscribe", tags=["subscribe"])
+router = APIRouter(tags=["subscribe"])
 
 
 @router.post("/", response_model=SubscribeResponse)

--- a/backend/app/routers/subscribe.py
+++ b/backend/app/routers/subscribe.py
@@ -1,0 +1,100 @@
+"""REST endpoints for weekly digest subscription management."""
+
+from __future__ import annotations
+
+from fastapi import APIRouter, Depends, HTTPException, Query
+from sqlalchemy.orm import Session
+
+from ..database import get_db
+from ..schemas import SubscribeRequest, SubscribeResponse, UnsubscribeRequest
+from ..services.email_service import _generate_token
+from ..models import DigestSubscription
+
+router = APIRouter(prefix="/subscribe", tags=["subscribe"])
+
+
+@router.post("/", response_model=SubscribeResponse)
+def subscribe(body: SubscribeRequest, db: Session = Depends(get_db)):
+    """Subscribe an email address to the weekly digest.
+
+    If the email was previously subscribed but unsubscribed, this
+    re-activates the subscription rather than creating a duplicate.
+    """
+    email = body.email.strip().lower()
+
+    existing = db.query(DigestSubscription).filter(
+        DigestSubscription.email == email
+    ).first()
+
+    if existing:
+        if existing.is_active:
+            raise HTTPException(
+                status_code=409,
+                detail="This email is already subscribed to the weekly digest.",
+            )
+        existing.is_active = True
+        existing.unsubscribe_token = _generate_token()
+        db.commit()
+        return SubscribeResponse(
+            message="Subscription re-activated. Welcome back!",
+            email=email,
+        )
+
+    sub = DigestSubscription(
+        email=email,
+        is_active=True,
+        unsubscribe_token=_generate_token(),
+    )
+    db.add(sub)
+    db.commit()
+    return SubscribeResponse(
+        message="You're subscribed! You'll receive your first digest next Sunday.",
+        email=email,
+    )
+
+
+@router.post("/unsubscribe")
+def unsubscribe(body: UnsubscribeRequest, db: Session = Depends(get_db)):
+    """Unsubscribe an email address from the weekly digest.
+
+    Requires both the email and its unsubscribe token for verification.
+    """
+    email = body.email.strip().lower()
+
+    sub = db.query(DigestSubscription).filter(
+        DigestSubscription.email == email,
+        DigestSubscription.is_active.is_(True),
+    ).first()
+
+    if not sub:
+        raise HTTPException(status_code=404, detail="Subscription not found or already inactive.")
+
+    if sub.unsubscribe_token != body.token:
+        raise HTTPException(status_code=403, detail="Invalid unsubscribe token.")
+
+    sub.is_active = False
+    db.commit()
+    return {"message": "You've been unsubscribed from the weekly digest.", "email": email}
+
+
+@router.get("/unsubscribe")
+def unsubscribe_via_get(
+    email: str = Query(...),
+    token: str = Query(...),
+    db: Session = Depends(get_db),
+):
+    """GET-based unsubscribe for one-click links in email."""
+    sub = db.query(DigestSubscription).filter(
+        DigestSubscription.email == email.strip().lower(),
+        DigestSubscription.is_active.is_(True),
+    ).first()
+
+    if not sub:
+        return {"message": "Subscription not found or already inactive."}
+
+    if sub.unsubscribe_token != token:
+        return {"message": "Invalid unsubscribe link."}
+
+    sub.is_active = False
+    db.commit()
+    return {"message": "You've been unsubscribed from the weekly digest."}

--- a/backend/app/schemas.py
+++ b/backend/app/schemas.py
@@ -78,6 +78,31 @@ class AnalyzeResponse(BaseModel):
     analysis_time_ms: float | None = None
 
 
+# ── Weekly Digest / Subscription ───────────────────────────────
+class SubscribeRequest(BaseModel):
+    email: str
+
+    @field_validator("email")
+    @classmethod
+    def email_must_be_valid(cls, v: str) -> str:
+        v = v.strip().lower()
+        if "@" not in v or "." not in v.split("@")[-1]:
+            raise ValueError("Invalid email address")
+        if len(v) > 320:
+            raise ValueError("Email too long")
+        return v
+
+
+class SubscribeResponse(BaseModel):
+    message: str
+    email: str
+
+
+class UnsubscribeRequest(BaseModel):
+    email: str
+    token: str
+
+
 # ── Health ────────────────────────────────────────────────────────────────────
 class HealthResponse(BaseModel):
     status: str

--- a/backend/app/services/email_service.py
+++ b/backend/app/services/email_service.py
@@ -11,7 +11,7 @@ import smtplib
 from sqlalchemy.orm import Session
 
 from ..config import settings
-from ..models import DigestSubscription, QueryHistory, User
+from ..models import QueryHistory, User
 
 
 # ── Helpers ──────────────────────────────────────────────────────────────────

--- a/backend/app/services/email_service.py
+++ b/backend/app/services/email_service.py
@@ -1,0 +1,263 @@
+"""Weekly digest email — SMTP sending and HTML template."""
+
+from __future__ import annotations
+import secrets
+from datetime import UTC, datetime, timedelta
+from email.mime.multipart import MIMEMultipart
+from email.mime.text import MIMEText
+import json
+import smtplib
+
+from sqlalchemy.orm import Session
+
+from ..config import settings
+from ..models import DigestSubscription, QueryHistory, User
+
+
+# ── Helpers ──────────────────────────────────────────────────────────────────
+
+
+def _generate_token() -> str:
+    return secrets.token_urlsafe(32)
+
+
+def _parse_score(result_json: str) -> int | None:
+    """Extract overall_score from an analysis result JSON."""
+    try:
+        data = json.loads(result_json)
+        return data.get("suggestions", {}).get("overall_score")
+    except (json.JSONDecodeError, TypeError, AttributeError):
+        return None
+
+
+def _most_common_bug(issues: list[dict]) -> str | None:
+    """Return the most frequent bug type from a list of debug issues."""
+    from collections import Counter
+    types = [i.get("type", "Unknown") for i in issues if i.get("type")]
+    if not types:
+        return None
+    return Counter(types).most_common(1)[0][0]
+
+
+# ── Stats computation ─────────────────────────────────────────────────────────
+
+
+def compute_subscriber_stats(db: Session, email: str) -> dict | None:
+    """Compute weekly analysis stats for a subscriber.
+
+    Returns a dict ready for the email template, or None if the user
+    has no analysis history.
+    """
+    user = db.query(User).filter(User.email == email).first()
+    if not user:
+        return None
+
+    now = datetime.now(UTC)
+    week_ago = now - timedelta(days=7)
+    two_weeks_ago = now - timedelta(days=14)
+
+    # This week
+    this_week: list[QueryHistory] = (
+        db.query(QueryHistory)
+        .filter(
+            QueryHistory.user_id == user.id,
+            QueryHistory.created_at >= week_ago,
+        )
+        .all()
+    )
+
+    if not this_week:
+        return None
+
+    # Last week (for week-over-week comparison)
+    last_week: list[QueryHistory] = (
+        db.query(QueryHistory)
+        .filter(
+            QueryHistory.user_id == user.id,
+            QueryHistory.created_at >= two_weeks_ago,
+            QueryHistory.created_at < week_ago,
+        )
+        .all()
+    )
+
+    total = len(this_week)
+    languages: set[str] = set()
+    scores: list[int] = []
+    all_issues: list[dict] = []
+
+    for h in this_week:
+        try:
+            data = json.loads(h.result_json)
+        except json.JSONDecodeError:
+            continue
+
+        # Language from explanation
+        lang = data.get("explanation", {}).get("language") or data.get("language")
+        if lang:
+            languages.add(lang)
+
+        # Score from suggestions
+        score = data.get("suggestions", {}).get("overall_score")
+        if score is not None:
+            scores.append(int(score))
+
+        # Issues from debugging
+        issues = data.get("debugging", {}).get("issues", [])
+        all_issues.extend(issues)
+
+    avg_score = round(sum(scores) / len(scores), 1) if scores else None
+
+    # Last week average for comparison
+    last_scores: list[int] = []
+    for h in last_week:
+        s = _parse_score(h.result_json)
+        if s is not None:
+            last_scores.append(s)
+    prev_avg = round(sum(last_scores) / len(last_scores), 1) if last_scores else None
+
+    improvement: float | None = None
+    trend: str = "stable"
+    if avg_score is not None and prev_avg is not None and prev_avg > 0:
+        improvement = round(((avg_score - prev_avg) / prev_avg) * 100, 1)
+        if improvement > 2:
+            trend = "up"
+        elif improvement < -2:
+            trend = "down"
+
+    top_bug = _most_common_bug(all_issues)
+
+    return {
+        "email": email,
+        "total_analyses": total,
+        "languages": sorted(languages) if languages else ["Unknown"],
+        "avg_score": avg_score,
+        "prev_avg": prev_avg,
+        "improvement": improvement,
+        "trend": trend,
+        "top_bug": top_bug,
+        "total_issues": len(all_issues),
+        "week_start": week_ago.strftime("%b %d"),
+        "week_end": now.strftime("%b %d, %Y"),
+    }
+
+
+# ── Email template ────────────────────────────────────────────────────────────
+
+
+def _build_html(stats: dict, unsubscribe_url: str) -> str:
+    """Render the weekly digest HTML email."""
+    score_line = ""
+    if stats["avg_score"] is not None:
+        emoji = {"up": "📈", "down": "📉", "stable": "➡️"}.get(stats["trend"], "➡️")
+        arrow = {"up": "↑", "down": "↓", "stable": "→"}.get(stats["trend"], "→")
+        change = ""
+        if stats["improvement"] is not None:
+            change = f" ({arrow} {abs(stats['improvement'])}% vs last week)"
+        score_line = f"""
+        <tr>
+          <td style="padding:8px 12px;border-bottom:1px solid #e0dcd4;"><strong>Average Score</strong></td>
+          <td style="padding:8px 12px;border-bottom:1px solid #e0dcd4;text-align:right;">{stats['avg_score']}/100 {emoji}{change}</td>
+        </tr>"""
+
+    bug_line = ""
+    if stats["top_bug"]:
+        bug_line = f"""
+        <tr>
+          <td style="padding:8px 12px;border-bottom:1px solid #e0dcd4;"><strong>Most Common Bug</strong></td>
+          <td style="padding:8px 12px;border-bottom:1px solid #e0dcd4;text-align:right;">{stats['top_bug']}</td>
+        </tr>"""
+
+    return f"""<!DOCTYPE html>
+<html lang="en">
+<head><meta charset="UTF-8"><meta name="viewport" content="width=device-width,initial-scale=1.0"></head>
+<body style="margin:0;padding:0;background:#f4f1ec;font-family:-apple-system,BlinkMacSystemFont,'Segoe UI',Roboto,sans-serif;">
+<table role="presentation" width="100%" cellpadding="0" cellspacing="0">
+<tr><td align="center" style="padding:32px 16px;">
+  <table role="presentation" width="560" cellpadding="0" cellspacing="0" style="background:#ffffff;border-radius:8px;overflow:hidden;box-shadow:0 1px 3px rgba(0,0,0,0.08);">
+    <tr><td style="background:#1a1a2e;padding:24px 32px;text-align:center;">
+      <h1 style="margin:0;color:#f0a030;font-size:1.4rem;">QyverixAI Weekly Digest</h1>
+      <p style="margin:4px 0 0;color:#aaa;font-size:0.85rem;">{stats['week_start']} – {stats['week_end']}</p>
+    </td></tr>
+    <tr><td style="padding:24px 32px;">
+      <p style="margin:0 0 16px;color:#333;font-size:0.95rem;">Here&#39;s your weekly code analysis summary.</p>
+      <table role="presentation" width="100%" cellpadding="0" cellspacing="0" style="border:1px solid #e0dcd4;border-radius:6px;">
+        <tr>
+          <td style="padding:8px 12px;border-bottom:1px solid #e0dcd4;"><strong>Analyses Run</strong></td>
+          <td style="padding:8px 12px;border-bottom:1px solid #e0dcd4;text-align:right;">{stats['total_analyses']}</td>
+        </tr>
+        <tr>
+          <td style="padding:8px 12px;border-bottom:1px solid #e0dcd4;"><strong>Languages</strong></td>
+          <td style="padding:8px 12px;border-bottom:1px solid #e0dcd4;text-align:right;">{', '.join(stats['languages'])}</td>
+        </tr>
+        {score_line}
+        <tr>
+          <td style="padding:8px 12px;border-bottom:1px solid #e0dcd4;"><strong>Issues Found</strong></td>
+          <td style="padding:8px 12px;border-bottom:1px solid #e0dcd4;text-align:right;">{stats['total_issues']}</td>
+        </tr>
+        {bug_line}
+      </table>
+    </td></tr>
+    <tr><td style="padding:0 32px 24px;text-align:center;">
+      <a href="{stats.get('base_url', 'https://qyverixai.onrender.com')}/app" style="display:inline-block;padding:10px 24px;background:#f0a030;color:#1a1a2e;text-decoration:none;border-radius:6px;font-weight:bold;font-size:0.9rem;">Open QyverixAI</a>
+    </td></tr>
+    <tr><td style="padding:16px 32px;background:#faf8f5;font-size:0.75rem;color:#888;text-align:center;">
+      <p style="margin:0;">This email was sent to {stats['email']} because you subscribed to the QyverixAI weekly digest.</p>
+      <p style="margin:4px 0 0;"><a href="{unsubscribe_url}" style="color:#888;text-decoration:underline;">Unsubscribe</a></p>
+    </td></tr>
+  </table>
+</td></tr></table>
+</body>
+</html>"""
+
+
+def _build_text(stats: dict, unsubscribe_url: str) -> str:
+    """Plain-text fallback for the digest email."""
+    score = f"Average Score: {stats['avg_score']}/100" if stats['avg_score'] is not None else ""
+    bug = f"Most Common Bug: {stats['top_bug']}" if stats['top_bug'] else ""
+    return (
+        f"QyverixAI Weekly Digest\n"
+        f"{stats['week_start']} \u2013 {stats['week_end']}\n\n"
+        f"Analyses Run: {stats['total_analyses']}\n"
+        f"Languages: {', '.join(stats['languages'])}\n"
+        f"{score}\n"
+        f"Issues Found: {stats['total_issues']}\n"
+        f"{bug}\n\n"
+        f"Open QyverixAI: {stats.get('base_url', 'https://qyverixai.onrender.com')}/app\n\n"
+        f"Unsubscribe: {unsubscribe_url}"
+    )
+
+
+# ── SMTP send ────────────────────────────────────────────────────────────────
+
+
+def send_digest(stats: dict, unsubscribe_token: str) -> bool:
+    """Build and send a weekly digest email via SMTP.
+
+    Returns True on success, False on failure.
+    """
+    if not settings.digest_enabled or not settings.smtp_host:
+        return False
+
+    base = settings.digest_base_url.rstrip("/")
+    unsubscribe_url = f"{base}/unsubscribe/?email={stats['email']}&token={unsubscribe_token}"
+
+    msg = MIMEMultipart("alternative")
+    msg["Subject"] = f"QyverixAI Weekly Digest — {stats['week_start']} to {stats['week_end']}"
+    msg["From"] = settings.email_from
+    msg["To"] = stats["email"]
+
+    msg.attach(MIMEText(_build_text(stats, unsubscribe_url), "plain"))
+    msg.attach(MIMEText(_build_html(stats, unsubscribe_url), "html"))
+
+    try:
+        with smtplib.SMTP(settings.smtp_host, settings.smtp_port, timeout=30) as server:
+            if settings.smtp_port == 587:
+                server.starttls()
+            if settings.smtp_user:
+                server.login(settings.smtp_user, settings.smtp_pass)
+            server.send_message(msg)
+        return True
+    except Exception as exc:
+        import logging
+        logging.getLogger(__name__).warning("Failed to send digest to %s: %s", stats["email"], exc)
+        return False

--- a/backend/app/services/scheduler.py
+++ b/backend/app/services/scheduler.py
@@ -1,0 +1,79 @@
+"""APScheduler integration — weekly Sunday digest dispatch."""
+
+from __future__ import annotations
+import logging
+from datetime import UTC, datetime
+
+from apscheduler.schedulers.background import BackgroundScheduler
+
+from ..config import settings
+from ..database import SessionLocal
+from ..models import DigestSubscription
+from .email_service import compute_subscriber_stats, send_digest
+
+log = logging.getLogger(__name__)
+scheduler = BackgroundScheduler(daemon=True)
+JOB_ID = "weekly_digest"
+
+
+def _send_weekly_digests() -> None:
+    """Query all active subscribers and send them their weekly digest."""
+    if not settings.digest_enabled:
+        log.info("Digest disabled — skipping weekly run")
+        return
+
+    db = SessionLocal()
+    try:
+        subs = (
+            db.query(DigestSubscription)
+            .filter(DigestSubscription.is_active.is_(True))
+            .all()
+        )
+        if not subs:
+            log.info("No active digest subscribers")
+            return
+
+        sent = 0
+        for sub in subs:
+            stats = compute_subscriber_stats(db, sub.email)
+            if not stats:
+                log.debug("No stats for %s, skipping", sub.email)
+                continue
+            ok = send_digest(stats, sub.unsubscribe_token)
+            if ok:
+                sub.last_sent_at = datetime.now(UTC)
+                sent += 1
+            else:
+                log.warning("Failed to deliver digest to %s", sub.email)
+
+        db.commit()
+        log.info("Weekly digest sent to %d/%d subscribers", sent, len(subs))
+    except Exception:
+        log.exception("Error in weekly digest job")
+    finally:
+        db.close()
+
+
+def start_scheduler() -> None:
+    """Start the background scheduler with the weekly digest job."""
+    if scheduler.get_job(JOB_ID):
+        return
+
+    log.info("Starting weekly digest scheduler (cron: 0 8 * * 0)")
+    scheduler.add_job(
+        _send_weekly_digests,
+        trigger="cron",
+        day_of_week="sun",
+        hour=8,
+        minute=0,
+        id=JOB_ID,
+        replace_existing=True,
+    )
+    scheduler.start()
+
+
+def stop_scheduler() -> None:
+    """Shut down the background scheduler."""
+    if scheduler.running:
+        log.info("Stopping weekly digest scheduler")
+        scheduler.shutdown(wait=False)

--- a/backend/requirements.txt
+++ b/backend/requirements.txt
@@ -5,3 +5,4 @@ httpx>=0.27.0
 python-multipart>=0.0.9
 pytest>=8.0.0
 pytest-asyncio>=0.23.0
+apscheduler>=3.10.0

--- a/backend/requirements.txt
+++ b/backend/requirements.txt
@@ -1,6 +1,9 @@
 fastapi>=0.115.0
 uvicorn[standard]>=0.30.0
 pydantic>=2.7.0
+sqlalchemy>=2.0.0
+pyjwt>=2.0.0
+python-dotenv>=1.0.0
 httpx>=0.27.0
 python-multipart>=0.0.9
 pytest>=8.0.0

--- a/backend/tests/test_digest.py
+++ b/backend/tests/test_digest.py
@@ -1,0 +1,155 @@
+"""
+Tests for weekly email digest — subscribe / unsubscribe / scheduler.
+Run: cd backend && pytest test_digest.py -v
+"""
+import pytest
+from fastapi.testclient import TestClient
+from sqlalchemy import create_engine
+from sqlalchemy.orm import sessionmaker
+
+import sys, os
+sys.path.insert(0, os.path.dirname(os.path.dirname(__file__)))
+
+from app.database import Base, get_db
+from app.models import DigestSubscription
+
+# Now import the FastAPI app and wire up the test DB override.
+from app.main import app as fastapi_app
+
+
+from sqlalchemy.pool import StaticPool
+TEST_ENGINE = create_engine(
+    "sqlite:///:memory:",
+    connect_args={"check_same_thread": False},
+    poolclass=StaticPool,
+)
+TEST_SESSION_LOCAL = sessionmaker(bind=TEST_ENGINE)
+
+
+def _override_db():
+    db = TEST_SESSION_LOCAL()
+    try:
+        yield db
+    finally:
+        db.close()
+
+
+fastapi_app.dependency_overrides[get_db] = _override_db
+client = TestClient(fastapi_app)
+
+
+# ── Setup / Teardown ──────────────────────────────────────────────────────────
+@pytest.fixture(autouse=True)
+def _recreate_tables():
+    """Recreate all tables before each test for a clean slate."""
+    Base.metadata.create_all(bind=TEST_ENGINE)
+    yield
+    Base.metadata.drop_all(bind=TEST_ENGINE)
+
+
+# ── Tests ─────────────────────────────────────────────────────────────────────
+def test_subscribe_success():
+    r = client.post("/subscribe/", json={"email": "test@example.com"})
+    assert r.status_code == 200
+    data = r.json()
+    assert data["email"] == "test@example.com"
+    assert "subscribed" in data["message"].lower()
+
+
+def test_subscribe_duplicate_returns_409():
+    client.post("/subscribe/", json={"email": "test@example.com"})
+    r = client.post("/subscribe/", json={"email": "test@example.com"})
+    assert r.status_code == 409
+    assert "already subscribed" in r.json()["detail"].lower()
+
+
+def test_subscribe_re_activates_after_unsubscribe():
+    client.post("/subscribe/", json={"email": "test@example.com"})
+
+    db = TEST_SESSION_LOCAL()
+    try:
+        sub = db.query(DigestSubscription).filter(
+            DigestSubscription.email == "test@example.com"
+        ).first()
+        token = sub.unsubscribe_token
+    finally:
+        db.close()
+
+    r = client.post("/subscribe/unsubscribe", json={
+        "email": "test@example.com", "token": token
+    })
+    assert r.status_code == 200
+
+    r = client.post("/subscribe/", json={"email": "test@example.com"})
+    assert r.status_code == 200
+    assert "re-activated" in r.json()["message"].lower()
+
+
+def test_unsubscribe_success():
+    client.post("/subscribe/", json={"email": "test@example.com"})
+    db = TEST_SESSION_LOCAL()
+    try:
+        sub = db.query(DigestSubscription).filter(
+            DigestSubscription.email == "test@example.com"
+        ).first()
+        token = sub.unsubscribe_token
+    finally:
+        db.close()
+
+    r = client.post("/subscribe/unsubscribe", json={
+        "email": "test@example.com", "token": token
+    })
+    assert r.status_code == 200
+    assert "unsubscribed" in r.json()["message"].lower()
+
+
+def test_unsubscribe_wrong_token():
+    client.post("/subscribe/", json={"email": "test@example.com"})
+    r = client.post("/subscribe/unsubscribe", json={
+        "email": "test@example.com", "token": "wrong-token"
+    })
+    assert r.status_code == 403
+
+
+def test_unsubscribe_nonexistent():
+    r = client.post("/subscribe/unsubscribe", json={
+        "email": "nobody@example.com", "token": "some-token"
+    })
+    assert r.status_code == 404
+
+
+def test_get_unsubscribe_link():
+    client.post("/subscribe/", json={"email": "test@example.com"})
+    db = TEST_SESSION_LOCAL()
+    try:
+        sub = db.query(DigestSubscription).filter(
+            DigestSubscription.email == "test@example.com"
+        ).first()
+        token = sub.unsubscribe_token
+    finally:
+        db.close()
+
+    r = client.get("/subscribe/unsubscribe", params={
+        "email": "test@example.com", "token": token
+    })
+    assert r.status_code == 200
+    assert "unsubscribed" in r.json()["message"].lower()
+
+
+def test_invalid_email():
+    r = client.post("/subscribe/", json={"email": "not-an-email"})
+    assert r.status_code == 422
+
+
+def test_subscribe_stores_token():
+    client.post("/subscribe/", json={"email": "token-test@example.com"})
+    db = TEST_SESSION_LOCAL()
+    try:
+        sub = db.query(DigestSubscription).filter(
+            DigestSubscription.email == "token-test@example.com"
+        ).first()
+        assert sub is not None
+        assert sub.is_active is True
+        assert len(sub.unsubscribe_token) >= 16
+    finally:
+        db.close()

--- a/frontend/index.html
+++ b/frontend/index.html
@@ -2181,14 +2181,25 @@
 
     <!-- ── FOOTER ─────────────────────────────────────────────────── -->
     <footer>
-      <div class="app">
-        <div class="footer-logo">QyverixAI</div>
-        <p>
-          <a href="https://github.com/imDarshanGK/AI-dev-assistant" target="_blank">GitHub</a>
-          · <a href="https://qyverixai.onrender.com/docs" target="_blank">API Docs</a>
-          · MIT License
-        </p>
-        <p style="margin-top:8px;font-size:0.75rem">Built for the open source community</p>
+      <div class="app" style="display:flex;flex-wrap:wrap;gap:32px;align-items:flex-start;justify-content:space-between;">
+        <div>
+          <div class="footer-logo">QyverixAI</div>
+          <p>
+            <a href="https://github.com/imDarshanGK/AI-dev-assistant" target="_blank">GitHub</a>
+            · <a href="https://qyverixai.onrender.com/docs" target="_blank">API Docs</a>
+            · MIT License
+          </p>
+          <p style="font-size:0.75rem">Built for the open source community</p>
+        </div>
+        <div style="max-width:320px;">
+          <p style="margin:0 0 6px;font-size:0.8rem;font-weight:600;color:var(--accent);">Weekly Digest</p>
+          <form id="digestForm" style="display:flex;gap:6px;">
+            <input type="email" id="digestEmail" placeholder="your@email.com" required
+                   style="flex:1;min-width:180px;padding:7px 10px;font-size:0.8rem;border:1px solid var(--border);border-radius:6px;background:var(--bg);color:var(--fg);">
+            <button type="submit" id="digestBtn" style="padding:7px 14px;font-size:0.8rem;font-weight:600;background:var(--accent);color:#fff;border:none;border-radius:6px;cursor:pointer;">Subscribe</button>
+          </form>
+          <p style="margin:6px 0 0;font-size:0.7rem;color:var(--muted);">Get a Sunday email with your weekly analysis stats.</p>
+        </div>
       </div>
     </footer>
 
@@ -3061,6 +3072,37 @@ int main() {
       });
       const savedUrl = localStorage.getItem('qyx_apiUrl');
       if (savedUrl) apiUrlInput.value = savedUrl;
+
+      /* ═══════════════════════════════════════════════════════════════
+         DIGEST SUBSCRIBE
+      ═══════════════════════════════════════════════════════════════ */
+      document.getElementById('digestForm').addEventListener('submit', async (e) => {
+        e.preventDefault();
+        const email = document.getElementById('digestEmail').value.trim();
+        const btn = document.getElementById('digestBtn');
+        btn.disabled = true;
+        btn.textContent = 'Subscribing…';
+        const base = apiUrlInput.value.replace(/\/$/, '');
+        try {
+          const r = await fetch(`${base}/subscribe/`, {
+            method: 'POST',
+            headers: { 'Content-Type': 'application/json' },
+            body: JSON.stringify({ email }),
+          });
+          const data = await r.json();
+          if (r.ok) {
+            toast(data.message, 'success');
+            document.getElementById('digestEmail').value = '';
+          } else {
+            toast(data.detail || 'Subscription failed', 'error');
+          }
+        } catch {
+          toast('Could not reach the server.', 'error');
+        } finally {
+          btn.disabled = false;
+          btn.textContent = 'Subscribe';
+        }
+      });
     </script>
 </body>
 


### PR DESCRIPTION
## Summary

Add a weekly email digest feature for the QyverixAI app. Users can subscribe via a form in the footer to receive a Sunday email with their weekly analysis stats — total analyses run, average score (with week-over-week trend), languages analyzed, total issues found, and most common bug type. Each digest email includes a one-click unsubscribe link.

Fixes #134 

Backend changes:
- `DigestSubscription` model (email, is_active, unsubscribe_token, subscribed_at, last_sent_at)
- SMTP config settings (`SMTP_HOST`, `SMTP_PORT`, `SMTP_USER`, `SMTP_PASS`, `EMAIL_FROM`, `DIGEST_ENABLED`, `DIGEST_BASE_URL`)
- `email_service.py` — HTML + plain-text email templates, stats computation from `QueryHistory`, SMTP send
- `scheduler.py` — APScheduler cron job (Sunday 08:00 UTC), lifespan integration
- `subscribe.py` router — `POST /subscribe/`, `POST /unsubscribe/`, `GET /unsubscribe`
- `requirements.txt` — added `apscheduler>=3.10.0`

Frontend changes:
- Subscribe email input + button in the footer
- Async JS handler with toast feedback, reuses existing `toast()` function

## Type of Change

- [ ] Bug fix
- [x] New feature
- [ ] Documentation update
- [ ] Refactor

## Testing

- [ ] I ran backend tests (`pytest -q`)
- [x] I tested frontend behavior manually

## Checklist

- [x] Code is readable and beginner-friendly
- [x] No fake or placeholder behavior introduced
- [x] Documentation updated if needed (`.env.example` updated)

## Screenshot

<img width="1897" height="907" alt="Screenshot 2026-05-20 181115" src="https://github.com/user-attachments/assets/e6cf8af9-35aa-45b7-9f08-ea4ad6f7068e" />

