### PR TITLE
Add Prism.js syntax highlighting to code editor

### DIFF
--- a/frontend/index.html
+++ b/frontend/index.html
@@ -9,6 +9,8 @@
   <link
     href="https://fonts.googleapis.com/css2?family=Syne:wght@400;600;700;800&family=JetBrains+Mono:wght@400;500;600&family=Inter:wght@400;500;600&display=swap"
     rel="stylesheet" />
+  <link rel="stylesheet"
+    href="https://cdnjs.cloudflare.com/ajax/libs/prism/1.29.0/themes/prism.min.css">
   <style>
     /* ═══════════════════════════════════════════════════════════════
    DESIGN TOKENS
@@ -1967,6 +1969,8 @@
           <div class="line-numbers" id="lineNumbers" aria-hidden="true">1</div>
           <textarea id="codeEditor" placeholder="# Paste your code here or click 'Try Sample Code' above…"
             spellcheck="false" autocorrect="off" autocapitalize="off" aria-label="Code Editor"></textarea>
+            <pre class="code-preview editor-preview"><code id="highlightedCode" 
+              class="language-python"></code></pre>
         </div>
 
         <div class="editor-footer">
@@ -3064,6 +3068,13 @@ int main() {
       const savedUrl = localStorage.getItem('qyx_apiUrl');
       if (savedUrl) apiUrlInput.value = savedUrl;
     </script>
+    <script
+     src="https://cdnjs.cloudflare.com/ajax/libs/prism/1.29.0/components/prism-core.min.js">
+    </script>
+    <script 
+     src="https://cdnjs.cloudflare.com/ajax/libs/prism/1.29.0/plugins/autoloader/prism-autoloader.min.js">
+    </script>
+
 </body>
 
 </html>

--- a/frontend/index.html
+++ b/frontend/index.html
@@ -611,9 +611,10 @@
 
     /* ── Code Editor ── */
     .editor-wrap {
-      position: relative;
-      display: flex
-    }
+  position: relative;
+  height: 500px;
+  overflow: hidden;
+}
 
     .line-numbers {
       padding: 16px 0 16px 12px;
@@ -629,20 +630,67 @@
     }
 
     #codeEditor {
-      width: 100%;
-      min-height: 300px;
-      max-height: 500px;
-      padding: 16px;
-      font-family: var(--font-mono);
-      font-size: 13px;
-      line-height: 1.7;
-      color: var(--text);
-      background: transparent;
-      border: none;
-      outline: none;
-      resize: vertical;
-      tab-size: 2;
-    }
+      position: absolute;
+
+      top: 0;
+      left: 44px;
+
+      width: calc(100% - 44px);
+     height: 100%;
+
+  margin: 0;
+  padding: 16px;
+
+  font-family: var(--font-mono);
+  font-size: 13px;
+  line-height: 1.7;
+
+  border: none;
+  outline: none;
+
+  tab-size: 2;
+
+  z-index: 2;
+
+  background: transparent;
+
+  color: transparent;
+
+  caret-color: var(--text);
+
+  resize: none;
+
+  overflow: auto;
+}
+.editor-preview {
+  position: absolute;
+
+  top: 0;
+  left: 44px;
+
+  width: calc(100% - 44px);
+  height: 100%;
+
+  margin: 0;
+  padding: 16px;
+
+  overflow: auto;
+
+  pointer-events: none;
+
+  font-family: var(--font-mono);
+  font-size: 13px;
+  line-height: 1.7;
+
+  white-space: pre;
+
+  z-index: 1;
+}
+
+#highlightedCode {
+  display: block;
+  min-height: 100%;
+}
 
     .editor-footer {
       display: flex;
@@ -2214,6 +2262,8 @@
          DOM REFS
       ═══════════════════════════════════════════════════════════════ */
       const editor = document.getElementById('codeEditor');
+      const highlightedCode = document.getElementById('highlightedCode');
+      const preview = document.querySelector('.editor-preview'); 
       const lineNumbers = document.getElementById('lineNumbers');
       const charCount = document.getElementById('charCount');
       const analyzeBtn = document.getElementById('analyzeBtn');
@@ -2260,23 +2310,64 @@
          EDITOR
       ═══════════════════════════════════════════════════════════════ */
       function updateEditor() {
-        const val = editor.value;
-        const lines = val ? val.split('\n').length : 0;
-        const chars = val.length;
-        const nonBlank = val ? val.split('\n').filter(l => l.trim()).length : 0;
-        charCount.textContent = val
-          ? chars.toLocaleString() + ' chars · ' + lines + ' lines · ' + nonBlank + ' non-blank'
-          : 'Paste or type code to begin';
-        const lineCount = Math.max(lines, 1);
-        lineNumbers.innerHTML = val
-          ? Array.from({ length: lineCount }, (_, i) => i + 1).join('<br>')
-          : '1';
-      }
+
+  const val = editor.value;
+
+  const lines = val ? val.split('\n').length : 0;
+
+  const chars = val.length;
+
+  const nonBlank =
+    val
+      ? val.split('\n').filter(l => l.trim()).length
+      : 0;
+
+  charCount.textContent = val
+    ? chars.toLocaleString() +
+      ' chars · ' +
+      lines +
+      ' lines · ' +
+      nonBlank +
+      ' non-blank'
+    : 'Paste or type code to begin';
+
+  const lineCount = Math.max(lines, 1);
+
+  lineNumbers.innerHTML =
+    Array.from(
+      { length: lineCount },
+      (_, i) => i + 1
+    ).join('<br>');
+
+  // ===== SYNTAX HIGHLIGHTING =====
+
+  let safeCode = val;
+
+  // Prevent last-line Prism bug
+  if (safeCode.endsWith('\n')) {
+    safeCode += ' ';
+  }
+
+  highlightedCode.textContent = safeCode;
+
+  highlightedCode.className =
+    `language-${selectedLang}`;
+
+  Prism.highlightElement(highlightedCode);
+}
 
       editor.addEventListener('input', updateEditor);
       editor.addEventListener('scroll', () => {
-        lineNumbers.scrollTop = editor.scrollTop;
-      });
+
+  lineNumbers.scrollTop =
+    editor.scrollTop;
+
+  preview.scrollTop =
+    editor.scrollTop;
+
+  preview.scrollLeft =
+    editor.scrollLeft;
+});
 
       // Tab key support
       editor.addEventListener('keydown', e => {
@@ -3068,12 +3159,19 @@ int main() {
       const savedUrl = localStorage.getItem('qyx_apiUrl');
       if (savedUrl) apiUrlInput.value = savedUrl;
     </script>
-    <script
-     src="https://cdnjs.cloudflare.com/ajax/libs/prism/1.29.0/components/prism-core.min.js">
-    </script>
-    <script 
-     src="https://cdnjs.cloudflare.com/ajax/libs/prism/1.29.0/plugins/autoloader/prism-autoloader.min.js">
-    </script>
+    <script src="https://cdnjs.cloudflare.com/ajax/libs/prism/1.29.0/prism.min.js"></script>
+
+<script src="https://cdnjs.cloudflare.com/ajax/libs/prism/1.29.0/components/prism-python.min.js"></script>
+
+<script src="https://cdnjs.cloudflare.com/ajax/libs/prism/1.29.0/components/prism-javascript.min.js"></script>
+
+<script src="https://cdnjs.cloudflare.com/ajax/libs/prism/1.29.0/components/prism-typescript.min.js"></script>
+
+<script src="https://cdnjs.cloudflare.com/ajax/libs/prism/1.29.0/components/prism-java.min.js"></script>
+
+<script src="https://cdnjs.cloudflare.com/ajax/libs/prism/1.29.0/components/prism-c.min.js"></script>
+
+<script src="https://cdnjs.cloudflare.com/ajax/libs/prism/1.29.0/components/prism-cpp.min.js"></script>
 
 </body>
 

--- a/frontend/script.js
+++ b/frontend/script.js
@@ -6,6 +6,7 @@ let lastResult = '';
 
 // ── DOM refs ──
 const codeInput = document.getElementById('codeInput');
+const highlightedCode = document.getElementById('highlightedCode');
 const runBtn = document.getElementById('runBtn');
 const runLabel = document.getElementById('runLabel');
 const outputBox = document.getElementById('outputBox');
@@ -60,6 +61,7 @@ document.querySelectorAll('.tab').forEach(tab => {
 codeInput.addEventListener('input', () => {
   const lines = codeInput.value.split('\n').length;
   lineCount.textContent = `${lines} line${lines !== 1 ? 's' : ''}`;
+  updateHighlightedCode();
 });
 
 // ── Keyboard shortcut ──
@@ -510,6 +512,17 @@ function renderFavorites() {
 function escHtml(s) {
   return s.replace(/&/g,'&amp;').replace(/</g,'&lt;').replace(/>/g,'&gt;');
 }
+function updateHighlightedCode() {
+  if (!highlightedCode) return;
+  highlightedCode.className = `language-${codeInput.dataset.lang || 'python'}`;
+  highlightedCode.textContent = codeInput.value || '// Start typing code...';
+  if (window.Prism) Prism.highlightElement(highlightedCode);
+}
+
+function setEditorLanguage(lang) {
+  codeInput.dataset.lang = lang;
+  updateHighlightedCode();
+}
 
 // ── Toast ──
 function showToast(msg) {
@@ -528,3 +541,4 @@ function showToast(msg) {
 // ── Init ──
 renderHistory();
 renderFavorites();
+updateHighlightedCode();

--- a/frontend/style.css
+++ b/frontend/style.css
@@ -600,3 +600,20 @@ body {
   .features, .app-section { padding: 2rem 1rem; }
   .section-label { padding: 0 1rem; }
 }
+.editor-preview {
+  margin: 0 16px 16px;
+  min-height: 220px;
+  max-height: 320px;
+  overflow: auto;
+  background: var(--bg-2);
+  border: 1px solid var(--border);
+  border-radius: var(--radius);
+  padding: 16px;
+}
+
+.editor-preview code {
+  font-family: var(--font-mono);
+  font-size: 13px;
+  line-height: 1.7;
+  white-space: pre;
+}


### PR DESCRIPTION
## What
Adds Prism.js syntax highlighting to the code editor in frontend/index.html.

## Why
Makes pasted code easier to read by highlighting syntax in real time.

## Changes
- Added Prism CSS and JS to the frontend.
- Added a highlighted preview block under the code editor.
- Updated JS to mirror editor content into the Prism preview.
- Added CSS styling for the preview block.

## Testing
- Verified the frontend changes locally in the browser