### PR TITLE
Add test coverage badge to README

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -46,7 +46,14 @@ jobs:
           RATE_LIMIT_PER_MINUTE: 300
         run: |
           cd backend
-          pytest -v --tb=short
+          pytest --cov=app --cov-report=xml --cov-report=term-missing -v --tb=short
+
+      - name: Upload coverage to Codecov
+        uses: codecov/codecov-action@v5
+        with:
+          directory: ./backend
+          fail_ci_if_error: false
+          verbose: false
 
   lint:
     name: Lint

--- a/README.md
+++ b/README.md
@@ -16,6 +16,7 @@
 [![FastAPI](https://img.shields.io/badge/FastAPI-0.115+-009688?logo=fastapi&logoColor=white)](https://fastapi.tiangolo.com)
 [![Python](https://img.shields.io/badge/Python-3.12+-3776AB?logo=python&logoColor=white)](https://python.org)
 [![PRs Welcome](https://img.shields.io/badge/PRs-welcome-brightgreen.svg)](CONTRIBUTING.md)
+[![Coverage](https://img.shields.io/codecov/c/github/imDarshanGK/AI-dev-assistant)](https://app.codecov.io/gh/imDarshanGK/AI-dev-assistant)
 [![GSSoC 2026](https://img.shields.io/badge/GSSoC-2026-FF6B35?logoColor=white)](https://gssoc.girlscript.tech)
 
 <br/>

--- a/backend/requirements.txt
+++ b/backend/requirements.txt
@@ -9,6 +9,7 @@ httpx>=0.27.0
 python-multipart>=0.0.9
 pytest>=8.0.0
 pytest-asyncio>=0.23.0
+pytest-cov>=5.0.0
 apscheduler>=3.10.0
 python-magic-bin>=0.4.14; platform_system == "Windows"
 python-magic>=0.4.27; platform_system != "Windows"


### PR DESCRIPTION
## Summary

Adds a **test coverage badge** to the project README, as requested in #500.

### Changes

1. **`backend/requirements.txt`** — Added `pytest-cov>=5.0.0` for coverage measurement
2. **`.github/workflows/ci.yml`** — Updated the test step to run with coverage reporting (`--cov=app --cov-report=xml --cov-report=term-missing`) and added a Codecov upload step
3. **`README.md`** — Added Codecov coverage badge to the badges section

### Verification

- All existing tests continue to run as part of CI
- Coverage is measured using pytest-cov with `--cov=app` targeting the backend application module
- Coverage reports are uploaded to Codecov for badge generation
- The badge will automatically show the current coverage once the repo is connected to Codecov (no token needed for public repos)

### What maintainers need to do after merge

1. Go to [codecov.io](https://codecov.io) and sign in with GitHub
2. Enable the `imDarshanGK/AI-dev-assistant` repository
3. The badge will update automatically on subsequent CI runs

Closes #500