### PR TITLE
test: strengthen health endpoint assertions

### DIFF
--- a/backend/tests/test_endpoints.py
+++ b/backend/tests/test_endpoints.py
@@ -9,9 +9,16 @@ from fastapi.testclient import TestClient
 from app.main import _request_counts
 import sys, os
 sys.path.insert(0, os.path.dirname(os.path.dirname(__file__)))
-from app.main import app
+from app.main import app, _request_counts
 
 client = TestClient(app)
+
+
+@pytest.fixture(autouse=True)
+def reset_rate_limit_state():
+    _request_counts.clear()
+    yield
+    _request_counts.clear()
 
 
 # ── Fixtures ──────────────────────────────────────────────────────────────────

--- a/backend/tests/test_endpoints.py
+++ b/backend/tests/test_endpoints.py
@@ -2,6 +2,8 @@
 QyverixAI — Test Suite
 Run: cd backend && pytest -v
 """
+import time
+
 import pytest
 from fastapi.testclient import TestClient
 from app.main import _request_counts
@@ -147,9 +149,16 @@ def test_root():
     assert "version" in data
 
 def test_health():
+    start = time.perf_counter()
     r = client.get("/health")
+    elapsed_ms = (time.perf_counter() - start) * 1000
+
     assert r.status_code == 200
-    assert r.json()["status"] == "ok"
+    data = r.json()
+    assert data["status"] == "ok"
+    assert data["version"] == "3.0.0"
+    assert "message" in data
+    assert elapsed_ms < 500
 
 
 # ── Explanation ───────────────────────────────────────────────────────────────


### PR DESCRIPTION
## Summary
- expand `/health` test coverage to assert the API version and message field
- add a lightweight response-time assertion under 500ms

## Verification
- ran `python3 -m compileall -q backend/tests/test_endpoints.py`
- attempted `python3 -m pytest tests/test_endpoints.py::test_health -q`, but pytest is not installed in this environment

References #69