### PR TITLE
fix: detect system theme on first load

### DIFF
--- a/frontend/index.html
+++ b/frontend/index.html
@@ -5,6 +5,16 @@
   <meta charset="UTF-8" />
   <meta name="viewport" content="width=device-width, initial-scale=1.0" />
   <title>QyverixAI — AI Developer Assistant</title>
+  <script>
+    (() => {
+      const themeKeys = ['qyx_theme', 'qyverix_theme'];
+      const storedTheme = themeKeys
+        .map((key) => localStorage.getItem(key))
+        .find((value) => value === 'dark' || value === 'light');
+      const systemTheme = window.matchMedia('(prefers-color-scheme: light)').matches ? 'light' : 'dark';
+      document.documentElement.setAttribute('data-theme', storedTheme || systemTheme);
+    })();
+  </script>
   <link rel="preconnect" href="https://fonts.googleapis.com" />
   <link rel="icon" type="image/svg+xml" href="../assets/icon.svg">
   <link
@@ -2255,23 +2265,46 @@
         btn.setAttribute('aria-pressed', theme === 'light' ? 'true' : 'false');
       }
 
-      const savedTheme = localStorage.getItem('qyx_theme');
+      const THEME_STORAGE_KEY = 'qyx_theme';
+      const LEGACY_THEME_STORAGE_KEY = 'qyverix_theme';
+      const prefersLightTheme = window.matchMedia('(prefers-color-scheme: light)');
 
-      const initialTheme = savedTheme
-       ? savedTheme
-       : window.matchMedia('(prefers-color-scheme: dark)').matches
-        ? 'dark'
-        : 'light';
+      function readStoredTheme() {
+        const primaryTheme = localStorage.getItem(THEME_STORAGE_KEY);
+        if (primaryTheme === 'dark' || primaryTheme === 'light') return primaryTheme;
 
-      document.documentElement.setAttribute('data-theme', initialTheme);
-      setThemeIcon(initialTheme);
+        const legacyTheme = localStorage.getItem(LEGACY_THEME_STORAGE_KEY);
+        if (legacyTheme === 'dark' || legacyTheme === 'light') {
+          localStorage.setItem(THEME_STORAGE_KEY, legacyTheme);
+          return legacyTheme;
+        }
+
+        return null;
+      }
+
+      function getPreferredTheme() {
+        return readStoredTheme() || (prefersLightTheme.matches ? 'light' : 'dark');
+      }
+
+      function applyTheme(theme, { persist = false } = {}) {
+        document.documentElement.setAttribute('data-theme', theme);
+        if (persist) {
+          localStorage.setItem(THEME_STORAGE_KEY, theme);
+        }
+        setThemeIcon(theme);
+      }
+
+      applyTheme(getPreferredTheme());
 
       document.getElementById('themeToggle').addEventListener('click', () => {
         const cur = document.documentElement.getAttribute('data-theme');
         const next = cur === 'dark' ? 'light' : 'dark';
-        document.documentElement.setAttribute('data-theme', next);
-        localStorage.setItem('qyx_theme', next);
-        setThemeIcon(next);
+        applyTheme(next, { persist: true });
+      });
+
+      prefersLightTheme.addEventListener('change', (event) => {
+        if (readStoredTheme()) return;
+        applyTheme(event.matches ? 'light' : 'dark');
       });
 
       /* ═══════════════════════════════════════════════════════════════

--- a/frontend/script.js
+++ b/frontend/script.js
@@ -19,21 +19,51 @@ const historyContainer = document.getElementById('historyContainer');
 const favContainer = document.getElementById('favContainer');
 const themeToggle = document.getElementById('themeToggle');
 const API_URL_STORAGE_KEY = 'qyverix_api_url';
+const THEME_STORAGE_KEY = 'qyverix_theme';
+const LEGACY_THEME_STORAGE_KEY = 'qyx_theme';
+const prefersLightTheme = window.matchMedia('(prefers-color-scheme: light)');
 
 // ── Theme ──
-const savedTheme = localStorage.getItem('qyverix_theme') || 'dark';
-if (savedTheme === 'light') document.documentElement.setAttribute('data-theme', 'light');
+function readStoredTheme() {
+  const primaryTheme = localStorage.getItem(THEME_STORAGE_KEY);
+  if (primaryTheme === 'dark' || primaryTheme === 'light') return primaryTheme;
+
+  const legacyTheme = localStorage.getItem(LEGACY_THEME_STORAGE_KEY);
+  if (legacyTheme === 'dark' || legacyTheme === 'light') {
+    localStorage.setItem(THEME_STORAGE_KEY, legacyTheme);
+    return legacyTheme;
+  }
+
+  return null;
+}
+
+function getPreferredTheme() {
+  return readStoredTheme() || (prefersLightTheme.matches ? 'light' : 'dark');
+}
+
+function applyTheme(theme, { persist = false } = {}) {
+  document.documentElement.setAttribute('data-theme', theme);
+  if (persist) {
+    localStorage.setItem(THEME_STORAGE_KEY, theme);
+  }
+}
+
+applyTheme(getPreferredTheme());
 
 themeToggle.addEventListener('click', () => {
   const isLight = document.documentElement.getAttribute('data-theme') === 'light';
-  document.documentElement.setAttribute('data-theme', isLight ? 'dark' : 'light');
-  localStorage.setItem('qyverix_theme', isLight ? 'dark' : 'light');
+  applyTheme(isLight ? 'dark' : 'light', { persist: true });
 
   const themeToggleBtn = document.getElementById('themeToggle');
   if (themeToggleBtn) {
     themeToggleBtn.setAttribute('aria-label', isLight ? 'Toggle dark mode' : 'Toggle light mode');
     themeToggleBtn.setAttribute('aria-pressed', isLight ? 'false' : 'true');
   }
+});
+
+prefersLightTheme.addEventListener('change', (event) => {
+  if (readStoredTheme()) return;
+  applyTheme(event.matches ? 'light' : 'dark');
 });
 
 const initialTheme = document.documentElement.getAttribute('data-theme') || 'dark';


### PR DESCRIPTION
## Summary
- respect the user's system color preference on first load when no theme has been saved yet
- persist explicit theme toggles without overriding them when the OS theme changes later
- migrate the old legacy theme storage key into the active one so existing users keep their preference

## Related Issue
Fixes #121

## Testing
- `/Users/saurabhkumarbajpaiai/.cache/codex-runtimes/codex-primary-runtime/dependencies/node/bin/node --check frontend/script.js`
- in-app browser verification on `http://127.0.0.1:3031` confirmed the page loads with the expected theme attribute and toggle label
- `git diff --check -- frontend/index.html frontend/script.js`

## Notes
- kept the change scoped to the frontend theme bootstrapping/runtime logic only
- no backend changes
