### PR TITLE
fix: prevent path traversal in zip member validation

### DIFF
--- a/backend/app/routers/analyze.py
+++ b/backend/app/routers/analyze.py
@@ -131,7 +131,10 @@ def _project_grade(score: int) -> str:
 
 
 def _safe_zip_name(name: str) -> str:
-    return name.replace("\\", "/").lstrip("/")
+    clean_name = name.replace("\\", "/").lstrip("/")
+    if ".." in PurePosixPath(clean_name).parts:
+        raise ValueError("Invalid path: contains '..'")
+    return clean_name
 
 
 def _is_safe_member(name: str) -> bool:


### PR DESCRIPTION
## Description
Fixed a path traversal vulnerability in `_safe_zip_name()` function in 
`backend/app/routers/analyze.py`. The original function only stripped 
leading slashes but did not reject `..` path components, allowing 
attackers to escape the intended directory and access sensitive files.

## Related Issue
Fixes #386

## Type of change
- [x] Bug fix

## Checklist
- [x] I have read CONTRIBUTING.md
- [x] My branch is up to date with `main`
- [x] I have run `pytest -v` and all tests pass
- [x] I have not introduced duplicate issues or features
- [x] My PR title follows the format: `fix: prevent path traversal in zip member validation`
- [x] No hardcoded secrets or API keys in my code
- [x] This PR is linked to a GSSoC 2026 issue

## Test evidence
```bash
pytest -v
# 93 passed in 3.96s
# Manually Tested the check.
```