### PR TITLE
feat: add copy suggestion button to debug issue cards (#778)

### DIFF
--- a/frontend/index.html
+++ b/frontend/index.html
@@ -3553,10 +3553,36 @@
       </div>
       <div class="issue-desc">${issue.description}</div>
       ${issue.code_snippet ? `<div class="issue-snippet">${escHtml(issue.code_snippet)}</div>` : ''}
-      <div class="issue-fix">${issue.suggestion}</div>
+      ${issue.suggestion ? `
+      <div class="issue-fix-container" style="display:flex; justify-content:space-between; align-items:flex-start; gap: 8px;">
+        <div class="issue-fix" style="flex:1;">${issue.suggestion}</div>
+        <button class="btn-copy-fix" id="copy-debug-fix-${i}" aria-label="Copy suggestion" style="margin-top:0; white-space:nowrap; flex-shrink:0;">
+          <svg width="12" height="12" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2"><rect x="9" y="9" width="13" height="13" rx="2"/><path d="M5 15H4a2 2 0 0 1-2-2V4a2 2 0 0 1 2-2h9a2 2 0 0 1 2 2v1"/></svg>
+          Copy
+        </button>
+      </div>` : ''}
     </div>`).join('');
 
         el.innerHTML = statBar + cards;
+
+        // Wire up "Copy suggestion" buttons after DOM insertion
+        dbg.issues.forEach((issue, i) => {
+          if (!issue.suggestion) return;
+          const btn = document.getElementById(`copy-debug-fix-${i}`);
+          if (!btn) return;
+
+          btn.addEventListener('click', () => {
+            navigator.clipboard.writeText(issue.suggestion).then(() => {
+              btn.textContent = '\u2713 Copied!';
+              btn.style.background = 'rgba(34,212,123,0.25)';
+              toast('Suggestion copied', 'success');
+              setTimeout(() => {
+                btn.innerHTML = `<svg width="12" height="12" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2"><rect x="9" y="9" width="13" height="13" rx="2"/><path d="M5 15H4a2 2 0 0 1-2-2V4a2 2 0 0 1 2-2h9a2 2 0 0 1 2 2v1"/></svg> Copy`;
+                btn.style.background = '';
+              }, 2000);
+            }).catch(() => toast('Copy failed', 'error'));
+          });
+        });
       }
 
       /* ═══════════════════════════════════════════════════════════════

--- a/frontend/script.js
+++ b/frontend/script.js
@@ -446,7 +446,10 @@ function renderResult(data, mode) {
             : issues.map(i => `<div style="margin-bottom:10px">
                 <span class="result-tag tag-error">${escHtml(i.type || 'Issue')}</span>
                 <p style="margin-top:4px">${escHtml(i.description || '')}</p>
-                ${i.suggestion ? `<p style="color:var(--accent-green);margin-top:4px">Fix: ${escHtml(i.suggestion)}</p>` : ''}
+                ${i.suggestion ? `<div style="display:flex; justify-content:space-between; align-items:flex-start; margin-top:4px; gap:8px;">
+                    <p style="color:var(--accent-green);margin-top:0;">Fix: ${escHtml(i.suggestion)}</p>
+                    <button class="btn-copy-fix-script" data-suggestion="${escHtml(i.suggestion)}" aria-label="Copy suggestion" style="white-space:nowrap; padding: 4px 8px; font-size: 11px; border-radius: 4px; background: var(--bg-3, #333); color: var(--text, #fff); border: 1px solid var(--border, #444); cursor: pointer;">Copy</button>
+                  </div>` : ''}
               </div>`).join('')}
         </div>
       </div>`;
@@ -492,7 +495,10 @@ function renderResult(data, mode) {
               <span class="result-tag tag-error">${escHtml(i.type || 'Issue')}</span>
               ${i.line ? `<span class="result-tag tag-info">Line ${i.line}</span>` : ''}
               <p style="margin-top:8px">${escHtml(i.description || '')}</p>
-              ${i.suggestion ? `<p style="margin-top:6px;color:var(--accent-green)">→ ${escHtml(i.suggestion)}</p>` : ''}
+              ${i.suggestion ? `<div style="display:flex; justify-content:space-between; align-items:flex-start; margin-top:6px; gap:8px;">
+                  <p style="margin-top:0;color:var(--accent-green)">→ ${escHtml(i.suggestion)}</p>
+                  <button class="btn-copy-fix-script" data-suggestion="${escHtml(i.suggestion)}" aria-label="Copy suggestion" style="white-space:nowrap; padding: 4px 8px; font-size: 11px; border-radius: 4px; background: var(--bg-3, #333); color: var(--text, #fff); border: 1px solid var(--border, #444); cursor: pointer;">Copy</button>
+                </div>` : ''}
             </div>`).join('')}
       </div>
     </div>`;
@@ -514,6 +520,24 @@ function renderResult(data, mode) {
 
   lastResult = text;
   outputBox.innerHTML = html || '<p style="color:var(--text-3)">No structured output returned.</p>';
+
+  // Wire up "Copy suggestion" buttons
+  document.querySelectorAll('.btn-copy-fix-script').forEach(btn => {
+    btn.addEventListener('click', () => {
+      const suggestion = btn.getAttribute('data-suggestion');
+      if (suggestion) {
+        navigator.clipboard.writeText(suggestion).then(() => {
+          btn.textContent = '\u2713 Copied!';
+          btn.style.background = 'rgba(34,212,123,0.25)';
+          showToast('Suggestion copied');
+          setTimeout(() => {
+            btn.textContent = 'Copy';
+            btn.style.background = 'var(--bg-3, #333)';
+          }, 2000);
+        }).catch(() => showToast('Copy failed'));
+      }
+    });
+  });
 }
 
 function showLoading() {


### PR DESCRIPTION
## Description
This PR addresses the issue where users had to manually select and copy text from the debug issue card suggestions. 

I've added a **"Copy"** button to the debug issue cards in both the main interface (`index.html`) and the standalone script (`script.js`). When clicked, it copies the exact suggestion text to the user's clipboard and provides visual feedback (the button text briefly changes to "✓ Copied!" with a green background, and a toast notification appears).

## Related Issue
Fixes #778

## Type of change
- [ ] Bug fix
- [x] New feature / enhancement
- [ ] Documentation update
- [ ] Test addition
- [ ] Refactor

## Checklist
<!-- All boxes must be checked before requesting review -->
- [x] My branch is up to date with `main`
- [ ] I have run `pytest -v` and all tests pass *(N/A - this is a frontend-only change)*
- [x] I have not introduced duplicate issues or features
- [x] My PR title follows the format: `feat/fix/docs/test: short description`
- [ ] I have added tests for new features (Level 2 and 3 issues) *(N/A - this is a minor UI addition)*
