### PR TITLE
fix: add system theme detection on first load

### DIFF
--- a/frontend/index.html
+++ b/frontend/index.html
@@ -2540,7 +2540,8 @@ main
         btn.setAttribute('aria-pressed', theme === 'light' ? 'true' : 'false');
       }
 
-      const savedTheme = localStorage.getItem('qyx_theme') || 'dark';
+     const systemDark = window.matchMedia('(prefers-color-scheme: dark)').matches;
+     const savedTheme = localStorage.getItem('qyx_theme') || (systemDark ? 'dark' : 'light');
       document.documentElement.setAttribute('data-theme', savedTheme);
       setThemeIcon(savedTheme);
 

--- a/frontend/index.html
+++ b/frontend/index.html
@@ -2540,8 +2540,8 @@ main
         btn.setAttribute('aria-pressed', theme === 'light' ? 'true' : 'false');
       }
 
-     const systemDark = window.matchMedia('(prefers-color-scheme: dark)').matches;
-     const savedTheme = localStorage.getItem('qyx_theme') || (systemDark ? 'dark' : 'light');
+    const systemDark = window.matchMedia('(prefers-color-scheme: dark)').matches;
+      const savedTheme = localStorage.getItem('qyx_theme') || (systemDark ? 'dark' : 'light');
       document.documentElement.setAttribute('data-theme', savedTheme);
       setThemeIcon(savedTheme);
 


### PR DESCRIPTION
This PR updates theme initialization logic to respect the user's system/browser preference on first visit.

- Added system theme detection using matchMedia
- Integrated localStorage-based preference handling
- Ensured manual toggle overrides system preference
