### PR TITLE
fix: detect magic numbers starting with 1

### DIFF
--- a/backend/app/services/code_assistant.py
+++ b/backend/app/services/code_assistant.py
@@ -879,7 +879,7 @@ def run_suggestions(code: str, language: str) -> dict:
     # ─────────────────────────────────────────────────────────────
     # SUGGESTION 3: Magic Numbers
     # ─────────────────────────────────────────────────────────────
-    magic_pattern = r"\b(?<![a-zA-Z_])[2-9]\d{1,}(?![a-zA-Z_])\b"
+    magic_pattern = r"\b(?<![a-zA-Z_])(?:1\d+|[2-9]\d+)(?![a-zA-Z_])\b"
     magic_lines = find_lines_matching_pattern(code, magic_pattern)
 
     if magic_lines:

--- a/backend/tests/test_endpoints.py
+++ b/backend/tests/test_endpoints.py
@@ -576,6 +576,31 @@ def test_add():
     assert d["overall_score"] >= 60  # clean code should score reasonably
 
 
+def test_suggestions_detect_magic_numbers_starting_with_one():
+    code = """
+import time
+
+TIMEOUT_FALLBACK = 5
+
+def fetch_data():
+    time.sleep(10)
+    limit = 1000
+    return limit
+"""
+    r = client.post("/suggestions/", json={"code": code, "language": "python"})
+    assert r.status_code == 200
+    d = r.json()
+
+    readability_suggestions = [
+        suggestion for suggestion in d["suggestions"]
+        if suggestion["category"] == "Readability"
+    ]
+
+    assert readability_suggestions
+    assert "Magic numbers detected" in readability_suggestions[0]["description"]
+    assert readability_suggestions[0]["line_number"] in (6, 7)
+
+
 # ── Full Analysis ─────────────────────────────────────────────────────────────
 def test_full_analyze():
     r = client.post("/analyze/", json={"code": PYTHON_BUGGY})


### PR DESCRIPTION
Closes #291

## Summary
- update the magic-number regex so values like `10`, `1000`, and `1024` are detected
- keep single-digit literals out of the suggestion as before
- add an endpoint regression test covering the `1xxx` case

## Testing
- `.codex-venv/bin/python -m pytest backend/tests/test_endpoints.py -q`
- `.codex-venv/bin/python -m py_compile backend/app/services/code_assistant.py backend/tests/test_endpoints.py`
- `git diff --check`