### PR TITLE
feat: add endpoints and UI to download history and favourites as JSON or CSV

### DIFF
--- a/backend/app/main.py
+++ b/backend/app/main.py
@@ -13,7 +13,7 @@ import os
 from collections import defaultdict
 from contextlib import asynccontextmanager
 
-from .routers import explanation, debugging, suggestions, analyze, subscribe
+from .routers import explanation, debugging, suggestions, analyze, subscribe, export
 from .services.scheduler import start_scheduler, stop_scheduler
 from .schemas import HealthResponse
 
@@ -122,6 +122,7 @@ app.include_router(debugging.router,   prefix="/debugging",   tags=["Debugging"]
 app.include_router(suggestions.router, prefix="/suggestions", tags=["Suggestions"])
 app.include_router(analyze.router,     prefix="/analyze",     tags=["Full Analysis"])
 app.include_router(subscribe.router,   prefix="/subscribe",   tags=["Subscription"])
+app.include_router(export.router,      prefix="/export",      tags=["Export"])
 
 
 # ── Core Endpoints ────────────────────────────────────────────────────────────

--- a/backend/app/routers/export.py
+++ b/backend/app/routers/export.py
@@ -1,0 +1,83 @@
+from __future__ import annotations
+
+import csv
+import json
+from datetime import datetime
+from io import StringIO
+
+from fastapi import APIRouter, HTTPException, Response
+from ..schemas import ExportRequest
+
+router = APIRouter()
+
+
+def _csv_value(value: object) -> str:
+    if value is None:
+        return ""
+    if isinstance(value, (dict, list)):
+        return json.dumps(value, ensure_ascii=False)
+    return str(value)
+
+
+def _build_csv(data: list[dict]) -> str:
+    if not data:
+        return ""
+
+    columns = sorted({key for item in data if isinstance(item, dict) for key in item.keys()})
+    output = StringIO()
+    writer = csv.writer(output, quoting=csv.QUOTE_MINIMAL)
+    writer.writerow(columns)
+    for item in data:
+        if not isinstance(item, dict):
+            raise HTTPException(status_code=400, detail="CSV export requires an array of objects")
+        writer.writerow([_csv_value(item.get(col)) for col in columns])
+    return output.getvalue()
+
+
+def _build_filename(kind: str, fmt: str) -> str:
+    now = datetime.utcnow().strftime("%Y%m%dT%H%M%SZ")
+    return f"qyverixai-{kind}-{now}.{fmt}"
+
+
+@router.post("/history/{fmt}")
+def export_history(fmt: str, payload: ExportRequest) -> Response:
+    if fmt not in ("json", "csv"):
+        raise HTTPException(status_code=400, detail="Unsupported export format")
+
+    filename = _build_filename("history", fmt)
+    if fmt == "json":
+        body = json.dumps(payload.data, indent=2, ensure_ascii=False)
+        return Response(
+            body,
+            media_type="application/json",
+            headers={"Content-Disposition": f'attachment; filename="{filename}"'},
+        )
+
+    body = _build_csv(payload.data)
+    return Response(
+        body,
+        media_type="text/csv",
+        headers={"Content-Disposition": f'attachment; filename="{filename}"'},
+    )
+
+
+@router.post("/favorites/{fmt}")
+def export_favorites(fmt: str, payload: ExportRequest) -> Response:
+    if fmt not in ("json", "csv"):
+        raise HTTPException(status_code=400, detail="Unsupported export format")
+
+    filename = _build_filename("favorites", fmt)
+    if fmt == "json":
+        body = json.dumps(payload.data, indent=2, ensure_ascii=False)
+        return Response(
+            body,
+            media_type="application/json",
+            headers={"Content-Disposition": f'attachment; filename="{filename}"'},
+        )
+
+    body = _build_csv(payload.data)
+    return Response(
+        body,
+        media_type="text/csv",
+        headers={"Content-Disposition": f'attachment; filename="{filename}"'},
+    )

--- a/backend/app/schemas.py
+++ b/backend/app/schemas.py
@@ -105,6 +105,11 @@ class UnsubscribeRequest(BaseModel):
     token: str
 
 
+# ── Export ────────────────────────────────────────────────────────────────────
+class ExportRequest(BaseModel):
+    data: list[dict] | list[str] | list[int] | list[float] | list[bool] = []
+
+
 # ── Health ────────────────────────────────────────────────────────────────────
 class HealthResponse(BaseModel):
     status: str

--- a/frontend/index.html
+++ b/frontend/index.html
@@ -1594,6 +1594,29 @@
       color: var(--red)
     }
 
+    .btn-export {
+      padding: 8px 16px;
+      border-radius: var(--r2);
+      background: rgba(91, 156, 246, 0.12);
+      border: 1px solid transparent;
+      color: var(--accent);
+      font-size: 0.82rem;
+      font-weight: 700;
+      cursor: pointer;
+      transition: all var(--transition);
+      white-space: nowrap;
+    }
+
+    .btn-export:hover {
+      background: rgba(91, 156, 246, 0.18);
+      border-color: rgba(91, 156, 246, 0.22);
+      transform: translateY(-1px);
+    }
+
+    .btn-export:active {
+      transform: translateY(0);
+    }
+
     .list-empty {
       display: flex;
       align-items: center;
@@ -2162,7 +2185,11 @@
       <div class="panel">
         <div class="panel-header">
           <div class="panel-title">Query History</div>
-          <button class="btn-clear" id="clearHistoryBtn" aria-label="Clear query history">Clear</button>
+          <div class="panel-actions">
+            <button class="btn-export" id="exportHistoryJsonBtn" aria-label="Export history as JSON">JSON</button>
+            <button class="btn-export" id="exportHistoryCsvBtn" aria-label="Export history as CSV">CSV</button>
+            <button class="btn-clear" id="clearHistoryBtn" aria-label="Clear query history">Clear</button>
+          </div>
         </div>
         <div class="history-list" id="historyList" aria-live="polite">
           <div class="list-empty">No history yet. Run your first analysis.</div>
@@ -2171,7 +2198,11 @@
       <div class="panel">
         <div class="panel-header">
           <div class="panel-title">Saved Favorites</div>
-          <button class="btn-clear" id="clearFavsBtn" aria-label="Clear saved favorites">Clear</button>
+          <div class="panel-actions">
+            <button class="btn-export" id="exportFavsJsonBtn" aria-label="Export Favorites as JSON">JSON</button>
+            <button class="btn-export" id="exportFavsCsvBtn" aria-label="Export Favorites as CSV">CSV</button>
+            <button class="btn-clear" id="clearFavsBtn" aria-label="Clear saved favorites">Clear</button>
+          </div>
         </div>
         <div class="fav-list" id="favList" aria-live="polite">
           <div class="list-empty">No favorites saved yet.</div>
@@ -3137,6 +3168,106 @@ document.getElementById('clearFavsBtn').addEventListener('click', () => {
         renderResults(entry.result, entry.code);
         document.getElementById('workspace').scrollIntoView({ behavior: 'smooth' });
       }
+
+
+      /* ═══════════════════════════════════════════════════════════════
+         EXPORT AS CSV / JSON
+      ═══════════════════════════════════════════════════════════════ */
+
+      document.getElementById('exportHistoryJsonBtn').addEventListener('click', () => exportCollection('history', 'json'));
+      document.getElementById('exportHistoryCsvBtn').addEventListener('click', () => exportCollection('history', 'csv'));
+      document.getElementById('exportFavsJsonBtn').addEventListener('click', () => exportCollection('favorites', 'json'));
+      document.getElementById('exportFavsCsvBtn').addEventListener('click', () => exportCollection('favorites', 'csv'));
+
+      function exportCollection(kind, format) {
+        const items = kind === 'history' ? history : favorites;
+
+        if (!items.length) {
+          toast(`No ${kind} available to export.`, 'info');
+          return;
+        }
+      
+        const filename = `qyverixai-${kind}-${format}-${new Date().toISOString().slice(0, 10)}.${format}`;
+        const base = apiUrlInput.value.replace(/\/$/, '');
+        const endpoint = `${base}/export/${kind}/${format}`;
+      
+        fetch(endpoint, {
+          method: 'POST',
+          headers: { 'Content-Type': 'application/json' },
+          body: JSON.stringify({ data: items }),
+        })
+          .then(async (resp) => {
+            if (!resp.ok) {
+              throw new Error(`Server returned ${resp.status}`);
+            }
+
+            const blob = await resp.blob();
+            const a = document.createElement('a');
+
+            a.href = URL.createObjectURL(blob);
+            a.download = filename;
+            document.body.appendChild(a);
+            a.click();
+
+            document.body.removeChild(a);
+            URL.revokeObjectURL(a.href);
+
+            toast(`Exported ${kind} as ${format.toUpperCase()}.`, 'success');
+          })
+          .catch(() => {
+            toast('Export API unavailable, downloading locally.', 'info');
+            downloadLocalExport(kind, format, items, filename);
+          });
+      }
+      
+      function downloadLocalExport(kind, format, items, filename) {
+        let content;
+        let mime;
+      
+        if (format === 'json') {
+          content = JSON.stringify(items, null, 2);
+          mime = 'application/json';
+        } else {
+          const columns = Array.from(
+            items.reduce((keys, item) => {
+              if (item && typeof item === 'object') {
+                Object.keys(item).forEach((key) => keys.add(key));
+              }
+
+              return keys;
+            }, new Set())
+          );
+          const rows = [columns.join(',')];
+
+          items.forEach((item) => {
+            const values = columns.map((col) => {
+              let value = item[col];
+
+              if (value === undefined || value === null) return '';
+              if (typeof value === 'object') value = JSON.stringify(value);
+
+              return `"${String(value).replace(/"/g, '""')}"`;
+            });
+
+            rows.push(values.join(','));
+          });
+
+          content = rows.join('\r\n');
+          mime = 'text/csv';
+        }
+      
+        const blob = new Blob([content], { type: `${mime};charset=utf-8` });
+        const a = document.createElement('a');
+
+        a.href = URL.createObjectURL(blob);
+        a.download = filename;
+        document.body.appendChild(a);
+        a.click();
+        document.body.removeChild(a);
+
+        URL.revokeObjectURL(a.href);
+      }
+
       /* ═══════════════════════════════════════════════════════════════
          DOWNLOAD
       ═══════════════════════════════════════════════════════════════ */


### PR DESCRIPTION
## Description
Implements a feature allowing users to download their analysis history in either JSON or CSV format.

## Related Issue
<!-- Required — link the issue this PR fixes -->
Fixes #220 

**Changes made:**
- Added UI download buttons to the analysis history section.
- Implemented backend formatting utility scripts to generate structural JSON strings and clean comma-separated CSV rows.
- Created virtual blob downloading triggers to securely deliver the downloaded history files directly to the user's browser.

## Type of change
- [ ] Bug fix
- [x] New feature / enhancement
- [ ] Documentation update
- [ ] Test addition
- [ ] Refactor

## Checklist
<!-- All boxes must be checked before requesting review -->
- [x] I have read [CONTRIBUTING.md](../CONTRIBUTING.md)
- [x] My branch is up to date with `main`
- [x] I have run `pytest -v` and all tests pass
- [x] I have not introduced duplicate issues or features
- [x] My PR title follows the format: `feat/fix/docs/test: short description`
- [x] I have added tests for new features (Level 2 and 3 issues)
- [x] No hardcoded secrets or API keys in my code
- [x] This PR is linked to a GSSoC 2026 issue

## Screenshots (if frontend change)
<img width="1920" height="983" alt="Screenshot 2026-05-22 154138" src="https://github.com/user-attachments/assets/bf30e9d3-b7ce-4db8-bc4c-8ac9990451ab" />