### PR TITLE
#129 : add visual side-by-side diff view to suggestion

### DIFF
--- a/frontend/index.html
+++ b/frontend/index.html
@@ -1273,6 +1273,178 @@
       overflow-x: auto;
     }
 
+    /* ── Diff View ── */
+    .diff-wrapper {
+      margin-top: 10px;
+      border-radius: var(--r2);
+      border: 1px solid var(--border);
+      overflow: hidden;
+      font-family: var(--font-mono);
+      font-size: 0.72rem;
+    }
+
+    .diff-header {
+      display: flex;
+      align-items: center;
+      justify-content: space-between;
+      padding: 6px 12px;
+      background: var(--bg3);
+      border-bottom: 1px solid var(--border);
+      font-size: 0.7rem;
+      color: var(--text3);
+      font-family: var(--font-ui);
+      gap: 8px;
+    }
+
+    .diff-header-labels {
+      display: flex;
+      gap: 16px;
+      flex: 1;
+    }
+
+    .diff-label {
+      display: flex;
+      align-items: center;
+      gap: 5px;
+      font-weight: 600;
+      font-size: 0.68rem;
+      text-transform: uppercase;
+      letter-spacing: 0.04em;
+    }
+
+    .diff-label-dot {
+      width: 7px;
+      height: 7px;
+      border-radius: 50%;
+    }
+
+    .diff-label-before .diff-label-dot { background: var(--red); }
+    .diff-label-after  .diff-label-dot { background: var(--green); }
+
+    .diff-view {
+      display: grid;
+      grid-template-columns: 1fr 1fr;
+      border-top: none;
+    }
+
+    @media (max-width: 640px) {
+      .diff-view {
+        grid-template-columns: 1fr;
+      }
+      .diff-col:first-child {
+        border-right: none;
+        border-bottom: 1px solid var(--border);
+      }
+    }
+
+    .diff-col {
+      overflow-x: auto;
+      background: var(--bg);
+    }
+
+    .diff-col:first-child {
+      border-right: 1px solid var(--border);
+    }
+
+    .diff-line {
+      display: flex;
+      align-items: flex-start;
+      padding: 2px 0;
+      min-height: 22px;
+      line-height: 1.6;
+      white-space: pre;
+    }
+
+    .diff-line-num {
+      min-width: 32px;
+      padding: 0 6px;
+      text-align: right;
+      color: var(--text3);
+      user-select: none;
+      font-size: 0.65rem;
+      flex-shrink: 0;
+      border-right: 1px solid var(--border);
+      margin-right: 8px;
+      line-height: 1.6;
+    }
+
+    .diff-line-content {
+      padding-right: 12px;
+      word-break: break-all;
+      white-space: pre-wrap;
+    }
+
+    .diff-line-removed {
+      background: rgba(242, 87, 87, 0.13);
+    }
+
+    .diff-line-removed .diff-line-num {
+      background: rgba(242, 87, 87, 0.18);
+      color: var(--red);
+    }
+
+    .diff-line-removed .diff-line-content {
+      color: var(--red);
+    }
+
+    .diff-line-added {
+      background: rgba(34, 212, 123, 0.10);
+    }
+
+    .diff-line-added .diff-line-num {
+      background: rgba(34, 212, 123, 0.15);
+      color: var(--green);
+    }
+
+    .diff-line-added .diff-line-content {
+      color: var(--green);
+    }
+
+    .diff-line-equal {
+      background: transparent;
+    }
+
+    .diff-line-equal .diff-line-content {
+      color: var(--text2);
+    }
+
+    .diff-line-placeholder {
+      background: var(--bg3);
+      opacity: 0.4;
+    }
+
+    .btn-copy-fix {
+      display: inline-flex;
+      align-items: center;
+      gap: 5px;
+      padding: 4px 10px;
+      border-radius: 6px;
+      font-size: 0.7rem;
+      font-weight: 600;
+      font-family: var(--font-ui);
+      cursor: pointer;
+      border: 1px solid rgba(34, 212, 123, 0.3);
+      background: rgba(34, 212, 123, 0.08);
+      color: var(--green);
+      transition: all var(--transition);
+      white-space: nowrap;
+      flex-shrink: 0;
+    }
+
+    .btn-copy-fix:hover {
+      background: rgba(34, 212, 123, 0.18);
+      border-color: var(--green);
+      transform: translateY(-1px);
+    }
+
+    .btn-copy-fix:active {
+      transform: translateY(0);
+    }
+
+    .btn-copy-fix svg {
+      flex-shrink: 0;
+    }
+
     /* ── Clean State ── */
     .clean-state {
       display: flex;
@@ -2692,6 +2864,152 @@
         el.innerHTML = statBar + cards;
       }
 
+      /* ═══════════════════════════════════════════════════════════════
+         PURE-JS LINE DIFF (LCS-based)
+      ═══════════════════════════════════════════════════════════════ */
+      function computeDiff(originalText, fixedText) {
+        const aLines = originalText.split('\n');
+        const bLines = fixedText.split('\n');
+        const m = aLines.length, n = bLines.length;
+
+        // Build LCS table
+        const dp = Array.from({ length: m + 1 }, () => new Array(n + 1).fill(0));
+        for (let i = 1; i <= m; i++) {
+          for (let j = 1; j <= n; j++) {
+            dp[i][j] = aLines[i - 1] === bLines[j - 1]
+              ? dp[i - 1][j - 1] + 1
+              : Math.max(dp[i - 1][j], dp[i][j - 1]);
+          }
+        }
+
+        // Backtrack to get edit script
+        const left = [];   // original column (removed + equal)
+        const right = [];  // fixed column    (added + equal)
+        let i = m, j = n;
+        const edits = [];
+        while (i > 0 || j > 0) {
+          if (i > 0 && j > 0 && aLines[i - 1] === bLines[j - 1]) {
+            edits.push({ type: 'equal', a: aLines[i - 1], b: bLines[j - 1] });
+            i--; j--;
+          } else if (j > 0 && (i === 0 || dp[i][j - 1] >= dp[i - 1][j])) {
+            edits.push({ type: 'added', b: bLines[j - 1] });
+            j--;
+          } else {
+            edits.push({ type: 'removed', a: aLines[i - 1] });
+            i--;
+          }
+        }
+        edits.reverse();
+
+        // Separate into two column lists
+        let aIdx = 0, bIdx = 0;
+        edits.forEach(e => {
+          if (e.type === 'equal') {
+            left.push({ type: 'equal', text: e.a, num: ++aIdx });
+            right.push({ type: 'equal', text: e.b, num: ++bIdx });
+          } else if (e.type === 'removed') {
+            left.push({ type: 'removed', text: e.a, num: ++aIdx });
+            right.push({ type: 'placeholder', text: '' });
+          } else {
+            left.push({ type: 'placeholder', text: '' });
+            right.push({ type: 'added', text: e.b, num: ++bIdx });
+          }
+        });
+        return { left, right };
+      }
+
+      function renderDiffCol(lines) {
+        return lines.map(l => {
+          if (l.type === 'placeholder') {
+            return `<div class="diff-line diff-line-placeholder"><span class="diff-line-num"></span><span class="diff-line-content"> </span></div>`;
+          }
+          const cls = l.type === 'removed' ? 'diff-line-removed'
+            : l.type === 'added' ? 'diff-line-added'
+              : 'diff-line-equal';
+          const prefix = l.type === 'removed' ? '− ' : l.type === 'added' ? '+ ' : '  ';
+          return `<div class="diff-line ${cls}"><span class="diff-line-num">${l.num}</span><span class="diff-line-content">${prefix}${escHtml(l.text)}</span></div>`;
+        }).join('');
+      }
+
+      /* Find the region of the editor code that best matches the fixed snippet.
+         Returns the matching original lines (as a string) or null if nothing found. */
+      function findOriginalSnippet(editorCode, fixedCode) {
+        if (!editorCode || !fixedCode) return null;
+        const fixedLines  = fixedCode.split('\n').map(l => l.trim()).filter(Boolean);
+        const editorLines = editorCode.split('\n');
+        if (!fixedLines.length || !editorLines.length) return null;
+
+        let bestScore = 0, bestStart = -1;
+
+        for (let i = 0; i < editorLines.length; i++) {
+          let score = 0;
+          for (let j = 0; j < fixedLines.length && i + j < editorLines.length; j++) {
+            const el = editorLines[i + j].trim();
+            const fl = fixedLines[j].trim();
+            if (!el || !fl) continue;
+            if (el === fl) {
+              score += 2;
+            } else if (fl.length > 6 && el.includes(fl.slice(0, Math.min(fl.length, 18)))) {
+              score += 1;
+            } else if (el.length > 6 && fl.includes(el.slice(0, Math.min(el.length, 18)))) {
+              score += 1;
+            }
+          }
+          if (score > bestScore) { bestScore = score; bestStart = i; }
+        }
+
+        if (bestStart === -1 || bestScore < 1) return null;
+
+        // Extract the matched region (same number of lines as the fixed snippet)
+        const start = Math.max(0, bestStart);
+        const end   = Math.min(editorLines.length, bestStart + fixedLines.length);
+        return editorLines.slice(start, end).join('\n');
+      }
+
+      /* Build the side-by-side diff HTML for one suggestion's example */
+      function buildDiffHtml(originalSnippet, fixedCode, copyId) {
+        const diff = computeDiff(originalSnippet, fixedCode);
+        const hasChanges = diff.left.some(l  => l.type === 'removed') ||
+                           diff.right.some(r => r.type === 'added');
+        // If nothing changed (identical), just show as fixed-code block
+        if (!hasChanges) {
+          const lines = fixedCode.split('\n').map((text, idx) => ({ type: 'added', text, num: idx + 1 }));
+          return `
+          <div class="diff-wrapper">
+            <div class="diff-header">
+              <div class="diff-header-labels">
+                <span class="diff-label diff-label-after"><span class="diff-label-dot"></span>Fixed Code</span>
+              </div>
+              <button class="btn-copy-fix" id="${copyId}" aria-label="Copy fixed code">
+                <svg width="12" height="12" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2"><rect x="9" y="9" width="13" height="13" rx="2"/><path d="M5 15H4a2 2 0 0 1-2-2V4a2 2 0 0 1 2-2h9a2 2 0 0 1 2 2v1"/></svg>
+                Copy fixed
+              </button>
+            </div>
+            <div class="diff-col" style="width:100%">${renderDiffCol(lines)}</div>
+          </div>`;
+        }
+        return `
+        <div class="diff-wrapper">
+          <div class="diff-header">
+            <div class="diff-header-labels">
+              <span class="diff-label diff-label-before"><span class="diff-label-dot"></span>Before</span>
+              <span class="diff-label diff-label-after"><span class="diff-label-dot"></span>After</span>
+            </div>
+            <button class="btn-copy-fix" id="${copyId}" aria-label="Copy fixed code">
+              <svg width="12" height="12" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2"><rect x="9" y="9" width="13" height="13" rx="2"/><path d="M5 15H4a2 2 0 0 1-2-2V4a2 2 0 0 1 2-2h9a2 2 0 0 1 2 2v1"/></svg>
+              Copy fixed
+            </button>
+          </div>
+          <div class="diff-view">
+            <div class="diff-col">${renderDiffCol(diff.left)}</div>
+            <div class="diff-col">${renderDiffCol(diff.right)}</div>
+          </div>
+        </div>`;
+      }
+
+      /* ═══════════════════════════════════════════════════════════════
+         RENDER SUGGESTIONS (with diff view)
+      ═══════════════════════════════════════════════════════════════ */
       function renderSuggest(sugg) {
         document.getElementById('emptySuggest').style.display = 'none';
         const el = document.getElementById('suggestResult');
@@ -2729,17 +3047,98 @@
 
         const cards = sugg.suggestions.length === 0
           ? `<div class="clean-state"><div class="clean-icon"><svg width="36" height="36" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="1.5"><polygon points="12,2 15.09,8.26 22,9.27 17,14.14 18.18,21.02 12,17.77 5.82,21.02 7,14.14 2,9.27 8.91,8.26"/></svg></div><h3>Perfect score!</h3><p>No improvement suggestions found.</p></div>`
-          : sugg.suggestions.map((s, i) => `
+          : sugg.suggestions.map((s, i) => {
+
+            let exampleHtml = '';
+            if (s.example) {
+              const copyId  = `copy-fix-${i}`;
+              const rawLines = s.example.split('\n');
+
+              // Case 1: example has unified diff markers (- / +)
+              const hasMarkers = rawLines.some(l => /^[\-\+]/.test(l) && l.length > 1);
+              if (hasMarkers) {
+                const originalText = rawLines.filter(l => !l.startsWith('+')).map(l => l.replace(/^-\s?/, '')).join('\n');
+                const fixedText    = rawLines.filter(l => !l.startsWith('-')).map(l => l.replace(/^\+\s?/, '')).join('\n');
+                exampleHtml = buildDiffHtml(originalText, fixedText, copyId);
+
+              // Case 2: two blocks separated by a blank line (before \n\n after)
+              } else {
+                const blankIdx = rawLines.findIndex(l => l.trim() === '');
+                if (blankIdx > 0 && blankIdx < rawLines.length - 1) {
+                  const originalText = rawLines.slice(0, blankIdx).join('\n');
+                  const fixedText    = rawLines.slice(blankIdx + 1).join('\n');
+                  exampleHtml = buildDiffHtml(originalText, fixedText, copyId);
+
+                // Case 3 (most common from API): single fixed-code block
+                // → find matching region in editor as "Before", diff against example as "After"
+                } else {
+                  const originalSnippet = findOriginalSnippet(editor.value, s.example);
+                  if (originalSnippet) {
+                    exampleHtml = buildDiffHtml(originalSnippet, s.example, copyId);
+                  } else {
+                    // No match – show fixed code as green "Fixed Code" block
+                    const lines = rawLines.map((text, idx) => ({ type: 'added', text, num: idx + 1 }));
+                    exampleHtml = `
+                    <div class="diff-wrapper">
+                      <div class="diff-header">
+                        <div class="diff-header-labels">
+                          <span class="diff-label diff-label-after"><span class="diff-label-dot"></span>Fixed Code</span>
+                        </div>
+                        <button class="btn-copy-fix" id="${copyId}" aria-label="Copy fixed code">
+                          <svg width="12" height="12" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2"><rect x="9" y="9" width="13" height="13" rx="2"/><path d="M5 15H4a2 2 0 0 1-2-2V4a2 2 0 0 1 2-2h9a2 2 0 0 1 2 2v1"/></svg>
+                          Copy fixed
+                        </button>
+                      </div>
+                      <div class="diff-col" style="width:100%">${renderDiffCol(lines)}</div>
+                    </div>`;
+                  }
+                }
+              }
+            }
+
+            return `
       <div class="suggest-card priority-${s.priority}" style="animation-delay:${i * 0.05}s" tabindex="0">
         <div class="suggest-header">
           <span class="suggest-cat">${s.category}</span>
           <span style="font-size:0.7rem;color:var(--text3);margin-left:auto">${s.priority} priority</span>
         </div>
         <div class="suggest-desc">${s.description}</div>
-        ${s.example ? `<pre class="suggest-example">${escHtml(s.example)}</pre>` : ''}
-      </div>`).join('');
+        ${exampleHtml}
+      </div>`;
+          }).join('');
 
         el.innerHTML = ring + cards;
+
+        // Wire up "Copy fixed" buttons after DOM insertion
+        sugg.suggestions.forEach((s, i) => {
+          if (!s.example) return;
+          const btn = document.getElementById(`copy-fix-${i}`);
+          if (!btn) return;
+
+          // Always copy the after/fixed code
+          const rawLines   = s.example.split('\n');
+          const hasMarkers = rawLines.some(l => /^[\-\+]/.test(l) && l.length > 1);
+          let fixedCode;
+          if (hasMarkers) {
+            fixedCode = rawLines.filter(l => !l.startsWith('-')).map(l => l.replace(/^\+\s?/, '')).join('\n');
+          } else {
+            const blankIdx = rawLines.findIndex(l => l.trim() === '');
+            fixedCode = blankIdx > 0 && blankIdx < rawLines.length - 1
+              ? rawLines.slice(blankIdx + 1).join('\n')
+              : s.example;
+          }
+
+          btn.addEventListener('click', () => {
+            navigator.clipboard.writeText(fixedCode).then(() => {
+              btn.textContent = '\u2713 Copied!';
+              btn.style.background = 'rgba(34,212,123,0.25)';
+              setTimeout(() => {
+                btn.innerHTML = `<svg width="12" height="12" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2"><rect x="9" y="9" width="13" height="13" rx="2"/><path d="M5 15H4a2 2 0 0 1-2-2V4a2 2 0 0 1 2-2h9a2 2 0 0 1 2 2v1"/></svg> Copy fixed`;
+                btn.style.background = '';
+              }, 2000);
+            }).catch(() => toast('Copy failed', 'error'));
+          });
+        });
       }
 
       /* ═══════════════════════════════════════════════════════════════


### PR DESCRIPTION
This fixes #129 : Add code diff view - show before/after for each suggestion

## Summary
Added a visual side-by-side diff view inside each suggestion card in the Improve tab. Previously, suggestions only showed the fixed code as plain text. Now, for every suggestion that has an example field, the UI shows:

Left panel (red): the original/before code extracted from the editor
Right panel (green): the improved/fixed code from the suggestion
A "Copy fixed" button to instantly copy the fixed snippet to clipboard
All implemented in frontend/index.html using a pure-JS LCS-based diff algorithm — no external libraries added.


## Type of Change

- [ ] Bug fix
- [Y] New feature
- [ ] Documentation update
- [ ] Refactor

## Testing

- [ ] I ran backend tests (`pytest -q`)
- [Y] I tested frontend behavior manually

## Checklist

- [Y] Code is readable and beginner-friendly
- [Y] No fake or placeholder behavior introduced
- [Y] Documentation updated if needed


BEFORE :
<img width="1348" height="1172" alt="Screenshot 2026-05-20 214315" src="https://github.com/user-attachments/assets/dd3a7f36-bb3d-4723-9e3d-2b926f2cef48" />


AFTER :
<img width="1338" height="1171" alt="Screenshot 2026-05-20 214336" src="https://github.com/user-attachments/assets/c8e71768-72c6-4f8c-98f3-bbcbdf9155e8" />
