### PR TITLE
fix: respect system theme preference on first load

### DIFF
--- a/frontend/index.html
+++ b/frontend/index.html
@@ -2540,7 +2540,8 @@ main
         btn.setAttribute('aria-pressed', theme === 'light' ? 'true' : 'false');
       }
 
-      const savedTheme = localStorage.getItem('qyx_theme') || 'dark';
+      const systemDark = window.matchMedia('(prefers-color-scheme: dark)').matches;
+      const savedTheme = localStorage.getItem('qyx_theme') || (systemDark ? 'dark' : 'light');
       document.documentElement.setAttribute('data-theme', savedTheme);
       setThemeIcon(savedTheme);
 


### PR DESCRIPTION
## Description
Updated the theme initialization logic in `frontend/index.html` to respect the user's OS/browser dark mode preference on first visit.

The existing `localStorage` behavior is preserved, so manually selected themes still persist for returning users.

## Related Issue
Fixes #121

## Type of change
- [x] Bug fix
- [x] New feature / enhancement

## Checklist
- [x] I have read CONTRIBUTING.md
- [x] My branch is up to date with main
- [x] I have tested the change locally
- [x] I have not introduced duplicate features