### PR TITLE
refactor: move shared constants into separate module (#492)

### DIFF
--- a/frontend/constants.js
+++ b/frontend/constants.js
@@ -1,0 +1,22 @@
+/**
+ * Shared constants for QyverixAI frontend.
+ * Loaded by index.html before script.js and security-utils.js.
+ */
+
+// ── Analysis Modes ─────────────────────────────────────────────
+const ALLOWED_MODES = new Set(['analyze', 'explanation', 'debugging', 'suggestions']);
+
+// ── localStorage Keys ──────────────────────────────────────────
+const STORAGE_KEYS = {
+  API_URL:   'qyverix_api_url',
+  HISTORY:   'qyverix_history',
+  FAVORITES: 'qyverix_favorites',
+  THEME:     'qyverix_theme',
+};
+
+// ── Validation Sets ────────────────────────────────────────────
+const ALLOWED_PRIORITIES = new Set(['high', 'medium', 'low']);
+const ALLOWED_SEVERITIES = new Set(['error', 'warning', 'info']);
+
+// ── Stored Entry Limits ────────────────────────────────────────
+const STORED_ENTRY_LIMITS = { lang: 64, ts: 64, preview: 120 };

--- a/frontend/script.js
+++ b/frontend/script.js
@@ -14,7 +14,7 @@ const SEC = window.QyverixSecurity || {
 };
 const { escHtml, sanitizeClientCode } = SEC;
 
-const ALLOWED_MODES = new Set(['analyze', 'explanation', 'debugging', 'suggestions']);
+
 function safeModeLabel(mode) {
   const key = String(mode || '').toLowerCase();
   return ALLOWED_MODES.has(key) ? key : 'analyze';
@@ -22,8 +22,8 @@ function safeModeLabel(mode) {
 
 // ── State ──
 let currentMode = 'analyze';
-let history = JSON.parse(localStorage.getItem('qyverix_history') || '[]');
-let favorites = JSON.parse(localStorage.getItem('qyverix_favorites') || '[]');
+let history = JSON.parse(localStorage.getItem(STORAGE_KEYS.HISTORY) || '[]');
+let favorites = JSON.parse(localStorage.getItem(STORAGE_KEYS.FAVORITES) || '[]');
 let lastResult = '';
 
 // ── DOM refs ──
@@ -40,16 +40,16 @@ const fileInput = document.getElementById('fileInput');
 const historyContainer = document.getElementById('historyContainer');
 const favContainer = document.getElementById('favContainer');
 const themeToggle = document.getElementById('themeToggle');
-const API_URL_STORAGE_KEY = 'qyverix_api_url';
+
 
 const systemDark = window.matchMedia('(prefers-color-scheme: dark)').matches;
-const savedTheme = localStorage.getItem('qyverix_theme') || (systemDark ? 'dark' : 'light');
+const savedTheme = localStorage.getItem(STORAGE_KEYS.THEME) || (systemDark ? 'dark' : 'light');
 document.documentElement.setAttribute('data-theme', savedTheme);
 
 themeToggle.addEventListener('click', () => {
   const isLight = document.documentElement.getAttribute('data-theme') === 'light';
   document.documentElement.setAttribute('data-theme', isLight ? 'dark' : 'light');
-  localStorage.setItem('qyverix_theme', isLight ? 'dark' : 'light');
+  localStorage.setItem(STORAGE_KEYS.THEME, isLight ? 'dark' : 'light');
 
   const themeToggleBtn = document.getElementById('themeToggle');
   if (themeToggleBtn) {
@@ -145,7 +145,7 @@ document.getElementById('saveBtn').addEventListener('click', () => {
   };
   favorites.unshift(entry);
   if (favorites.length > 20) favorites = favorites.slice(0, 20);
-  localStorage.setItem('qyverix_favorites', JSON.stringify(favorites));
+  localStorage.setItem(STORAGE_KEYS.FAVORITES, JSON.stringify(favorites));
   renderFavorites();
   showToast('Saved to favorites ♡');
 });
@@ -153,7 +153,7 @@ document.getElementById('saveBtn').addEventListener('click', () => {
 // ── Clear history ──
 document.getElementById('clearHistoryBtn').addEventListener('click', () => {
   history = [];
-  localStorage.setItem('qyverix_history', JSON.stringify(history));
+  localStorage.setItem(STORAGE_KEYS.HISTORY, JSON.stringify(history));
   renderHistory();
 });
 
@@ -244,7 +244,7 @@ async function checkConnection() {
         if (fallbackResp.ok) {
           const fallbackHealth = await fallbackResp.json().catch(() => ({}));
           apiUrlInput.value = suggestedApi;
-          localStorage.setItem(API_URL_STORAGE_KEY, suggestedApi);
+          localStorage.setItem(STORAGE_KEYS.API_URL, suggestedApi);
           updateDocsLink();
           statusDot.className = 'status-dot online';
           setEngineBadge(fallbackHealth.llm_enabled ? 'llm' : 'rule');
@@ -311,7 +311,7 @@ function setEngineBadge(mode) {
 }
 
 function initializeApiUrl() {
-  const saved = normalizeApiUrl(localStorage.getItem(API_URL_STORAGE_KEY));
+  const saved = normalizeApiUrl(localStorage.getItem(STORAGE_KEYS.API_URL));
   const current = normalizeApiUrl(apiUrlInput.value);
   const suggested = normalizeApiUrl(getSuggestedApiUrl());
   const pageHost = window.location.hostname;
@@ -328,7 +328,7 @@ function initializeApiUrl() {
   }
 
   apiUrlInput.value = chosen;
-  localStorage.setItem(API_URL_STORAGE_KEY, chosen);
+  localStorage.setItem(STORAGE_KEYS.API_URL, chosen);
   updateDocsLink();
 }
 
@@ -364,7 +364,7 @@ function getUserFriendlyError(err, responseStatus) {
 
 initializeApiUrl();
 apiUrlInput.addEventListener('change', () => {
-  localStorage.setItem(API_URL_STORAGE_KEY, getApiUrl());
+  localStorage.setItem(STORAGE_KEYS.API_URL, getApiUrl());
   updateDocsLink();
   checkConnection();
 });
@@ -551,7 +551,7 @@ function saveHistory(code, mode, result) {
     time: new Date().toLocaleTimeString()
   });
   if (history.length > 50) history = history.slice(0, 50);
-  localStorage.setItem('qyverix_history', JSON.stringify(history));
+  localStorage.setItem(STORAGE_KEYS.HISTORY, JSON.stringify(history));
   renderHistory();
 }
 

--- a/frontend/security-utils.js
+++ b/frontend/security-utils.js
@@ -3,9 +3,9 @@
  * Loaded by index.html; tested via frontend/tests/*.test.mjs
  */
 (function (global) {
-  const ALLOWED_PRIORITIES = new Set(['high', 'medium', 'low']);
-  const ALLOWED_SEVERITIES = new Set(['error', 'warning', 'info']);
-  const STORED_ENTRY_LIMITS = { lang: 64, ts: 64, preview: 120 };
+
+
+
 
   const FAV_HEART_SVG =
     '<svg width="13" height="13" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" aria-hidden="true">' +


### PR DESCRIPTION
## Summary
Moves shared constants out of individual files into a new frontend/constants.js module.

## Changes
- Created `frontend/constants.js` as a single source of truth for shared constants
- Moved `ALLOWED_MODES`, `ALLOWED_PRIORITIES`, `ALLOWED_SEVERITIES`, `STORED_ENTRY_LIMITS` into it
- Replaced all hardcoded `qyverix_*` localStorage strings with `STORAGE_KEYS` object
- Removed duplicate constant declarations from `script.js` and `security-utils.js`

## Why
Avoids duplication, makes future key changes a one-line edit, improves readability.

Closes #492
