### PR TITLE
fix: avoid blocking database check in readiness endpoint

### DIFF
--- a/backend/app/routers/health.py
+++ b/backend/app/routers/health.py
@@ -22,6 +22,7 @@ unchanged for backward compatibility with anything already pointing at them.
 
 from __future__ import annotations
 
+import asyncio
 import time
 
 from fastapi import APIRouter, Response, status
@@ -84,7 +85,7 @@ def _check_database(timeout_seconds: float = 2.0) -> tuple[bool, str | None, flo
     },
 )
 async def readiness(response: Response) -> ReadinessResponse:
-    db_ok, db_error, db_elapsed_ms = _check_database()
+    db_ok, db_error, db_elapsed_ms = await asyncio.to_thread(_check_database)
 
     checks = {
         "database": {


### PR DESCRIPTION
## Description

This PR addresses a synchronous database call being executed directly from the asynchronous readiness endpoint.

### Changes Made

* Added `asyncio` import.
* Updated the readiness health check to execute `_check_database()` using `asyncio.to_thread(...)`.

### Why

The readiness endpoint (`async def readiness`) was directly executing a synchronous database probe. Running the blocking database check in a worker thread prevents blocking the event loop while preserving existing behavior.

## Related Issue

Fixes #472

## Type of change

* [x] Bug fix
* [ ] New feature / enhancement
* [ ] Documentation update
* [ ] Test addition
* [ ] Refactor

## Checklist

* [x] I have read CONTRIBUTING.md
* [x] My branch is up to date with `main`
* [x] I have run `python -m pytest tests/test_health_metrics.py -v` and all tests pass
* [x] I have not introduced duplicate issues or features
* [x] My PR title follows the format: `fix: avoid blocking database check in readiness endpoint`
* [ ] I have added tests for new features (not applicable)
* [x] No hardcoded secrets or API keys in my code
* [x] This PR is linked to a GSSoC 2026 issue

## Screenshots (if frontend change)
<!-- Add before/after screenshots -->

## Test evidence
<!-- Paste pytest output here -->
```bash
pytest -v
# paste output
```
