### PR TITLE
fix: add create_all for fresh DB initialization

### DIFF
--- a/backend/app/database.py
+++ b/backend/app/database.py
@@ -14,6 +14,7 @@ Base = declarative_base()
 
 from . import models  # noqa: E402,F401  # Register ORM models before creating tables.
 
+Base.metadata.create_all(bind=engine)
 
 def get_db():
     db = SessionLocal()


### PR DESCRIPTION
## Description
Added `Base.metadata.create_all(bind=engine)` to `database.py` to automatically create tables when starting with a fresh database. Without this, tables don't exist and queries fail.

## Related Issue
Fixes #461

## Type of change
- [x] Bug fix

## Checklist
- [x] I have read [CONTRIBUTING.md](../CONTRIBUTING.md)
- [x] My branch is up to date with `main`
- [x] I have run `pytest -v` and all tests pass
- [x] I have not introduced duplicate issues or features
- [x] My PR title follows the format: `feat/fix/docs/test: short description`
- [ ] I have added tests for new features (Level 2 and 3 issues)
- [x] No hardcoded secrets or API keys in my code
- [x] This PR is linked to issue #461


## Test evidence
```bash
pytest -v
=========================================== 399 passed, 2 warnings in 39.19s ============================================
```
