### PR TITLE
fix: detect OS color scheme preference on first visit (#121)

### DIFF
--- a/frontend/index.html
+++ b/frontend/index.html
@@ -10,6 +10,13 @@
   <link
     href="https://fonts.googleapis.com/css2?family=Syne:wght@400;600;700;800&family=JetBrains+Mono:wght@400;500;600&family=Inter:wght@400;500;600&display=swap"
     rel="stylesheet" />
+  <script>
+    (function() {
+      const systemDark = window.matchMedia('(prefers-color-scheme: dark)').matches;
+      const savedTheme = localStorage.getItem('qyx_theme') || (systemDark ? 'dark' : 'light');
+      document.documentElement.setAttribute('data-theme', savedTheme);
+    })();
+  </script>
   <style>
     /* ═══════════════════════════════════════════════════════════════
    DESIGN TOKENS
@@ -2786,13 +2793,8 @@
         btn.setAttribute('aria-pressed', theme === 'light' ? 'true' : 'false');
       }
 
-      const savedTheme = localStorage.getItem('qyx_theme');
-
-      const initialTheme = savedTheme
-       ? savedTheme
-       : window.matchMedia('(prefers-color-scheme: dark)').matches
-        ? 'dark'
-        : 'light';
+      const systemDark = window.matchMedia('(prefers-color-scheme: dark)').matches;
+      const initialTheme = localStorage.getItem('qyx_theme') || (systemDark ? 'dark' : 'light');
 
       document.documentElement.setAttribute('data-theme', initialTheme);
       setThemeIcon(initialTheme);

--- a/frontend/script.js
+++ b/frontend/script.js
@@ -20,9 +20,9 @@ const favContainer = document.getElementById('favContainer');
 const themeToggle = document.getElementById('themeToggle');
 const API_URL_STORAGE_KEY = 'qyverix_api_url';
 
-// ── Theme ──
-const savedTheme = localStorage.getItem('qyverix_theme') || 'dark';
-if (savedTheme === 'light') document.documentElement.setAttribute('data-theme', 'light');
+const systemDark = window.matchMedia('(prefers-color-scheme: dark)').matches;
+const savedTheme = localStorage.getItem('qyverix_theme') || (systemDark ? 'dark' : 'light');
+document.documentElement.setAttribute('data-theme', savedTheme);
 
 themeToggle.addEventListener('click', () => {
   const isLight = document.documentElement.getAttribute('data-theme') === 'light';


### PR DESCRIPTION
## Description
Fixes theme initialization to respect the OS `prefers-color-scheme` 
setting on first visit instead of always defaulting to dark mode. Adds 
a blocking inline script in `<head>` to apply the correct theme before 
the browser paints, eliminating the visual "dark mode flash" for light 
mode users on first load.

## Related Issue
Fixes #121

## Type of change
- [x] Bug fix

## Checklist
- [x] I have read CONTRIBUTING.md
- [x] My branch is up to date with `main`
- [x] I have run `pytest -v` and all tests pass
- [x] I have not introduced duplicate issues or features
- [x] My PR title follows the format: `fix: detect OS color scheme preference on first visit (#121)`
- [ ] I have added tests for new features (Level 2 and 3 issues)
- [x] No hardcoded secrets or API keys in my code
- [x] This PR is linked to a GSSoC 2026 issue

## Screenshots

After
<img width="1439" height="726" alt="Screenshot 2026-05-26 at 12 46 06 PM" src="https://github.com/user-attachments/assets/074a13e1-fda7-4e5b-87b2-7548a4db584c" />


## Test evidence
pytest tests/test_line_references.py -v
# 12 passed in 0.02s