### PR TITLE
fix: make test_ping deterministic

### DIFF
--- a/backend/tests/test_ping.py
+++ b/backend/tests/test_ping.py
@@ -1,10 +1,8 @@
 from fastapi.testclient import TestClient
 from app.main import app
 
-client = TestClient(app)
-
-
 def test_ping():
-    response = client.get("/ping")
-    assert response.status_code == 200
-    assert response.json() == {"message": "pong"}
+    with TestClient(app) as client:
+        response = client.get("/ping")
+        assert response.status_code == 200
+        assert response.json() == {"message": "pong"}


### PR DESCRIPTION
## Description

Updated `test_ping` to use `TestClient` as a context manager instead of a global instance. This ensures proper startup/shutdown lifecycle handling and improves test reliability.

## Related Issue

Fixes #521

## Type of change

* [x] Bug fix
* [ ] New feature / enhancement
* [ ] Documentation update
* [x] Test addition
* [ ] Refactor

## Checklist

* [x] I have read CONTRIBUTING.md
* [x] My branch is up to date with `main`
* [x] I have run `pytest -v` and all tests pass
* [x] I have not introduced duplicate issues or features
* [x] My PR title follows the format: `feat/fix/docs/test: short description`
* [ ] I have added tests for new features (Level 2 and 3 issues)
* [x] No hardcoded secrets or API keys in my code
* [x] This PR is linked to a GSSoC 2026 issue

## Test evidence

```bash
pytest tests/test_ping.py -v

============================== test session starts ==============================
...
tests/test_ping.py::test_ping PASSED
======================== 1 passed, 2 warnings in 0.53s =========================fix: make test_ping deterministic
```
