### PR TITLE
feat: add cyclomatic complexity metrics to explanation engine (#137)

### DIFF
--- a/backend/app/schemas.py
+++ b/backend/app/schemas.py
@@ -28,6 +28,8 @@ class ExplanationResponse(BaseModel):
     line_count: int
     function_count: int
     class_count: int
+    cyclomatic_complexity: int
+    complexity_risk: str
 
 
 # ── Debugging ─────────────────────────────────────────────────────────────────

--- a/backend/app/services/code_assistant.py
+++ b/backend/app/services/code_assistant.py
@@ -95,6 +95,41 @@ def detect_language(code: str, hint: str | None = None) -> str:
     return best if scores[best] > 0 else "Unknown"
 
 
+# ── Cyclomatic Complexity ──────────────────────────────────────────────────────
+_DECISION_RE = re.compile(
+    r"\b(if|elif|else|for|while|and|or|case|catch|except)\b|\?(?![?:.])",
+    re.MULTILINE,
+)
+
+_RISK_THRESHOLDS: tuple[tuple[int, str], ...] = (
+    (5,  "Simple"),
+    (10, "Moderate"),
+    (20, "High"),
+)
+
+
+def calculate_cyclomatic_complexity(code: str, language: str) -> tuple[int, str]:
+    """Calculate the cyclomatic complexity of a code snippet.
+
+    Uses a simplified McCabe formula: M = decision points + 1, where decision
+    points are control-flow keywords (if, elif, else, for, while, and, or,
+    case, catch, except) and ternary operators.
+
+    Args:
+        code: The source code to analyse.
+        language: The programming language of the code.
+
+    Returns:
+        A tuple of (score, risk) where risk is one of "Simple", "Moderate",
+        "High", or "Very High".
+    """
+    score = len(_DECISION_RE.findall(code)) + 1
+    for threshold, label in _RISK_THRESHOLDS:
+        if score <= threshold:
+            return score, label
+    return score, "Very High"
+
+
 # ── Complexity Estimation ──────────────────────────────────────────────────────
 def estimate_complexity(code: str) -> str:
     """Estimate the overall complexity level of the given code snippet.
@@ -599,6 +634,7 @@ def run_explanation(code: str, language: str) -> dict:
     lines = code.splitlines()
     non_blank = [line for line in lines if line.strip()]
     complexity = estimate_complexity(code)
+    cyclomatic_complexity, complexity_risk = calculate_cyclomatic_complexity(code, language)
 
     func_names = re.findall(
         r"def\s+(\w+)\s*\(|function\s+(\w+)\s*\(|(\w+)\s*=\s*\(.*\)\s*=>|\bfn\s+(\w+)\s*\(",
@@ -650,6 +686,8 @@ def run_explanation(code: str, language: str) -> dict:
         "line_count": len(lines),
         "function_count": len(funcs),
         "class_count": len(class_names),
+        "cyclomatic_complexity": cyclomatic_complexity,
+        "complexity_risk": complexity_risk,
     }
 
 

--- a/backend/tests/test_endpoints.py
+++ b/backend/tests/test_endpoints.py
@@ -213,6 +213,124 @@ def test_explanation_cpp():
     d = r.json()
     assert d["language"] == "C++"
 
+# ── Cyclomatic Complexity ─────────────────────────────────────────────────────
+def test_explanation_cyclomatic_fields_present():
+    r = client.post("/explanation/", json={"code": PYTHON_CLEAN, "language": "python"})
+    assert r.status_code == 200
+    d = r.json()
+    assert "cyclomatic_complexity" in d
+    assert "complexity_risk" in d
+    assert isinstance(d["cyclomatic_complexity"], int)
+    assert d["complexity_risk"] in ("Simple", "Moderate", "High", "Very High")
+
+
+def test_explanation_cyclomatic_simple():
+    code = "def add(a: int, b: int) -> int:\n    return a + b\n"
+    r = client.post("/explanation/", json={"code": code, "language": "python"})
+    assert r.status_code == 200
+    d = r.json()
+    assert d["cyclomatic_complexity"] >= 1
+    assert d["complexity_risk"] == "Simple"
+
+
+def test_explanation_cyclomatic_moderate():
+    code = """
+def validate(x, y, z):
+    if x < 0:
+        return False
+    elif y < 0:
+        return False
+    elif z < 0:
+        return False
+    elif x > 100 or y > 100:
+        return False
+    else:
+        return True
+"""
+    r = client.post("/explanation/", json={"code": code, "language": "python"})
+    assert r.status_code == 200
+    d = r.json()
+    assert 6 <= d["cyclomatic_complexity"] <= 10
+    assert d["complexity_risk"] == "Moderate"
+
+
+def test_explanation_cyclomatic_high():
+    code = """
+def process(items, config, flags):
+    if not items:
+        return []
+    elif not config:
+        return None
+    results = []
+    for item in items:
+        if item and flags.get("enabled"):
+            if item > 0 and item < 100:
+                results.append(item)
+            elif item >= 100 or item == -1:
+                results.append(item * 2)
+            else:
+                results.append(0)
+        elif item is None:
+            pass
+        else:
+            while item > 0:
+                item -= 1
+            results.append(item)
+    return results
+"""
+    r = client.post("/explanation/", json={"code": code, "language": "python"})
+    assert r.status_code == 200
+    d = r.json()
+    assert 11 <= d["cyclomatic_complexity"] <= 20
+    assert d["complexity_risk"] == "High"
+
+
+def test_explanation_cyclomatic_very_high():
+    code = """
+def route(req, user, db, cache, logger):
+    if not req:
+        return None
+    elif not user:
+        return None
+    elif not db:
+        return None
+    if user.role == "admin" and user.active and not user.banned:
+        if req.method == "GET" or req.method == "HEAD":
+            if cache.has(req.path) and not req.bypass_cache:
+                return cache.get(req.path)
+            else:
+                result = db.query(req.path)
+                if result and not result.expired:
+                    cache.set(req.path, result)
+                    return result
+                elif result and result.expired:
+                    if cache.has_stale(req.path) or logger.warn("stale"):
+                        return cache.get_stale(req.path)
+                    else:
+                        return None
+                else:
+                    return None
+        elif req.method == "POST":
+            if user.can_write and req.body:
+                for item in req.body:
+                    if item.valid and item.size < 1024:
+                        db.insert(item)
+                    else:
+                        logger.warn("invalid item")
+            else:
+                return None
+        else:
+            return None
+    else:
+        return None
+"""
+    r = client.post("/explanation/", json={"code": code, "language": "python"})
+    assert r.status_code == 200
+    d = r.json()
+    assert d["cyclomatic_complexity"] >= 21
+    assert d["complexity_risk"] == "Very High"
+
+
 # ── Debugging ─────────────────────────────────────────────────────────────────
 def test_debug_detects_zero_division():
     r = client.post("/debugging/", json={"code": "result = a / b", "language": "python"})

--- a/frontend/index.html
+++ b/frontend/index.html
@@ -1118,6 +1118,30 @@
       border: 1px solid var(--red);
     }
 
+    .risk-Simple {
+      background: rgba(34, 197, 94, 0.12);
+      color: var(--green);
+      border: 1px solid var(--green);
+    }
+
+    .risk-Moderate {
+      background: rgba(234, 179, 8, 0.12);
+      color: var(--yellow);
+      border: 1px solid var(--yellow);
+    }
+
+    .risk-High {
+      background: rgba(249, 115, 22, 0.12);
+      color: var(--orange);
+      border: 1px solid var(--orange);
+    }
+
+    .risk-Very-High {
+      background: rgba(239, 68, 68, 0.12);
+      color: var(--red);
+      border: 1px solid var(--red);
+    }
+
     .key-points {
       list-style: none
     }
@@ -2638,6 +2662,7 @@
       <div class="meta-chip"><svg width="12" height="12" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2"><path d="M14 2H6a2 2 0 0 0-2 2v16a2 2 0 0 0 2 2h12a2 2 0 0 0 2-2V8z"/><polyline points="14,2 14,8 20,8"/></svg> ${exp.line_count} lines</div>
       <div class="meta-chip"><svg width="12" height="12" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2"><polyline points="16,18 22,12 16,6"/><polyline points="8,6 2,12 8,18"/></svg> ${exp.function_count} fn${exp.function_count !== 1 ? 's' : ''}</div>
       ${exp.class_count > 0 ? '<div class="meta-chip"><svg width="12" height="12" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2"><rect x="3" y="3" width="18" height="18" rx="2"/><path d="M3 9h18"/></svg> ' + exp.class_count + ' class' + (exp.class_count !== 1 ? 'es' : '') + '</div>' : ''}
+      ${exp.cyclomatic_complexity != null ? `<div class="meta-chip risk-${(exp.complexity_risk || 'Simple').replace(/\s+/g, '-')}"><svg width="12" height="12" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2"><polyline points="22,12 18,12 15,21 9,3 6,12 2,12"/></svg> M=${exp.cyclomatic_complexity} &middot; ${exp.complexity_risk}</div>` : ''}
     </div>
     <ul class="key-points">
       ${exp.key_points.map((p, i) => `<li style="animation-delay:${i * 0.05}s">${renderMarkdown(p)}</li>`).join('')}


### PR DESCRIPTION
  ## Summary

  Closes #137

  - Added `calculate_cyclomatic_complexity(code, language)` to `backend/app/services/code_assistant.py` using a simplified McCabe formula: **M = 
  decision points + 1**, counting `if`, `elif`, `else`, `for`, `while`, `and`, `or`, `case`, `catch`, `except`, and ternary `?`
  - Extended `ExplanationResponse` in `backend/app/schemas.py` with `cyclomatic_complexity: int` and `complexity_risk: str`
  - Displayed as a colour-coded metric chip in the Explain tab (`M=7 · Moderate`) — green → yellow → orange → red as complexity rises
  - Added a null-safe guard in the frontend so old clients degrade gracefully without crashing

  ## Risk thresholds

  | Score | Label     |
  |-------|-----------|
  | 1–5   | Simple    |
  | 6–10  | Moderate  |
  | 11–20 | High      |
  | 21+   | Very High |

Screenshots for verification of the changes: 
<img width="2144" height="1492" alt="Screenshot 2026-05-20 at 8 47 54 PM" src="https://github.com/user-attachments/assets/f9868022-d5ca-4428-ac02-db4c74b42864" />
<img width="2138" height="1542" alt="Screenshot 2026-05-20 at 8 49 53 PM" src="https://github.com/user-attachments/assets/ab655f79-fbcc-4e15-a768-c52f3a4ac260" />
<img width="3024" height="1718" alt="Screenshot 2026-05-20 at 8 55 22 PM" src="https://github.com/user-attachments/assets/b6f86dea-c4a2-433d-b81a-0439a3234d5b" />
