### PR TITLE
fix: add pytest to backend/requirements.txt (#772)

### DIFF
--- a/backend/requirements.txt
+++ b/backend/requirements.txt
@@ -13,3 +13,4 @@ apscheduler>=3.10.0
 python-magic-bin>=0.4.14; platform_system == "Windows"
 python-magic>=0.4.27; platform_system != "Windows"
 prometheus-client>=0.20.0
+pytest>=7.0.0


### PR DESCRIPTION
Fixes #772

## Problem
`pytest` was missing from `backend/requirements.txt`, causing 
`No module named pytest` error on a fresh setup.

## Fix
Added `pytest>=7.0.0` to `backend/requirements.txt`.

## Testing
- Created a fresh `.venv`
- Ran `pip install -r backend/requirements.txt`
- Confirmed `python -m pytest -q` runs successfully

## Environment
- OS: Windows
- Python: 3.12