### PR TITLE
feat: add OpenAPI examples for /explanation/, /debugging/, /suggestio…

### DIFF
--- a/backend/app/routers/analyze.py
+++ b/backend/app/routers/analyze.py
@@ -1,10 +1,85 @@
 """Full analysis router — POST /analyze/"""
-from fastapi import APIRouter
+from fastapi import APIRouter, Body
 from ..schemas import CodeRequest, AnalyzeResponse
 from ..services.code_assistant import full_analysis
 
 router = APIRouter()
 
-@router.post("/", response_model=AnalyzeResponse, summary="Run full analysis (explain + debug + suggest)")
-async def analyze(req: CodeRequest):
+_ANALYZE_EXAMPLES = {
+    "python_full": {
+        "summary": "Python — full analysis",
+        "description": "A Python snippet with a mix of issues and improvement opportunities.",
+        "value": {
+            "code": (
+                "import os\n\n"
+                "def read_file(path):\n"
+                "    f = open(path)          # not using context manager\n"
+                "    data = f.read()\n"
+                "    f.close()\n"
+                "    return data\n\n"
+                "def main():\n"
+                "    content = read_file('config.txt')\n"
+                "    password = 'secret123'  # hardcoded credential\n"
+                "    print(content)\n\n"
+                "main()"
+            ),
+            "language": "python",
+        },
+    },
+    "javascript_full": {
+        "summary": "JavaScript — full analysis",
+        "description": "JavaScript with var usage, loose equality, and missing error handling.",
+        "value": {
+            "code": (
+                "var API_KEY = 'abc123';  // hardcoded secret\n\n"
+                "function fetchUser(id) {\n"
+                "  var url = 'https://api.example.com/users/' + id;\n"
+                "  fetch(url)\n"
+                "    .then(function(res) {\n"
+                "      return res.json();\n"
+                "    })\n"
+                "    .then(function(data) {\n"
+                "      if (data.id == id) {  // loose equality\n"
+                "        console.log(data);\n"
+                "      }\n"
+                "    });\n"
+                "  // no .catch() — unhandled rejection\n"
+                "}"
+            ),
+            "language": "javascript",
+        },
+    },
+    "python_clean": {
+        "summary": "Python — well-written code",
+        "description": "Clean Python to verify the API returns a high score with minimal issues.",
+        "value": {
+            "code": (
+                "from pathlib import Path\n\n\n"
+                "def read_config(path: Path) -> str:\n"
+                "    \"\"\"Read and return the contents of a config file.\"\"\"\n"
+                "    with path.open(encoding='utf-8') as fh:\n"
+                "        return fh.read()\n\n\n"
+                "def main() -> None:\n"
+                "    config_path = Path('config.txt')\n"
+                "    if not config_path.exists():\n"
+                "        raise FileNotFoundError(f'{config_path} not found')\n"
+                "    content = read_config(config_path)\n"
+                "    print(content)\n\n\n"
+                "if __name__ == '__main__':\n"
+                "    main()"
+            ),
+            "language": "python",
+        },
+    },
+}
+
+
+@router.post(
+    "/",
+    response_model=AnalyzeResponse,
+    summary="Run full analysis (explain + debug + suggest)",
+)
+async def analyze(
+    req: CodeRequest = Body(openapi_examples=_ANALYZE_EXAMPLES),
+):
     return full_analysis(req.code, req.language)

--- a/backend/app/routers/debugging.py
+++ b/backend/app/routers/debugging.py
@@ -1,12 +1,71 @@
 """Debugging router — POST /debugging/"""
-from fastapi import APIRouter
+from fastapi import APIRouter, Body
 from ..schemas import CodeRequest, DebuggingResponse
 from ..services.code_assistant import detect_language, run_bug_detection
 
 router = APIRouter()
 
-@router.post("/", response_model=DebuggingResponse, summary="Detect bugs and issues")
-async def debug(req: CodeRequest):
+_DEBUGGING_EXAMPLES = {
+    "python_bugs": {
+        "summary": "Python — multiple bugs",
+        "description": "Python snippet with a division-by-zero risk, unused variable, and bare except.",
+        "value": {
+            "code": (
+                "def divide(a, b):\n"
+                "    result = a / b   # ZeroDivisionError if b == 0\n"
+                "    unused = 42      # unused variable\n"
+                "    return result\n\n"
+                "try:\n"
+                "    print(divide(10, 0))\n"
+                "except:\n"
+                "    pass             # bare except swallows all errors"
+            ),
+            "language": "python",
+        },
+    },
+    "javascript_bugs": {
+        "summary": "JavaScript — common pitfalls",
+        "description": "JavaScript code with == instead of ===, var hoisting, and missing semicolons.",
+        "value": {
+            "code": (
+                "var x = 5\n"
+                "if (x == '5') {\n"
+                "    console.log('loose equality')\n"
+                "}\n\n"
+                "function greet(name) {\n"
+                "    console.log('Hello, ' + name)\n"
+                "}\n\n"
+                "greet(undefined)"
+            ),
+            "language": "javascript",
+        },
+    },
+    "clean_code": {
+        "summary": "Python — clean code (no issues)",
+        "description": "Well-written Python that should return zero issues.",
+        "value": {
+            "code": (
+                "def greet(name: str) -> str:\n"
+                "    \"\"\"Return a greeting string.\"\"\"\n"
+                "    if not name:\n"
+                "        raise ValueError('name must not be empty')\n"
+                "    return f'Hello, {name}!'\n\n"
+                "print(greet('World'))"
+            ),
+            "language": "python",
+        },
+    },
+}
+
+
+@router.post(
+    "/",
+    response_model=DebuggingResponse,
+    summary="Detect bugs and issues",
+)
+async def debug(
+    req: CodeRequest = Body(openapi_examples=_DEBUGGING_EXAMPLES),
+):
     lang = detect_language(req.code, req.language)
     issues = run_bug_detection(req.code, lang)
     errors   = sum(1 for i in issues if i["severity"] == "error")

--- a/backend/app/routers/explanation.py
+++ b/backend/app/routers/explanation.py
@@ -1,11 +1,70 @@
 """Explanation router — POST /explanation/"""
-from fastapi import APIRouter
+from fastapi import APIRouter, Body
 from ..schemas import CodeRequest, ExplanationResponse
 from ..services.code_assistant import detect_language, run_explanation
 
 router = APIRouter()
 
-@router.post("/", response_model=ExplanationResponse, summary="Explain code in plain English")
-async def explain(req: CodeRequest):
+_EXPLANATION_EXAMPLES = {
+    "python_function": {
+        "summary": "Python — simple function",
+        "description": "A basic Python function that adds two numbers.",
+        "value": {
+            "code": (
+                "def add(a, b):\n"
+                "    \"\"\"Return the sum of a and b.\"\"\"\n"
+                "    return a + b\n\n"
+                "result = add(3, 7)\n"
+                "print(result)"
+            ),
+            "language": "python",
+        },
+    },
+    "javascript_class": {
+        "summary": "JavaScript — ES6 class",
+        "description": "A small ES6 class with a constructor and a method.",
+        "value": {
+            "code": (
+                "class Counter {\n"
+                "  constructor(start = 0) {\n"
+                "    this.count = start;\n"
+                "  }\n\n"
+                "  increment() {\n"
+                "    this.count += 1;\n"
+                "    return this.count;\n"
+                "  }\n"
+                "}\n\n"
+                "const c = new Counter();\n"
+                "console.log(c.increment());"
+            ),
+            "language": "javascript",
+        },
+    },
+    "auto_detect": {
+        "summary": "Auto-detect language",
+        "description": "Omit the language field and let the API detect it automatically.",
+        "value": {
+            "code": (
+                "fn fibonacci(n: u32) -> u32 {\n"
+                "    match n {\n"
+                "        0 => 0,\n"
+                "        1 => 1,\n"
+                "        _ => fibonacci(n - 1) + fibonacci(n - 2),\n"
+                "    }\n"
+                "}"
+            ),
+        },
+    },
+}
+
+
+@router.post(
+    "/",
+    response_model=ExplanationResponse,
+    summary="Explain code in plain English",
+)
+async def explain(
+    req: CodeRequest = Body(openapi_examples=_EXPLANATION_EXAMPLES),
+):
     lang = detect_language(req.code, req.language)
     return run_explanation(req.code, lang)

--- a/backend/app/routers/suggestions.py
+++ b/backend/app/routers/suggestions.py
@@ -1,11 +1,70 @@
 """Suggestions router — POST /suggestions/"""
-from fastapi import APIRouter
+from fastapi import APIRouter, Body
 from ..schemas import CodeRequest, SuggestionsResponse
 from ..services.code_assistant import detect_language, run_suggestions
 
 router = APIRouter()
 
-@router.post("/", response_model=SuggestionsResponse, summary="Get improvement suggestions")
-async def suggest(req: CodeRequest):
+_SUGGESTIONS_EXAMPLES = {
+    "python_unoptimized": {
+        "summary": "Python — unoptimized list building",
+        "description": "Python code that builds a list with a loop instead of a list comprehension.",
+        "value": {
+            "code": (
+                "def get_squares(n):\n"
+                "    squares = []\n"
+                "    for i in range(n):\n"
+                "        squares.append(i * i)\n"
+                "    return squares\n\n"
+                "print(get_squares(10))"
+            ),
+            "language": "python",
+        },
+    },
+    "javascript_callback_hell": {
+        "summary": "JavaScript — callback nesting",
+        "description": "Deeply nested callbacks that could be refactored to async/await.",
+        "value": {
+            "code": (
+                "function fetchData(id, callback) {\n"
+                "  getUser(id, function(user) {\n"
+                "    getPosts(user.id, function(posts) {\n"
+                "      getComments(posts[0].id, function(comments) {\n"
+                "        callback(comments);\n"
+                "      });\n"
+                "    });\n"
+                "  });\n"
+                "}"
+            ),
+            "language": "javascript",
+        },
+    },
+    "python_no_type_hints": {
+        "summary": "Python — missing type hints",
+        "description": "A Python module without type annotations or docstrings.",
+        "value": {
+            "code": (
+                "def process(data):\n"
+                "    result = {}\n"
+                "    for item in data:\n"
+                "        key = item[0]\n"
+                "        value = item[1]\n"
+                "        result[key] = value\n"
+                "    return result\n"
+            ),
+            "language": "python",
+        },
+    },
+}
+
+
+@router.post(
+    "/",
+    response_model=SuggestionsResponse,
+    summary="Get improvement suggestions",
+)
+async def suggest(
+    req: CodeRequest = Body(openapi_examples=_SUGGESTIONS_EXAMPLES),
+):
     lang = detect_language(req.code, req.language)
     return run_suggestions(req.code, lang)

--- a/backend/app/schemas.py
+++ b/backend/app/schemas.py
@@ -1,10 +1,19 @@
 """Pydantic request / response models for QyverixAI."""
 
 from __future__ import annotations
-from pydantic import BaseModel, field_validator
+from pydantic import BaseModel, ConfigDict, field_validator
 
 
 class CodeRequest(BaseModel):
+    model_config = ConfigDict(
+        json_schema_extra={
+            "example": {
+                "code": "def add(a, b):\n    return a + b\n\nresult = add(1, 2)\nprint(result)",
+                "language": "python",
+            }
+        }
+    )
+
     code: str
     language: str | None = None
 


### PR DESCRIPTION
## Summary

Closes #205

Populate OpenAPI examples for all four analysis endpoints so users can try sample payloads directly in the Swagger UI (`/docs`).

## Changes

- `backend/app/schemas.py` — Added `model_config` with `json_schema_extra` example on `CodeRequest`
- `backend/app/routers/explanation.py` — Added 3 named examples: Python function, JavaScript ES6 class, auto-detect language
- `backend/app/routers/debugging.py` — Added 3 named examples: Python bugs, JavaScript pitfalls, clean code
- `backend/app/routers/suggestions.py` — Added 3 named examples: unoptimized loop, callback hell, missing type hints
- `backend/app/routers/analyze.py` — Added 3 named examples: Python with issues, JavaScript with issues, clean Python

## How it works

Each endpoint now uses `Body(openapi_examples=...)` which renders a named dropdown in Swagger UI's "Try it out" panel. Users can pick a sample payload and test without typing anything.

## Testing

- Syntax verified with `python -m py_compile` on all changed files
- Compatible with FastAPI >= 0.115.0 and Pydantic v2
