### PR TITLE
fix: correct weekly digest unsubscribe route

### DIFF
--- a/backend/app/services/email_service.py
+++ b/backend/app/services/email_service.py
@@ -244,7 +244,7 @@ def send_digest(stats: dict, unsubscribe_token: str) -> bool:
 
     base = settings.digest_base_url.rstrip("/")
     unsubscribe_url = (
-        f"{base}/unsubscribe/?email={stats['email']}&token={unsubscribe_token}"
+        f"{base}/subscribe/unsubscribe?email={stats['email']}&token={unsubscribe_token}"
     )
 
     msg = MIMEMultipart("alternative")

--- a/frontend/index.html
+++ b/frontend/index.html
@@ -3208,7 +3208,7 @@ document.getElementById('clearFavsBtn').addEventListener('click', () => {
          SAMPLE CODE LOADER
       ═══════════════════════════════════════════════════════════════ */
       const SAMPLES = {
-        python: `// Python Sample
+        python: `# Python Sample
   import os
 
 # [!] Hardcoded secret - security risk


### PR DESCRIPTION
Fixes #317

## Changes Made

* Updated weekly digest unsubscribe URL
* Changed route from:
  `/unsubscribe/?email=...&token=...`
  to:
  `/subscribe/unsubscribe?email=...&token=...`

## Why

The backend mounts the subscription router under `/subscribe`, so the old unsubscribe link pointed to an unmapped route.

## Result

Users can now successfully unsubscribe using the digest email link.
