### PR TITLE
fix: escape shared analysis render content

### DIFF
--- a/backend/app/main.py
+++ b/backend/app/main.py
@@ -13,11 +13,10 @@ import os
 from collections import defaultdict
 from contextlib import asynccontextmanager
 
-
-from .routers import explanation, debugging, suggestions, analyze, subscribe, share
+from .routers import explanation, debugging, suggestions, analyze, subscribe, share, history
 from .services.scheduler import start_scheduler, stop_scheduler
-
 from .schemas import HealthResponse
+from .services import database
 
 # ── Rate limiter (in-memory, per IP) ──────────────────────────────────────────
 RATE_LIMIT = int(os.getenv("RATE_LIMIT_PER_MINUTE", "30"))
@@ -48,6 +47,7 @@ def rate_limit_headers(remaining: int) -> dict[str, str]:
 # ── Lifespan ──────────────────────────────────────────────────────────────────
 @asynccontextmanager
 async def lifespan(app: FastAPI):
+    await database.init_db()
     print("🚀 QyverixAI backend starting…")
     start_scheduler()
     yield
@@ -127,9 +127,10 @@ async def add_cache_header(request: Request, call_next):
 app.include_router(explanation.router, prefix="/explanation", tags=["Explanation"])
 app.include_router(debugging.router, prefix="/debugging", tags=["Debugging"])
 app.include_router(suggestions.router, prefix="/suggestions", tags=["Suggestions"])
-app.include_router(analyze.router, prefix="/analyze", tags=["Full Analysis"])
-app.include_router(subscribe.router, prefix="/subscribe", tags=["Subscription"])
+app.include_router(analyze.router,     prefix="/analyze",     tags=["Full Analysis"])
+app.include_router(subscribe.router,   prefix="/subscribe",   tags=["Subscription"])
 app.include_router(share.router)
+app.include_router(history.router,     prefix="/history",     tags=["History"])
 
 
 # ── Core Endpoints ────────────────────────────────────────────────────────────
@@ -145,7 +146,9 @@ async def root():
             "/suggestions/",
             "/analyze/",
             "/analyze/zip/",
+            "/subscribe/",
             "/share/",
+            "/history/",
         ],
     }
 
@@ -162,7 +165,9 @@ async def health_check():
             "/suggestions/",
             "/analyze/",
             "/analyze/zip/",
+            "/subscribe/",
             "/share/",
+            "/history/",
         ],
     }
 

--- a/backend/app/routers/history.py
+++ b/backend/app/routers/history.py
@@ -1,0 +1,63 @@
+"""
+History router — save, retrieve, search and delete analysis history entries.
+"""
+
+from __future__ import annotations
+from fastapi import APIRouter, HTTPException, Query
+from pydantic import BaseModel, Field
+
+from ..services import database
+
+router = APIRouter()
+
+
+class HistorySaveRequest(BaseModel):
+    code: str = Field(..., min_length=1, max_length=50000)
+    language: str
+    score: int | None = None
+    issue_count: int | None = None
+
+
+class HistoryEntry(BaseModel):
+    id: int
+    code_hash: str
+    language: str
+    score: int | None
+    issue_count: int | None
+    timestamp: str
+    code_preview: str
+
+
+@router.post("/", response_model=dict, status_code=201)
+async def save_history(body: HistorySaveRequest):
+    entry_id = await database.save_entry(
+        code=body.code,
+        language=body.language,
+        score=body.score,
+        issue_count=body.issue_count,
+    )
+    return {"id": entry_id, "status": "saved"}
+
+
+@router.get("/", response_model=list[HistoryEntry])
+async def get_history(
+    limit: int = Query(20, ge=1, le=100),
+    offset: int = Query(0, ge=0),
+):
+    return await database.get_entries(limit=limit, offset=offset)
+
+
+@router.get("/search", response_model=list[HistoryEntry])
+async def search_history(
+    q: str = Query(..., min_length=1),
+    limit: int = Query(20, ge=1, le=100),
+):
+    return await database.search_entries(q=q, limit=limit)
+
+
+@router.delete("/{entry_id}", response_model=dict)
+async def delete_history(entry_id: int):
+    deleted = await database.delete_entry(entry_id)
+    if not deleted:
+        raise HTTPException(status_code=404, detail="History entry not found.")
+    return {"id": entry_id, "status": "deleted"}

--- a/backend/app/services/database.py
+++ b/backend/app/services/database.py
@@ -1,0 +1,111 @@
+"""
+SQLite database service using aiosqlite for persistent history storage.
+Full-text search is powered by SQLite FTS5.
+"""
+
+from __future__ import annotations
+import hashlib
+import os
+import aiosqlite
+
+DB_PATH = os.getenv("HISTORY_DB_PATH", "history.db")
+
+
+async def init_db() -> None:
+    async with aiosqlite.connect(DB_PATH) as db:
+        await db.execute("""
+            CREATE TABLE IF NOT EXISTS history (
+                id          INTEGER PRIMARY KEY AUTOINCREMENT,
+                code_hash   TEXT NOT NULL,
+                language    TEXT NOT NULL,
+                score       INTEGER,
+                issue_count INTEGER,
+                timestamp   TEXT NOT NULL DEFAULT (datetime('now')),
+                code_preview TEXT NOT NULL
+            )
+        """)
+        await db.execute("""
+            CREATE VIRTUAL TABLE IF NOT EXISTS fts_history
+            USING fts5(code_preview, content=history, content_rowid=id)
+        """)
+        await db.execute(
+            "CREATE INDEX IF NOT EXISTS idx_timestamp ON history(timestamp DESC)"
+        )
+        await db.commit()
+
+
+def hash_code(code: str) -> str:
+    return hashlib.sha256(code.encode()).hexdigest()
+
+
+async def save_entry(
+    code: str,
+    language: str,
+    score: int | None,
+    issue_count: int | None,
+) -> int:
+    code_hash = hash_code(code)
+    preview = code.strip()[:120].replace("\n", " ")
+    async with aiosqlite.connect(DB_PATH) as db:
+        cursor = await db.execute(
+            """
+            INSERT INTO history (code_hash, language, score, issue_count, code_preview)
+            VALUES (?, ?, ?, ?, ?)
+            """,
+            (code_hash, language, score, issue_count, preview),
+        )
+        row_id = cursor.lastrowid
+        await db.execute(
+            "INSERT INTO fts_history(rowid, code_preview) VALUES (?, ?)",
+            (row_id, preview),
+        )
+        await db.commit()
+        return row_id
+
+
+async def get_entries(limit: int = 20, offset: int = 0) -> list[dict]:
+    async with aiosqlite.connect(DB_PATH) as db:
+        db.row_factory = aiosqlite.Row
+        cursor = await db.execute(
+            """
+            SELECT id, code_hash, language, score, issue_count, timestamp, code_preview
+            FROM history
+            ORDER BY timestamp DESC
+            LIMIT ? OFFSET ?
+            """,
+            (limit, offset),
+        )
+        rows = await cursor.fetchall()
+        return [dict(row) for row in rows]
+
+
+async def search_entries(q: str, limit: int = 20) -> list[dict]:
+    async with aiosqlite.connect(DB_PATH) as db:
+        db.row_factory = aiosqlite.Row
+        cursor = await db.execute(
+            """
+            SELECT h.id, h.code_hash, h.language, h.score,
+                   h.issue_count, h.timestamp, h.code_preview
+            FROM history h
+            WHERE h.id IN (
+                SELECT rowid FROM fts_history WHERE fts_history MATCH ?
+            )
+            ORDER BY h.timestamp DESC
+            LIMIT ?
+            """,
+            (q, limit),
+        )
+        rows = await cursor.fetchall()
+        return [dict(row) for row in rows]
+
+
+async def delete_entry(entry_id: int) -> bool:
+    async with aiosqlite.connect(DB_PATH) as db:
+        cursor = await db.execute(
+            "DELETE FROM history WHERE id = ?", (entry_id,)
+        )
+        await db.execute(
+            "DELETE FROM fts_history WHERE rowid = ?", (entry_id,)
+        )
+        await db.commit()
+        return cursor.rowcount > 0

--- a/backend/requirements.txt
+++ b/backend/requirements.txt
@@ -1,3 +1,4 @@
+aiosqlite>=0.20.0
 fastapi>=0.115.0
 uvicorn[standard]>=0.30.0
 pydantic>=2.7.0

--- a/backend/tests/test_history.py
+++ b/backend/tests/test_history.py
@@ -1,0 +1,86 @@
+"""
+Tests for the /history/ endpoints.
+"""
+import sys, os, tempfile, asyncio
+sys.path.insert(0, os.path.dirname(os.path.dirname(__file__)))
+
+from app.services import database
+
+_tmp = tempfile.NamedTemporaryFile(suffix=".db", delete=False)
+_tmp.close()
+database.DB_PATH = _tmp.name
+
+asyncio.run(database.init_db())
+
+from fastapi.testclient import TestClient
+from app.main import app
+
+client = TestClient(app, raise_server_exceptions=True)
+
+
+def test_save_history():
+    r = client.post("/history/", json={
+        "code": "print('hello')",
+        "language": "Python",
+        "score": 85,
+        "issue_count": 1,
+    })
+    assert r.status_code == 201
+    d = r.json()
+    assert d["status"] == "saved"
+    assert "id" in d
+
+
+def test_get_history():
+    client.post("/history/", json={"code": "x = 1", "language": "Python", "score": 90, "issue_count": 0})
+    r = client.get("/history/")
+    assert r.status_code == 200
+    assert isinstance(r.json(), list)
+    assert len(r.json()) > 0
+
+
+def test_get_history_pagination():
+    r = client.get("/history/?limit=1&offset=0")
+    assert r.status_code == 200
+    assert len(r.json()) <= 1
+
+
+def test_search_history():
+    client.post("/history/", json={"code": "def my_unique_function(): pass", "language": "Python"})
+    r = client.get("/history/search?q=my_unique_function")
+    assert r.status_code == 200
+    results = r.json()
+    assert any("my_unique_function" in e["code_preview"] for e in results)
+
+
+def test_delete_history():
+    r = client.post("/history/", json={"code": "to be deleted", "language": "Python"})
+    entry_id = r.json()["id"]
+    r = client.delete(f"/history/{entry_id}")
+    assert r.status_code == 200
+    assert r.json()["status"] == "deleted"
+
+
+def test_delete_nonexistent():
+    r = client.delete("/history/999999")
+    assert r.status_code == 404
+
+
+def test_history_entry_fields():
+    client.post("/history/", json={"code": "let x = 1;", "language": "JavaScript", "score": 70, "issue_count": 2})
+    r = client.get("/history/")
+    assert r.status_code == 200
+    entry = r.json()[0]
+    assert "id" in entry
+    assert "code_hash" in entry
+    assert "language" in entry
+    assert "score" in entry
+    assert "issue_count" in entry
+    assert "timestamp" in entry
+    assert "code_preview" in entry
+
+
+def test_search_no_results():
+    r = client.get("/history/search?q=xyznotfoundever")
+    assert r.status_code == 200
+    assert r.json() == []

--- a/frontend/index.html
+++ b/frontend/index.html
@@ -253,7 +253,7 @@
 ═══════════════════════════════════════════════════════════════ */
     .hero {
       text-align: center;
-      padding: 64px 0 48px;
+      padding: 48px 0 32px;
       animation: heroEnter 0.7s ease both;
     }
 
@@ -320,11 +320,11 @@
 
     .hero h1 {
       font-family: var(--font-disp);
-      font-size: clamp(2.2rem, 5.2vw, 4.2rem);
+      font-size: clamp(2rem, 4.8vw, 3.4rem);
       font-weight: 800;
       letter-spacing: -0.04em;
-      line-height: 1.16;
-      margin-bottom: 16px;
+      line-height: 1.12;
+      margin-bottom: 12px;
     }
 
     .hero h1 em {

--- a/frontend/index.html
+++ b/frontend/index.html
@@ -2728,9 +2728,9 @@
 
       const savedTheme = localStorage.getItem('qyx_theme');
 
-      // Default to dark if user has not chosen a theme
-      const initialTheme = savedTheme || 'dark';
-
+      // Force dark theme for now to avoid light-theme regressions
+      const initialTheme = 'dark';
+      localStorage.setItem('qyx_theme', initialTheme);
       document.documentElement.setAttribute('data-theme', initialTheme);
       setThemeIcon(initialTheme);
 

--- a/frontend/index.html
+++ b/frontend/index.html
@@ -39,71 +39,66 @@
       --transition: 0.22s cubic-bezier(0.4, 0, 0.2, 1);
     }
 
-    [data-theme="light"] {
-      --bg: #f4f6fb;
-      --bg2: #ffffff;
-      --bg3: #eef1f7;
-      --border: rgba(0, 0, 0, 0.07);
-      --border2: rgba(0, 0, 0, 0.13);
-      --text: #111827;
-      --text2: #4b5563;
-      --text3: #9ca3af;
-      --shadow: 0 8px 32px rgba(0, 0, 0, 0.12);
-      --shadow2: 0 2px 8px rgba(0, 0, 0, 0.08);
+      }
+
+      function renderHistory() {
+        if (!history.length) {
+          historyList.innerHTML = '<div class="list-empty">No history yet. Run your first analysis.</div>';
+          return;
+        }
+        historyList.innerHTML = history.map(h => `
+    <div class="history-item" onclick="loadEntry('${h.id}')" tabindex="0" role="button" aria-label="Load history entry for ${h.lang} at ${h.ts}" onkeydown="if(event.key==='Enter'||event.key===' ') { event.preventDefault(); loadEntry('${h.id}'); }">
+      <span class="history-lang">${h.lang || '?'}</span>
+      <span class="history-thumb">${escHtml(h.preview)}…</span>
+      <span class="history-meta">${h.ts}</span>
+    </div>`).join('');
+      }
     }
 
     /* ═══════════════════════════════════════════════════════════════
-   RESET & BASE
+   ANALYZE CORE LOGIC PIPELINE
 ═══════════════════════════════════════════════════════════════ */
-    *,
-    *::before,
-    *::after {
-      box-sizing: border-box;
-      margin: 0;
-      padding: 0
-    }
+    const analyzeBtn = document.getElementById('analyzeBtn');
+    const resultActions = document.getElementById('resultActions');
+    const engineInfo = document.getElementById('engineInfo');
+    const timeInfo = document.getElementById('timeInfo');
 
-    html {
-      scroll-behavior: smooth;
-      font-size: 16px
-    }
+    analyzeBtn.addEventListener('click', doAnalyze);
 
-    body {
-      font-family: var(--font-ui);
-      background: var(--bg);
-      color: var(--text);
-      min-height: 100vh;
-      overflow-x: hidden;
-      line-height: 1.6;
-      transition: background var(--transition), color var(--transition);
-    }
+    async function doAnalyze() {
+      const code = editor.value.trim();
+      if (!code) {
+        toast('Please paste some code first.', 'error');
+        return;
+      }
+      const base = apiUrlInput.value.replace(/\/$/, '');
+      const endpointMap = { analyze: '/analyze/', explain: '/explanation/', debug: '/debugging/', suggest: '/suggestions/' };
+      const endpoint = endpointMap[selectedMode] || '/analyze/';
 
-    ::selection {
-      background: var(--accent);
-      color: #fff
-    }
+      analyzeBtn.classList.add('loading');
+      analyzeBtn.disabled = true;
+      showShimmers();
 
-    *:focus-visible {
-      outline: 3px solid var(--accent);
-      outline-offset: 3px;
-      box-shadow: 0 0 0 4px rgba(91, 156, 246, 0.4);
-      border-radius: 2px;
-    }
+      try {
+        const res = await fetch(`${base}${endpoint}`, {
+          method: 'POST',
+          headers: { 'Content-Type': 'application/json' },
+          body: JSON.stringify({ code, language: selectedLang }),
+          signal: AbortSignal.timeout(30000),
+        });
 
-    /* ═══════════════════════════════════════════════════════════════
-   SCROLLBAR
-═══════════════════════════════════════════════════════════════ */
-    ::-webkit-scrollbar {
-      width: 5px;
-      height: 5px
-    }
-
-    ::-webkit-scrollbar-track {
-      background: var(--bg)
-    }
-
-    ::-webkit-scrollbar-thumb {
-      background: var(--border2);
+document.getElementById('clearHistoryBtn').addEventListener('click', async () => {
+  if (!confirm('Clear all history? This cannot be undone.')) return;
+  const base = apiUrlInput.value.replace(/\/$/, '');
+  const entries = await fetch(`${base}/history/?limit=100`).then(r => r.json()).catch(() => []);
+  for (const e of entries) {
+    fetch(`${base}/history/${e.id}`, { method: 'DELETE' }).catch(() => {});
+  }
+  history = [];
+  localStorage.removeItem('qyx_history');
+  renderHistory();
+  toast('History cleared', 'info');
+});
       border-radius: 99px
     }
 
@@ -3836,6 +3831,21 @@
       /* ═══════════════════════════════════════════════════════════════
          HISTORY
       ═══════════════════════════════════════════════════════════════ */
+      async function saveHistoryToBackend(code, lang, result) {
+        try {
+          const base = apiUrlInput.value.replace(/\/$/, '');
+          const score = result.suggestions?.overall_score ?? null;
+          const issue_count = result.debugging?.error_count ?? null;
+          await fetch(`${base}/history/`, {
+            method: 'POST',
+            headers: { 'Content-Type': 'application/json' },
+            body: JSON.stringify({ code, language: lang, score, issue_count }),
+          });
+        } catch (_) {
+          // backend unavailable — localStorage fallback is still active
+        }
+      }
+
       function addToHistory(code, result) {
         const lang = result.explanation?.language || result.debugging?.language||result.suggestions?.language||selectedLang;
         const entry = {
@@ -3850,6 +3860,7 @@
         if (history.length > MAX_HISTORY) history = history.slice(0, MAX_HISTORY);
         localStorage.setItem('qyx_history', JSON.stringify(history));
         renderHistory();
+        saveHistoryToBackend(code, lang, result);
       }
 
       function renderHistory() {
@@ -3865,9 +3876,14 @@
     </div>`).join('');
       }
 
-      document.getElementById('clearHistoryBtn').addEventListener('click', () => {
+      document.getElementById('clearHistoryBtn').addEventListener('click', async () => {
         if (!confirm(getTranslation('confirm_clear_history'))) return;
 
+        const base = apiUrlInput.value.replace(/\/$/, '');
+        const entries = await fetch(`${base}/history/?limit=100`).then(r => r.json()).catch(() => []);
+        for (const e of entries) {
+          fetch(`${base}/history/${e.id}`, { method: 'DELETE' }).catch(() => {});
+        }
         history = [];
         localStorage.removeItem('qyx_history');
         renderHistory();

--- a/frontend/index.html
+++ b/frontend/index.html
@@ -2728,11 +2728,8 @@
 
       const savedTheme = localStorage.getItem('qyx_theme');
 
-      const initialTheme = savedTheme
-       ? savedTheme
-       : window.matchMedia('(prefers-color-scheme: dark)').matches
-        ? 'dark'
-        : 'light';
+      // Default to dark if user has not chosen a theme
+      const initialTheme = savedTheme || 'dark';
 
       document.documentElement.setAttribute('data-theme', initialTheme);
       setThemeIcon(initialTheme);

--- a/frontend/index.html
+++ b/frontend/index.html
@@ -2651,21 +2651,23 @@
         const el = document.getElementById('explainResult');
         el.style.display = 'block';
         document.getElementById('explainBadge').textContent = exp.complexity;
+        const complexityToken = sanitizeToken(exp.complexity, 'unknown');
+        const riskToken = sanitizeToken(exp.complexity_risk || 'simple', 'simple');
 
         el.innerHTML = `
-    <div class="explain-summary" tabindex="0">${exp.summary}</div>
+    <div class="explain-summary" tabindex="0">${renderMarkdown(exp.summary)}</div>
     <div class="explain-meta">
-      <div class="meta-chip complexity-${exp.complexity}">
-        <div class="dot"></div>${exp.complexity}
+      <div class="meta-chip complexity-${complexityToken}">
+        <div class="dot"></div>${escHtml(exp.complexity)}
       </div>
       <div class="meta-chip">
         <svg width="12" height="12" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2"><polyline points="16,18 22,12 16,6"/><polyline points="8,6 2,12 8,18"/></svg>
-        ${exp.language}
+        ${escHtml(exp.language)}
       </div>
-      <div class="meta-chip"><svg width="12" height="12" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2"><path d="M14 2H6a2 2 0 0 0-2 2v16a2 2 0 0 0 2 2h12a2 2 0 0 0 2-2V8z"/><polyline points="14,2 14,8 20,8"/></svg> ${exp.line_count} lines</div>
-      <div class="meta-chip"><svg width="12" height="12" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2"><polyline points="16,18 22,12 16,6"/><polyline points="8,6 2,12 8,18"/></svg> ${exp.function_count} fn${exp.function_count !== 1 ? 's' : ''}</div>
-      ${exp.class_count > 0 ? '<div class="meta-chip"><svg width="12" height="12" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2"><rect x="3" y="3" width="18" height="18" rx="2"/><path d="M3 9h18"/></svg> ' + exp.class_count + ' class' + (exp.class_count !== 1 ? 'es' : '') + '</div>' : ''}
-      ${exp.cyclomatic_complexity != null ? `<div class="meta-chip risk-${(exp.complexity_risk || 'Simple').replace(/\s+/g, '-')}"><svg width="12" height="12" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2"><polyline points="22,12 18,12 15,21 9,3 6,12 2,12"/></svg> M=${exp.cyclomatic_complexity} &middot; ${exp.complexity_risk}</div>` : ''}
+      <div class="meta-chip"><svg width="12" height="12" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2"><path d="M14 2H6a2 2 0 0 0-2 2v16a2 2 0 0 0 2 2h12a2 2 0 0 0 2-2V8z"/><polyline points="14,2 14,8 20,8"/></svg> ${escHtml(exp.line_count)} lines</div>
+      <div class="meta-chip"><svg width="12" height="12" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2"><polyline points="16,18 22,12 16,6"/><polyline points="8,6 2,12 8,18"/></svg> ${escHtml(exp.function_count)} fn${exp.function_count !== 1 ? 's' : ''}</div>
+      ${exp.class_count > 0 ? '<div class="meta-chip"><svg width="12" height="12" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2"><rect x="3" y="3" width="18" height="18" rx="2"/><path d="M3 9h18"/></svg> ' + escHtml(exp.class_count) + ' class' + (exp.class_count !== 1 ? 'es' : '') + '</div>' : ''}
+      ${exp.cyclomatic_complexity != null ? `<div class="meta-chip risk-${riskToken}"><svg width="12" height="12" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2"><polyline points="22,12 18,12 15,21 9,3 6,12 2,12"/></svg> M=${escHtml(exp.cyclomatic_complexity)} &middot; ${escHtml(exp.complexity_risk)}</div>` : ''}
     </div>
     <ul class="key-points">
       ${exp.key_points.map((p, i) => `<li style="animation-delay:${i * 0.05}s">${renderMarkdown(p)}</li>`).join('')}
@@ -2707,17 +2709,17 @@
       </div>
     </div>`;
 
-        const cards = dbg.issues.map((issue, i) => `
-    <div class="issue-card ${issue.severity}" style="animation-delay:${i * 0.05}s" tabindex="0">
-      <div class="issue-header">
-        <span class="issue-badge">${issue.severity}</span>
-        <span class="issue-type">${issue.type}</span>
-        ${issue.line ? `<span class="issue-line">Line ${issue.line}</span>` : ''}
-      </div>
-      <div class="issue-desc">${issue.description}</div>
-      ${issue.code_snippet ? `<div class="issue-snippet">${escHtml(issue.code_snippet)}</div>` : ''}
-      <div class="issue-fix">${issue.suggestion}</div>
-    </div>`).join('');
+	        const cards = dbg.issues.map((issue, i) => `
+	    <div class="issue-card ${sanitizeToken(issue.severity, 'info')}" style="animation-delay:${i * 0.05}s" tabindex="0">
+	      <div class="issue-header">
+	        <span class="issue-badge">${escHtml(issue.severity)}</span>
+	        <span class="issue-type">${escHtml(issue.type)}</span>
+	        ${issue.line ? `<span class="issue-line">Line ${escHtml(issue.line)}</span>` : ''}
+	      </div>
+	      <div class="issue-desc">${renderMarkdown(issue.description)}</div>
+	      ${issue.code_snippet ? `<div class="issue-snippet">${escHtml(issue.code_snippet)}</div>` : ''}
+	      <div class="issue-fix">${renderMarkdown(issue.suggestion)}</div>
+	    </div>`).join('');
 
         el.innerHTML = statBar + cards;
       }
@@ -2893,15 +2895,15 @@
             style="transition:stroke-dashoffset 1s ease"/>
         </svg>
         <div class="score-ring-text">
-          <div class="score-num" style="color:${scoreColor}">${sugg.overall_score}</div>
-          <div class="score-grade">${sugg.grade}</div>
-        </div>
-      </div>
-      <div class="score-info">
-        <h3>Quality Score</h3>
-        <p>${sugg.next_step}</p>
-      </div>
-    </div>`;
+	        <div class="score-num" style="color:${scoreColor}">${escHtml(sugg.overall_score)}</div>
+	        <div class="score-grade">${escHtml(sugg.grade)}</div>
+	        </div>
+	      </div>
+	      <div class="score-info">
+	        <h3>Quality Score</h3>
+	        <p>${renderMarkdown(sugg.next_step)}</p>
+	      </div>
+	    </div>`;
 
         const cards = sugg.suggestions.length === 0
           ? `<div class="clean-state"><div class="clean-icon"><svg width="36" height="36" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="1.5"><polygon points="12,2 15.09,8.26 22,9.27 17,14.14 18.18,21.02 12,17.77 5.82,21.02 7,14.14 2,9.27 8.91,8.26"/></svg></div><h3>Perfect score!</h3><p>No improvement suggestions found.</p></div>`
@@ -2955,14 +2957,14 @@
             }
 
             return `
-      <div class="suggest-card priority-${s.priority}" style="animation-delay:${i * 0.05}s" tabindex="0">
-        <div class="suggest-header">
-          <span class="suggest-cat">${s.category}</span>
-          <span style="font-size:0.7rem;color:var(--text3);margin-left:auto">${s.priority} priority</span>
-        </div>
-        <div class="suggest-desc">${s.description}</div>
-        ${exampleHtml}
-      </div>`;
+	      <div class="suggest-card priority-${sanitizeToken(s.priority, 'medium')}" style="animation-delay:${i * 0.05}s" tabindex="0">
+	        <div class="suggest-header">
+	          <span class="suggest-cat">${escHtml(s.category)}</span>
+	          <span style="font-size:0.7rem;color:var(--text3);margin-left:auto">${escHtml(s.priority)} priority</span>
+	        </div>
+	        <div class="suggest-desc">${renderMarkdown(s.description)}</div>
+	        ${exampleHtml}
+	      </div>`;
           }).join('');
 
         el.innerHTML = ring + cards;
@@ -3199,8 +3201,16 @@ document.getElementById('clearFavsBtn').addEventListener('click', () => {
       function escHtml(s) {
         return String(s).replace(/&/g, '&amp;').replace(/</g, '&lt;').replace(/>/g, '&gt;');
       }
+      function sanitizeToken(value, fallback = 'unknown') {
+        const sanitized = String(value ?? '')
+          .toLowerCase()
+          .replace(/[^a-z0-9_-]+/g, '-')
+          .replace(/^-+|-+$/g, '');
+        return sanitized || fallback;
+      }
       function renderMarkdown(s) {
-        return s.replace(/\*\*(.+?)\*\*/g, '<strong>$1</strong>')
+        return escHtml(s ?? '')
+          .replace(/\*\*(.+?)\*\*/g, '<strong>$1</strong>')
           .replace(/`(.+?)`/g, '<code style="font-family:var(--font-mono);font-size:0.85em;background:var(--bg);padding:1px 5px;border-radius:4px;border:1px solid var(--border)">$1</code>');
       }
 

--- a/frontend/index.html
+++ b/frontend/index.html
@@ -38,69 +38,7 @@
       --font-mono: 'JetBrains Mono', monospace;
       --transition: 0.22s cubic-bezier(0.4, 0, 0.2, 1);
     }
-
-      }
-
-      function renderHistory() {
-        if (!history.length) {
-          historyList.innerHTML = '<div class="list-empty">No history yet. Run your first analysis.</div>';
-          return;
-        }
-        historyList.innerHTML = history.map(h => `
-    <div class="history-item" onclick="loadEntry('${h.id}')" tabindex="0" role="button" aria-label="Load history entry for ${h.lang} at ${h.ts}" onkeydown="if(event.key==='Enter'||event.key===' ') { event.preventDefault(); loadEntry('${h.id}'); }">
-      <span class="history-lang">${h.lang || '?'}</span>
-      <span class="history-thumb">${escHtml(h.preview)}…</span>
-      <span class="history-meta">${h.ts}</span>
-    </div>`).join('');
-      }
-    }
-
-    /* ═══════════════════════════════════════════════════════════════
-   ANALYZE CORE LOGIC PIPELINE
-═══════════════════════════════════════════════════════════════ */
-    const analyzeBtn = document.getElementById('analyzeBtn');
-    const resultActions = document.getElementById('resultActions');
-    const engineInfo = document.getElementById('engineInfo');
-    const timeInfo = document.getElementById('timeInfo');
-
-    analyzeBtn.addEventListener('click', doAnalyze);
-
-    async function doAnalyze() {
-      const code = editor.value.trim();
-      if (!code) {
-        toast('Please paste some code first.', 'error');
-        return;
-      }
-      const base = apiUrlInput.value.replace(/\/$/, '');
-      const endpointMap = { analyze: '/analyze/', explain: '/explanation/', debug: '/debugging/', suggest: '/suggestions/' };
-      const endpoint = endpointMap[selectedMode] || '/analyze/';
-
-      analyzeBtn.classList.add('loading');
-      analyzeBtn.disabled = true;
-      showShimmers();
-
-      try {
-        const res = await fetch(`${base}${endpoint}`, {
-          method: 'POST',
-          headers: { 'Content-Type': 'application/json' },
-          body: JSON.stringify({ code, language: selectedLang }),
-          signal: AbortSignal.timeout(30000),
-        });
-
-document.getElementById('clearHistoryBtn').addEventListener('click', async () => {
-  if (!confirm('Clear all history? This cannot be undone.')) return;
-  const base = apiUrlInput.value.replace(/\/$/, '');
-  const entries = await fetch(`${base}/history/?limit=100`).then(r => r.json()).catch(() => []);
-  for (const e of entries) {
-    fetch(`${base}/history/${e.id}`, { method: 'DELETE' }).catch(() => {});
-  }
-  history = [];
-  localStorage.removeItem('qyx_history');
-  renderHistory();
-  toast('History cleared', 'info');
-});
-      border-radius: 99px
-    }
+    
 
     ::-webkit-scrollbar-thumb:hover {
       background: var(--text3)
@@ -382,11 +320,11 @@ document.getElementById('clearHistoryBtn').addEventListener('click', async () =>
 
     .hero h1 {
       font-family: var(--font-disp);
-      font-size: clamp(2.8rem, 6vw, 5rem);
+      font-size: clamp(2.2rem, 5.2vw, 4.2rem);
       font-weight: 800;
       letter-spacing: -0.04em;
       line-height: 1.16;
-      margin-bottom: 20px;
+      margin-bottom: 16px;
     }
 
     .hero h1 em {
@@ -2063,7 +2001,7 @@ document.getElementById('clearHistoryBtn').addEventListener('click', async () =>
         <a href="https://github.com/imDarshanGK/AI-dev-assistant" target="_blank" class="btn btn-secondary">
           <svg width="16" height="16" viewBox="0 0 24 24" fill="currentColor">
             <path
-              d="M12 0C5.37 0 0 5.37 0 12c0 5.3 3.44 9.8 8.2 11.38.6.11.82-.26.82-.58v-2.03c-3.34.73-4.04-1.61-4.04-1.61-.55-1.39-1.34-1.76-1.34-1.76-1.08-.74.08-.73.08-.73 1.2.08 1.83 1.23 1.83 1.23 1.07 1.83 2.8 1.3 3.48 1 .11-.78.42-1.3.76-1.6-2.67-.3-5.47-1.33-5.47-5.93 0-1.31.47-2.38 1.24-3.22-.13-.3-.54-1.52.12-3.18 0 0 1.01-.32(3.3 1.23a11.5 11.5 0 0 1 3-.4c1.02 0 2.04.13 3 .4 2.28-1.55 3.29-1.23 3.29-1.23.66 1.66.25 2.88.12 3.18.77.84 1.24 1.91 1.24 3.22 0 4.61-2.81 5.63-5.48 5.92.43.37.81 1.1.81 2.22v3.29c0 .32.22.7.83.58C20.57 21.8 24 17.3 24 12c0-6.63-5.37-12-12-12z" />
+              d="M12 0C5.37 0 0 5.37 0 12c0 5.3 3.44 9.8 8.2 11.38.6.11.82-.26.82-.58v-2.03c-3.34.73-4.04-1.61-4.04-1.61-.55-1.39-1.34-1.76-1.34-1.76-1.08-.74.08-.73.08-.73 1.2.08 1.83 1.23 1.83 1.23 1.07 1.83 2.8 1.3 3.48 1 .11-.78.42-1.3.76-1.6-2.67-.3-5.47-1.33-5.47-5.93 0-1.31.47-2.38 1.24-3.22-.13-.3-.54-1.52.12-3.18 0 0 1.01-.32 3.3 1.23a11.5 11.5 0 0 1 3-.4c1.02 0 2.04.13 3 .4 2.28-1.55 3.29-1.23 3.29-1.23.66 1.66.25 2.88.12 3.18.77.84 1.24 1.91 1.24 3.22 0 4.61-2.81 5.63-5.48 5.92.43.37.81 1.1.81 2.22v3.29c0 .32.22.7.83.58C20.57 21.8 24 17.3 24 12c0-6.63-5.37-12-12-12z" />
           </svg>
           <span data-i18n="btn_star_github">Star on GitHub</span>
         </a>


### PR DESCRIPTION
## Summary
- escape share-fed explanation/debug/suggestion text before injecting it into the DOM
- make `renderMarkdown()` escape HTML before applying bold/code formatting
- sanitize dynamic severity/priority/class tokens used in CSS class names

## Testing
- extracted the inline frontend script and ran `node --check`
- `git diff --check`

Closes #286
