### PR TITLE
[refactor] update Pydantic mode='after' validator to instance method to fix deprecation warning

### DIFF
--- a/backend/app/schemas.py
+++ b/backend/app/schemas.py
@@ -294,11 +294,10 @@ class ShareCreateRequest(BaseModel):
         return values
 
     @model_validator(mode="after")
-    @classmethod
-    def ensure_result_present(cls, model: "ShareCreateRequest") -> "ShareCreateRequest":
-        if model.result is None:
+    def ensure_result_present(self) -> "ShareCreateRequest":
+        if self.result is None:
             raise ValueError("result or result_json is required")
-        return model
+        return self
 
 
 class ShareRecord(BaseModel):


### PR DESCRIPTION
## Description
This PR resolves the `PydanticDeprecatedSince212` warning triggered during the backend test suite execution. 

In Pydantic V2.12+, using the `@model_validator(mode="after")` decorator on a `@classmethod` is deprecated. I have refactored the `ensure_result_present` validator in `backend/app/schemas.py` to be a standard instance method operating on `self`. This ensures full compatibility with Pydantic V2 and keeps the test summary output completely clean of internal code warnings.

## Related Issue
Fixes #719 

## Type of change
- [ ] Bug fix
- [ ] New feature / enhancement
- [ ] Documentation update
- [ ] Test addition
- [x] Refactor

## Checklist
<!-- All boxes must be checked before requesting review -->
- [x] I have read [CONTRIBUTING.md](../CONTRIBUTING.md)
- [x] My branch is up to date with `main`
- [x] I have run `pytest -v` and all tests pass
- [x] I have not introduced duplicate issues or features
- [x] My PR title follows the format: `feat/fix/docs/test: short description`
- [x] I have added tests for new features (Level 2 and 3 issues)
- [x] No hardcoded secrets or API keys in my code
- [x] This PR is linked to a GSSoC 2026 issue

## Screenshots (if frontend change)
N/A — backend logic refactoring only.

## Test evidence
```bash
pytest -v

# ... [Test output omitted for brevity] ...
tests/test_zip_dos.py::test_analyze_zip_too_large_via_header PASSED                                                         [ 99%]
tests/test_zip_dos.py::test_analyze_zip_too_large_via_stream PASSED                                                         [ 99%]
tests/test_zip_dos.py::test_analyze_zip_valid PASSED                                                                        [100%]

========================================================= warnings summary =========================================================
aidevenv\Lib\site-packages\fastapi\testclient.py:1
  D:\AI-dev-assistant\backend\aidevenv\Lib\site-packages\fastapi\testclient.py:1: StarletteDeprecationWarning: Using `httpx` with `starlette.testclient` is deprecated; install `httpx2` instead.
    from starlette.testclient import TestClient as TestClient  # noqa

-- Docs: [https://docs.pytest.org/en/stable/how-to/capture-warnings.html](https://docs.pytest.org/en/stable/how-to/capture-warnings.html)
================================================== 367 passed, 1 warning in 9.20s ==================================================

```