### PR TITLE
fix(a11y): add aria-label to interactive buttons in frontend (#414)

### DIFF
--- a/frontend/index.html
+++ b/frontend/index.html
@@ -2230,14 +2230,14 @@
           </div>
           <div style="display:flex;align-items:center;gap:8px">
             <div id="apiStatusText" data-status="disconnected" style="font-size:0.85rem;color:var(--text3)">Disconnected</div>
-            <button id="pingBtn" class="icon-btn" title="Ping API" style="padding:6px 10px">Ping</button>
+            <button id="pingBtn" class="icon-btn" title="Ping API" aria-label="Ping API" style="padding:6px 10px">Ping</button>
           </div>
         </div>
 
         <!-- Result action buttons (hidden until results) -->
         <div id="resultActions" class="result-actions" style="display:none">
-          <button class="icon-btn" id="favBtn" title="Save to favorites">★</button>
-          <button class="icon-btn" id="downloadBtn" title="Download results">⬇</button>
+          <button class="icon-btn" id="favBtn" title="Save to favorites" aria-label="Save to favorites">★</button>
+          <button class="icon-btn" id="downloadBtn" title="Download results" aria-label="Download results">⬇</button>
         </div>
 
       </div>


### PR DESCRIPTION
﻿## Summary
Added `aria-label` attributes to icon-only buttons in `frontend/index.html`:
- `aria-label="Ping API"` on the ping button
- `aria-label="Save to favorites"` on the star/favorites button
- `aria-label="Download results"` on the download button

Fixes #414
