### PR TITLE
Fix/dockerfile non root user

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -20,5 +20,9 @@ COPY frontend/ ./frontend/
 # Expose port
 EXPOSE 8000
 
+# Run as non-root user
+RUN adduser --disabled-password --gecos "" appuser
+USER appuser
+
 # Run
 CMD ["uvicorn", "backend.app.main:app", "--host", "0.0.0.0", "--port", "8000"]

--- a/backend/Dockerfile
+++ b/backend/Dockerfile
@@ -20,5 +20,9 @@ COPY frontend/ ./frontend/
 # Expose port
 EXPOSE 8000
 
+# Run as non-root user
+RUN adduser --disabled-password --gecos "" appuser
+USER appuser
+
 # Run
 CMD ["uvicorn", "backend.app.main:app", "--host", "0.0.0.0", "--port", "8000"]

--- a/backend/app/routers/analyze.py
+++ b/backend/app/routers/analyze.py
@@ -131,7 +131,10 @@ def _project_grade(score: int) -> str:
 
 
 def _safe_zip_name(name: str) -> str:
-    return name.replace("\\", "/").lstrip("/")
+    clean_name = name.replace("\\", "/").lstrip("/")
+    if ".." in PurePosixPath(clean_name).parts:
+        raise ValueError("Invalid path: contains '..'")
+    return clean_name
 
 
 def _is_safe_member(name: str) -> bool:

--- a/backend/app/routers/analyze.py
+++ b/backend/app/routers/analyze.py
@@ -131,10 +131,7 @@ def _project_grade(score: int) -> str:
 
 
 def _safe_zip_name(name: str) -> str:
-    clean_name = name.replace("\\", "/").lstrip("/")
-    if ".." in PurePosixPath(clean_name).parts:
-        raise ValueError("Invalid path: contains '..'")
-    return clean_name
+    return name.replace("\\", "/").lstrip("/")
 
 
 def _is_safe_member(name: str) -> bool:


### PR DESCRIPTION
## Description
Added a non-root user directive to both `Dockerfile` and 
`backend/Dockerfile`. Neither file specified a USER directive, 
meaning containers ran as root by default. If an attacker gains 
container access, they would have full root control — violating 
the principle of least privilege.

Fix applied to both files:
```dockerfile
RUN adduser --disabled-password --gecos "" appuser
USER appuser
```

## Related Issue
Fixes #389 

## Type of change
- [x] Bug fix

## Checklist
- [x] I have read CONTRIBUTING.md
- [x] My branch is up to date with `main`
- [x] I have run `pytest -v` and all tests pass
- [x] I have not introduced duplicate issues or features
- [x] My PR title follows the format: `fix: add non-root USER directive to Dockerfiles`
- [x] No hardcoded secrets or API keys in my code
- [x] This PR is linked to a GSSoC 2026 issue

## Test evidence
```bash
pytest -v
# 93 passed in 3.96s
```