### PR TITLE
fix: sync drag-drop uploads with language tabs

### DIFF
--- a/frontend/index.html
+++ b/frontend/index.html
@@ -2455,6 +2455,9 @@
         e.preventDefault();
         const file = e.dataTransfer.files[0];
         if (!file) return;
+        const ext = file.name.split('.').pop().toLowerCase();
+        const langMap = { py: 'python', js: 'javascript', ts: 'typescript', java: 'java', cpp: 'cpp' };
+        if (langMap[ext]) setLanguage(langMap[ext]);
         const reader = new FileReader();
         reader.onload = ev => {
           editor.value = ev.target.result;


### PR DESCRIPTION
## Summary
- make drag-and-drop uploads auto-detect and select the matching language tab
- keep drag-and-drop behavior aligned with the existing file picker flow

## Testing
- extracted the inline frontend script and ran `node --check`
- `git diff --check`

Closes #308
