### PR TITLE
fix: wrap chat fallback in try/catch and return 503 on failure

### DIFF
--- a/backend/app/routers/chat.py
+++ b/backend/app/routers/chat.py
@@ -1,4 +1,6 @@
-from fastapi import APIRouter
+import logging
+
+from fastapi import APIRouter, HTTPException
 
 from ..config import settings
 from ..schemas import ChatMessageRequest, ChatMessageResponse, ChatRequest, ChatResponse
@@ -6,6 +8,7 @@ from ..services.code_assistant import chat_fallback_reply
 from ..services.llm_analysis import llm_analysis_client
 
 router = APIRouter(prefix="/chat", tags=["Chat"])
+logger = logging.getLogger("chat")
 
 
 @router.post("", response_model=ChatResponse)
@@ -19,16 +22,23 @@ async def chat(payload: ChatRequest) -> ChatResponse:
                 level="intermediate",
             )
             return ChatResponse(response=reply)
-        except Exception:
-            pass
+        except Exception as exc:
+            logger.warning("LLM chat_reply failed: %s", exc, exc_info=True)
 
-    fallback_reply = chat_fallback_reply(
-        message=payload.message,
-        code=payload.code,
-        history=payload.history,
-        level="beginner",
-    )
-    return ChatResponse(response=fallback_reply)
+    try:
+        fallback_reply = chat_fallback_reply(
+            message=payload.message,
+            code=payload.code,
+            history=payload.history,
+            level="beginner",
+        )
+        return ChatResponse(response=fallback_reply)
+    except Exception as exc:
+        logger.error("Fallback chat_reply failed: %s", exc, exc_info=True)
+        raise HTTPException(
+            status_code=503,
+            detail="Service temporarily unavailable. Please try again later.",
+        ) from exc
 
 
 @router.post("/message", response_model=ChatMessageResponse)
@@ -47,19 +57,26 @@ async def chat_message(payload: ChatMessageRequest) -> ChatMessageResponse:
                 mode="live-llm",
                 reply=reply,
             )
-        except Exception:
-            pass
+        except Exception as exc:
+            logger.warning("LLM chat_reply failed: %s", exc, exc_info=True)
 
-    fallback_reply = chat_fallback_reply(
-        message=payload.message,
-        code=payload.code,
-        history=payload.history,
-        level=payload.level,
-    )
+    try:
+        fallback_reply = chat_fallback_reply(
+            message=payload.message,
+            code=payload.code,
+            history=payload.history,
+            level=payload.level,
+        )
 
-    return ChatMessageResponse(
-        provider=settings.ai_provider,
-        model=settings.ai_model,
-        mode="ready+chat_fallback",
-        reply=fallback_reply,
-    )
+        return ChatMessageResponse(
+            provider=settings.ai_provider,
+            model=settings.ai_model,
+            mode="ready+chat_fallback",
+            reply=fallback_reply,
+        )
+    except Exception as exc:
+        logger.error("Fallback chat_reply failed: %s", exc, exc_info=True)
+        raise HTTPException(
+            status_code=503,
+            detail="Service temporarily unavailable. Please try again later.",
+        ) from exc


### PR DESCRIPTION
## Summary

Fixed unhandled promise rejections in AI API calls by adding proper error handling and logging to chat endpoints.

## Changes

- Added logging for LLM and fallback failures in `chat.py`
- Wrapped fallback `chat_fallback_reply` calls in try/catch blocks
- Returns HTTP 503 with a friendly error message when both LLM and fallback fail
- Prevents silent failures and improves debuggability

## Related Issue

closes #365
