### PR TITLE
feat: Add Ruby language detection to LANG_SIGNATURES

### DIFF
--- a/backend/app/services/code_assistant.py
+++ b/backend/app/services/code_assistant.py
@@ -83,6 +83,15 @@ LANG_SIGNATURES: dict[str, list[str]] = {
         r"data\s+class\s+\w+",
         r":\s*\w+\s*\?",
     ],
+    "Ruby": [
+        r"\bdef\s+\w+",
+        r"\bend\b",
+        r"\bputs\b",
+        r"\brequire\s+['\"]",
+        r"\bclass\s+\w+",
+        r"\bdo\s*\|",
+        r"\.each\s*\|",
+    ],
 }
 
 

--- a/backend/tests/test_endpoints.py
+++ b/backend/tests/test_endpoints.py
@@ -146,6 +146,34 @@ data class User(val name: String, val age: Int)
 println("Hello World")
 """
 
+RUBY_CODE = """
+class Animal
+  def initialize(name)
+    @name = name
+  end
+
+  def speak
+    puts "Hello from #{@name}"
+  end
+end
+
+require 'json'
+
+animals = ["cat", "dog", "bird"]
+animals.each do |animal|
+  puts animal
+end
+"""
+
+
+def test_ruby_language_detection():
+    response = client.post(
+        "/explanation/",
+        json={"code": RUBY_CODE, "language": "Ruby"},
+    )
+    assert response.status_code == 200
+    data = response.json()
+    assert data["language"] == "Ruby"
 
 # ── Health ────────────────────────────────────────────────────────────────────
 def test_root():


### PR DESCRIPTION
Fixes #170

## Changes Made
- Added Ruby detection patterns to `LANG_SIGNATURES` in `backend/app/services/code_assistant.py`
- Added `RUBY_CODE` fixture and `test_ruby_language_detection()` test in `backend/tests/test_endpoints.py`

## Ruby Patterns Added
- `def` keyword for method definitions
- `end` keyword
- `puts` for output
- `require` for imports
- `class` keyword
- `do |block|` syntax
- `.each` iterator