### PR TITLE
fix: add missing aria-labels to result action buttons

### DIFF
--- a/frontend/index.html
+++ b/frontend/index.html
@@ -2224,8 +2224,8 @@
 
         <!-- Result action buttons (hidden until results) -->
         <div id="resultActions" class="result-actions" style="display:none">
-          <button class="icon-btn" id="favBtn" title="Save to favorites">★</button>
-          <button class="icon-btn" id="downloadBtn" title="Download results">⬇</button>
+          <button class="icon-btn" id="favBtn" title="Save to favorites" aria-label="Save analysis to favorites">★</button>
+          <button class="icon-btn" id="downloadBtn" title="Download results" aria-label="Download analysis results">⬇</button>
         </div>
 
       </div>


### PR DESCRIPTION
## Summary

Added missing aria-labels to result action buttons for better screen reader support.

## Changes

- Added `aria-label="Save analysis to favorites"` to the favorites button
- Added `aria-label="Download analysis results"` to the download button

## Related Issue

closes #376
