### PR TITLE
fix: handle SyntaxError gracefully in ast_analyzer

### DIFF
--- a/backend/app/services/ast_analyzer.py
+++ b/backend/app/services/ast_analyzer.py
@@ -304,7 +304,20 @@ def detect_deep_nesting(tree, code):
     return issues
 
 def analyze(source: str) -> list[dict]:
-    tree = ast.parse(source)
+    try:
+        tree = ast.parse(source)
+    except SyntaxError as exc:
+        return [
+            _make_issue(
+                "Syntax Error",
+                exc.lineno or 1,
+                f"Python syntax error: {exc.msg}",
+                "Fix the syntax error before running analysis.",
+                "error",
+                ""
+            )
+        ]
+
     issues = []
     issues += detect_unreachable_code(tree, source)
     issues += detect_unused_imports(tree, source)

--- a/backend/tests/test_ast_analyzer.py
+++ b/backend/tests/test_ast_analyzer.py
@@ -230,3 +230,10 @@ def test_deep_nesting_exact_boundary():
     )
     issues = analyze(code)
     assert not any(i["type"] == "Deep Nesting" for i in issues)
+
+
+def test_analyze_handles_syntax_error():
+    result = analyze("def f(:\n    pass")
+
+    assert len(result) == 1
+    assert result[0]["type"] == "Syntax Error"


### PR DESCRIPTION
## Description

This PR fixes a bug in the AST analyzer where invalid Python source code causes `analyze()` to raise a `SyntaxError` instead of returning a structured analyzer issue.

The analyzer currently crashes when malformed Python code is passed to `ast.parse()`. This behavior interrupts analysis and requires callers to handle unexpected exceptions.

With this change, syntax errors are handled gracefully and returned through the analyzer's existing issue-reporting system.

## Changes Made

* Added `SyntaxError` handling around `ast.parse()`
* Return a structured analyzer issue when parsing fails
* Added test coverage for syntax-error handling
* Preserved existing analyzer behavior for valid Python code

## Example

### Before

```python
analyze(
"""
def f(:
    pass
"""
)
```

Result:

```text
SyntaxError: invalid syntax
```

### After

The analyzer returns a structured issue describing the syntax error instead of crashing.

## Related Issue

Fixes #741

## Testing

Added:

* `test_analyze_handles_syntax_error`

Verified:

* Invalid Python syntax returns a structured analyzer issue
* Existing analyzer functionality remains unchanged
* Tests pass successfully

## Notes

This issue is different from #466.

Issue #466 focuses on adding test coverage for existing AST analyzer behaviors, while #741 addresses a separate bug where invalid Python syntax can cause the analyzer to raise an unhandled exception and terminate analysis.

This PR implements the bug fix and corresponding test coverage for Issue #741.
