### PR TITLE
docs: add onboarding guide and starter issue references

### DIFF
--- a/README.md
+++ b/README.md
@@ -485,6 +485,24 @@ Read the full workflow, code standards, and pattern guide in [CONTRIBUTING.md](C
 
 Browse all open issues: [github.com/imDarshanGK/AI-dev-assistant/issues](https://github.com/imDarshanGK/AI-dev-assistant/issues)
 
+### How to Claim an Issue
+
+1. Browse the open issues list.
+2. Pick a `good first issue` that matches your skills.
+3. Comment on the issue:
+   "I would like to work on this issue."
+4. Wait for a maintainer to assign the issue.
+5. Fork the repository and create your changes.
+6. Submit a Pull Request referencing the issue number.
+
+### Recommended Starter Issues
+
+- #652 - Add good-first-issue meta list in README
+- #644 - Add onboarding issue templates for GSSoC contributors
+- #640 - Add explicit license header file for assets
+
+> New contributors are encouraged to start with beginner-friendly issues before attempting medium or hard tasks.
+
 ---
 
 ## Roadmap


### PR DESCRIPTION
Added a new contributor onboarding section to the README.

Changes include:

* Issue claiming workflow
* Steps for new contributors
* Recommended starter issues
* Clear guidance for GSSoC participants

This improves contributor onboarding and makes it easier for newcomers to find and claim beginner-friendly issues.

Fixes #652

## Description
<!-- What does this PR do? Be specific. -->

## Related Issue
<!-- Required — link the issue this PR fixes -->
Fixes #

## Type of change
- [ ] Bug fix
- [ ] New feature / enhancement
- [ ] Documentation update
- [ ] Test addition
- [ ] Refactor

## Checklist
<!-- All boxes must be checked before requesting review -->
- [ ] I have read [CONTRIBUTING.md](../CONTRIBUTING.md)
- [ ] My branch is up to date with `main`
- [ ] I have run `pytest -v` and all tests pass
- [ ] I have not introduced duplicate issues or features
- [ ] My PR title follows the format: `feat/fix/docs/test: short description`
- [ ] I have added tests for new features (Level 2 and 3 issues)
- [ ] No hardcoded secrets or API keys in my code
- [ ] This PR is linked to a GSSoC 2026 issue

## Screenshots (if frontend change)
<!-- Add before/after screenshots -->

## Test evidence
<!-- Paste pytest output here -->
```bash
pytest -v
# paste output
```
