### PR TITLE
fix: gracefully handle AI API failures with 503 Service Unavailable

### DIFF
--- a/backend/app/routers/chat.py
+++ b/backend/app/routers/chat.py
@@ -1,9 +1,12 @@
-from fastapi import APIRouter
+import logging
+from fastapi import APIRouter, HTTPException, status
 
 from ..config import settings
 from ..schemas import ChatMessageRequest, ChatMessageResponse, ChatRequest, ChatResponse
 from ..services.code_assistant import chat_fallback_reply
 from ..services.llm_analysis import llm_analysis_client
+
+logger = logging.getLogger(__name__)
 
 router = APIRouter(prefix="/chat", tags=["Chat"])
 
@@ -19,16 +22,23 @@ async def chat(payload: ChatRequest) -> ChatResponse:
                 level="intermediate",
             )
             return ChatResponse(response=reply)
-        except Exception:
-            pass
+        except Exception as e:
+            logger.error(f"LLM chat_reply failed: {e}")
 
-    fallback_reply = chat_fallback_reply(
-        message=payload.message,
-        code=payload.code,
-        history=payload.history,
-        level="beginner",
-    )
-    return ChatResponse(response=fallback_reply)
+    try:
+        fallback_reply = chat_fallback_reply(
+            message=payload.message,
+            code=payload.code,
+            history=payload.history,
+            level="beginner",
+        )
+        return ChatResponse(response=fallback_reply)
+    except Exception as e:
+        logger.error(f"Fallback chat_fallback_reply failed: {e}")
+        raise HTTPException(
+            status_code=status.HTTP_503_SERVICE_UNAVAILABLE,
+            detail="Service Unavailable: Both LLM and fallback AI failed to generate a response."
+        )
 
 
 @router.post("/message", response_model=ChatMessageResponse)
@@ -47,19 +57,26 @@ async def chat_message(payload: ChatMessageRequest) -> ChatMessageResponse:
                 mode="live-llm",
                 reply=reply,
             )
-        except Exception:
-            pass
+        except Exception as e:
+            logger.error(f"LLM chat_reply failed: {e}")
 
-    fallback_reply = chat_fallback_reply(
-        message=payload.message,
-        code=payload.code,
-        history=payload.history,
-        level=payload.level,
-    )
+    try:
+        fallback_reply = chat_fallback_reply(
+            message=payload.message,
+            code=payload.code,
+            history=payload.history,
+            level=payload.level,
+        )
 
-    return ChatMessageResponse(
-        provider=settings.ai_provider,
-        model=settings.ai_model,
-        mode="ready+chat_fallback",
-        reply=fallback_reply,
-    )
+        return ChatMessageResponse(
+            provider=settings.ai_provider,
+            model=settings.ai_model,
+            mode="ready+chat_fallback",
+            reply=fallback_reply,
+        )
+    except Exception as e:
+        logger.error(f"Fallback chat_fallback_reply failed: {e}")
+        raise HTTPException(
+            status_code=status.HTTP_503_SERVICE_UNAVAILABLE,
+            detail="Service Unavailable: Both LLM and fallback AI failed to generate a response."
+        )


### PR DESCRIPTION
## Summary

This PR addresses the unhandled exceptions in the AI chat API endpoints that were previously causing process crashes. I've added robust try/except blocks around both the LLM and fallback logic.

## Changes

- Added logging for LLM and fallback failures in chat.py
- Wrapped chat_fallback_reply calls in try/except blocks
- Now returns HTTP 503 Service Unavailable with a friendly error message when both LLM and fallback fail
- Prevents silent failures and improves debuggability, matching the proposed solution in the original issue.

Closes #365