### PR TITLE
feat: add .env.example and document local dev setup in README

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -1,14 +1,37 @@
-# QyverixAI — Environment Variables
-# Copy this file to .env and fill in values as needed.
-# NEVER commit your actual .env file to git.
+# AI Provider
+AI_PROVIDER=rule-based
+AI_MODEL=local-rule-engine-v1
 
-# ── Rate Limiting ─────────────────────────────────────────────
-RATE_LIMIT_PER_MINUTE=30
+# Limits
+MAX_CODE_CHARS=20000
+MAX_REQUEST_BYTES=1048576
+RATE_LIMIT_REQUESTS=120
+RATE_LIMIT_WINDOW_SECONDS=60
 
-# ── Optional LLM Integration ──────────────────────────────────
-# Set LLM_ENABLED=true to enable AI-powered analysis.
-# Works with OpenAI, Groq, Together AI, Ollama, or any OpenAI-compatible endpoint.
-LLM_ENABLED=false
+# Cache
+CACHE_ENABLED=True
+CACHE_TTL_SECONDS=300
+CACHE_MAX_ENTRIES=100
+REDIS_URL=
+
+# Sentry (optional)
+SENTRY_DSN=
+SENTRY_TRACES_SAMPLE_RATE=0.0
+
+# Docs & Info
+ENABLE_DOCS=False
+PUBLIC_ROOT_INFO=False
+
+# Database
+DATABASE_URL=sqlite:///./assistant.db
+
+# JWT
+JWT_SECRET=change-this-in-production-min-32-bytes
+JWT_ALGORITHM=HS256
+ACCESS_TOKEN_MINUTES=720
+
+# LLM (optional)
+LLM_ENABLED=False
 LLM_API_KEY=
 LLM_BASE_URL=https://api.openai.com/v1
 LLM_MODEL=gpt-4o-mini

--- a/README.md
+++ b/README.md
@@ -96,7 +96,14 @@ git clone https://github.com/imDarshanGK/AI-dev-assistant.git
 cd AI-dev-assistant
 ```
 
-### 2 - Run the backend
+### 2 - Configure
+
+```bash
+cp .env.example .env
+# Edit .env to set your JWT_SECRET and any LLM_API_KEY if needed
+```
+
+### 3 - Run the backend
 
 ```bash
 cd backend
@@ -110,7 +117,7 @@ uvicorn app.main:app --reload
 | Interactive docs | http://localhost:8000/docs |
 | Health check | http://localhost:8000/health |
 
-### 3 - Open the frontend
+### 4 - Open the frontend
 
 ```bash
 # No build step required - open directly in your browser


### PR DESCRIPTION
Fixes #206. Adds .env.example with all configurable environment variables from the Settings class, and adds a copy-env step to the Quick Start guide.