### PR TITLE
fix: Respect OS theme preference on first load

### DIFF
--- a/frontend/index.html
+++ b/frontend/index.html
@@ -1,5 +1,5 @@
 <!DOCTYPE html>
-<html lang="en" data-theme="dark">
+<html lang="en">
 
 <head>
   <meta charset="UTF-8" />
@@ -2540,9 +2540,16 @@ main
         btn.setAttribute('aria-pressed', theme === 'light' ? 'true' : 'false');
       }
 
-      const savedTheme = localStorage.getItem('qyx_theme') || 'dark';
-      document.documentElement.setAttribute('data-theme', savedTheme);
-      setThemeIcon(savedTheme);
+      const savedTheme = localStorage.getItem('qyx_theme');
+
+      const initialTheme = savedTheme
+       ? savedTheme
+       : window.matchMedia('(prefers-color-scheme: dark)').matches
+        ? 'dark'
+        : 'light';
+
+      document.documentElement.setAttribute('data-theme', initialTheme);
+      setThemeIcon(initialTheme);
 
       document.getElementById('themeToggle').addEventListener('click', () => {
         const cur = document.documentElement.getAttribute('data-theme');


### PR DESCRIPTION
## Summary

Updated the frontend theme initialization logic to respect the user's OS-level `prefers-color-scheme` setting on first load.

## Changes Made

* Use saved theme from `localStorage` if available
* Fallback to `prefers-color-scheme` when no saved theme exists
* Preserve existing manual theme toggle behavior

## Files Changed

* `frontend/index.html`

 **closes #178**

Attached screenshots showing the app correctly respecting OS-level theme preference on first load.

* Light OS preference → app loads light theme
<img width="1900" height="991" alt="LIGHTMODE" src="https://github.com/user-attachments/assets/4275b9de-0395-4316-af38-1369e8f2a6f7" />

* Dark OS preference → app loads dark theme
<img width="1906" height="993" alt="DARK MODE" src="https://github.com/user-attachments/assets/ea50f2a9-69e5-457f-a4c5-c4030bf2e2e3" />



