### PR TITLE
fix: replace em dash in hero subtitle with period

### DIFF
--- a/frontend/index.html
+++ b/frontend/index.html
@@ -2126,7 +2126,7 @@
       <h1 data-i18n="hero_title">Debug. Understand.<br><em>Ship faster.</em></h1>
       <p class="hero-sub" data-i18n="hero_subtitle">
         Paste your code and get instant bug detection, plain-English explanations, and actionable improvement
-        suggestions — no account needed.
+        suggestions. No account needed.
       </p>
       <div class="hero-cta">
         <button class="btn btn-primary"
@@ -2454,7 +2454,7 @@
           nav_api_docs: "API Docs",
           hero_badge: "Open Source · AI-Powered · Free",
           hero_title: "Debug. Understand.<br /><em>Ship faster.</em>",
-          hero_subtitle: "Paste your code and get instant bug detection, plain-English explanations, and actionable improvement suggestions — no account needed.",
+          hero_subtitle: "Paste your code and get instant bug detection, plain-English explanations, and actionable improvement suggestions. No account needed.",
           btn_start_analyzing: "Start Analyzing",
           btn_try_sample: "Try Sample Code",
           btn_star_github: "Star on GitHub",


### PR DESCRIPTION
## Summary

Replaced the em dash in the hero subtitle with a period to improve readability and align with the issue requirements.

### Changes Made

* Updated the hero subtitle text in `frontend/index.html`
* Replaced:

  * "suggestions — no account needed."
* With:

  * "suggestions. No account needed."

### Issue

Closes #805
