### PR TITLE
fix: localize ZIP upload success toast message

### DIFF
--- a/frontend/index.html
+++ b/frontend/index.html
@@ -3073,7 +3073,7 @@
           editor.value = `ZIP ready for project analysis: ${file.name}\n\nClick Analyze Code to scan up to 20 source files.`;
           updateEditor();
           resetResults();
-          toast(`Loaded ZIP ${file.name}`, 'success');
+         toast(getTranslation('toast_loaded').replace('{name}', file.name), 'success');
           return;
         }
 


### PR DESCRIPTION
## Description

Replaced the hardcoded ZIP upload success message with the existing translation key `toast_loaded`.

## Related Issue

Fixes #323

## Type of change

* [x] Bug fix
* [ ] New feature / enhancement
* [ ] Documentation update
* [ ] Test addition
* [ ] Refactor

## Checklist

* [x] I have read CONTRIBUTING.md
* [x] I have not introduced duplicate issues or features
* [x] My PR title follows the required format
* [x] This PR is linked to a GSSoC 2026 issue

## Screenshots (if frontend change)

Not applicable.

## Test evidence

Not required for this small localization change.
