### PR TITLE
Add Docker image publishing workflow using GHCR

### DIFF
--- a/.github/workflows/docker-publish.yml
+++ b/.github/workflows/docker-publish.yml
@@ -1,0 +1,40 @@
+name: Publish Docker Image
+
+on:
+  push:
+    branches:
+      - main
+
+  release:
+    types: [published]
+
+jobs:
+  docker:
+    runs-on: ubuntu-latest
+
+    permissions:
+      contents: read
+      packages: write
+
+    steps:
+      - name: Checkout repository
+        uses: actions/checkout@v4
+
+      - name: Set up Docker Buildx
+        uses: docker/setup-buildx-action@v3
+
+      - name: Log in to GHCR
+        uses: docker/login-action@v3
+        with:
+          registry: ghcr.io
+          username: ${{ github.actor }}
+          password: ${{ secrets.GITHUB_TOKEN }}
+
+      - name: Build and Push Docker Image
+        uses: docker/build-push-action@v5
+        with:
+          context: .
+          push: true
+          tags: ghcr.io/${{ github.repository }}:latest
+          cache-from: type=gha
+          cache-to: type=gha,mode=max


### PR DESCRIPTION
## Description

Added a GitHub Actions workflow to automatically build and publish Docker images to GitHub Container Registry (GHCR).

### Changes
- Added `.github/workflows/docker-publish.yml`
- Trigger workflow on pushes to main
- Trigger workflow on releases
- Authenticate with GHCR using docker/login-action
- Build and push Docker image using docker/build-push-action
- Added Docker layer caching

Fixes #818