### PR TITLE
feat: implement third-party plugin system with safe execution sandbox

### DIFF
--- a/backend/app/config.py
+++ b/backend/app/config.py
@@ -81,5 +81,14 @@ class Settings:
         "DIGEST_BASE_URL", "https://qyverixai.onrender.com"
     )
 
+    # ── Plugins ─────────────────────────────────────────────────
+    plugins_enabled: bool = _bool_env("PLUGINS_ENABLED", True)
+    plugins_dir: str = os.getenv(
+        "PLUGINS_DIR",
+        os.path.join(
+            os.path.dirname(os.path.dirname(os.path.abspath(__file__))), "plugins"
+        ),
+    )
+
 
 settings = Settings()

--- a/backend/app/routers/analyze.py
+++ b/backend/app/routers/analyze.py
@@ -379,3 +379,13 @@ async def analyze_zip(request: Request, file: UploadFile = File(...)):
         "skipped_files": skipped_files,
         "analysis_time_ms": round(elapsed_ms, 2),
     }
+
+
+@router.get(
+    "/plugins",
+    summary="List all loaded and active analysis plugins",
+)
+async def list_plugins():
+    """Return a list of metadata for all registered analysis plugins."""
+    from ..services.plugin_manager import plugin_manager
+    return [p.to_dict() for p in plugin_manager.get_plugins()]

--- a/backend/app/services/code_assistant.py
+++ b/backend/app/services/code_assistant.py
@@ -871,6 +871,38 @@ def run_bug_detection(code: str, language: str) -> list[dict]:
         except SyntaxError:
             pass
 
+    # Run third-party plugins
+    try:
+        from .plugin_manager import plugin_manager
+        import logging
+        logger = logging.getLogger("ai_assistant.code_assistant")
+
+        plugin_issues = plugin_manager.run_all_plugins(code, language)
+        for issue in plugin_issues:
+            key = f"{issue['type']}:{issue['line']}"
+            if key not in seen:
+                seen.add(key)
+
+                # Ensure snippet & context are present
+                line_idx = issue["line"] - 1
+                if "code_snippet" not in issue:
+                    issue["code_snippet"] = (
+                        lines[line_idx].strip()[:120]
+                        if 0 <= line_idx < len(lines)
+                        else ""
+                    )
+                if "code_context" not in issue:
+                    issue["code_context"] = format_code_snippet(
+                        code, [issue["line"]], context_lines=2
+                    )
+
+                found.append(issue)
+    except Exception as exc:
+        import logging
+        logging.getLogger("ai_assistant.code_assistant").exception(
+            "Error running plugins: %s", exc
+        )
+
     return found
 
 

--- a/backend/app/services/plugin_manager.py
+++ b/backend/app/services/plugin_manager.py
@@ -1,0 +1,334 @@
+"""Third-party plugin system for extending analysis capabilities safely."""
+
+from __future__ import annotations
+
+import importlib.util
+import inspect
+import logging
+import multiprocessing
+import os
+import sys
+from abc import ABC, abstractmethod
+from pathlib import Path
+from typing import TYPE_CHECKING
+
+if TYPE_CHECKING:
+    from types import ModuleType
+
+logger = logging.getLogger("ai_assistant.plugins")
+
+
+class BasePlugin(ABC):
+    """Abstract base class that all analysis plugins must inherit from."""
+
+    @property
+    @abstractmethod
+    def name(self) -> str:
+        """Return the unique name of the plugin."""
+        pass
+
+    @property
+    @abstractmethod
+    def version(self) -> str:
+        """Return the version of the plugin."""
+        pass
+
+    @property
+    @abstractmethod
+    def description(self) -> str:
+        """Return a brief description of the plugin's analysis capabilities."""
+        pass
+
+    @property
+    @abstractmethod
+    def supported_languages(self) -> list[str]:
+        """Return list of supported languages, e.g. ["Python", "JavaScript"], or ["*"] for all."""
+        pass
+
+    @abstractmethod
+    def analyze(self, code: str, language: str) -> list[dict]:
+        """Analyze the source code and return a list of issue dicts.
+
+        Each issue dict must match the format:
+        {
+            "type": str,          # e.g., "TodoComment"
+            "line": int,          # 1-indexed line number
+            "description": str,   # Detailed description of the issue
+            "suggestion": str,    # Suggestion on how to fix it
+            "severity": str,      # "error", "warning", or "info"
+        }
+        """
+        pass
+
+
+class PluginInfo:
+    """Metadata container for loaded plugins."""
+
+    def __init__(
+        self,
+        name: str,
+        version: str,
+        description: str,
+        supported_languages: list[str],
+        file_path: str,
+        class_name: str,
+    ) -> None:
+        self.name = name
+        self.version = version
+        self.description = description
+        self.supported_languages = supported_languages
+        self.file_path = file_path
+        self.class_name = class_name
+
+    def to_dict(self) -> dict:
+        return {
+            "name": self.name,
+            "version": self.version,
+            "description": self.description,
+            "supported_languages": self.supported_languages,
+        }
+
+
+def _security_audit_hook(event: str, args: tuple) -> None:
+    """Security audit hook to block unauthorized actions in plugin subprocess."""
+    # Block network calls
+    if event in ("socket.connect", "socket.bind", "socket.connect_ex"):
+        raise PermissionError(
+            f"Plugin security policy violation: network access is forbidden ({event})"
+        )
+
+    # Block command and subprocess execution
+    if event in ("subprocess.Popen", "os.system", "os.exec", "os.spawn"):
+        raise PermissionError(
+            f"Plugin security policy violation: subprocess execution is forbidden ({event})"
+        )
+
+    # Block file writes, allowing file reads
+    if event == "open":
+        path, mode = args[0], args[1]
+        # Any writing, appending, creating, or updating is forbidden
+        if any(c in mode for c in ("w", "a", "x", "+")):
+            raise PermissionError(
+                f"Plugin security policy violation: file write is forbidden (file: {path}, mode: {mode})"
+            )
+
+
+def _run_plugin_subprocess_target(
+    file_path: str,
+    class_name: str,
+    code: str,
+    language: str,
+    conn: multiprocessing.connection.Connection,
+    backend_dir: str,
+) -> None:
+    """Entry point for the isolated plugin execution subprocess."""
+    try:
+        # Enable importing backend modules
+        if backend_dir not in sys.path:
+            sys.path.insert(0, backend_dir)
+
+        # Install security audit hook before importing or executing plugin code
+        sys.addaudithook(_security_audit_hook)
+
+        # Load plugin module dynamically
+        module_name = Path(file_path).stem
+        spec = importlib.util.spec_from_file_location(module_name, file_path)
+        if spec is None or spec.loader is None:
+            raise ImportError(f"Could not load module spec for: {file_path}")
+
+        module = importlib.util.module_from_spec(spec)
+        spec.loader.exec_module(module)
+
+        # Instantiate class
+        plugin_class = getattr(module, class_name)
+        plugin_instance = plugin_class()
+
+        # Run analysis
+        issues = plugin_instance.analyze(code, language)
+
+        # Sanitize results before serialization
+        sanitized = []
+        for issue in issues:
+            sanitized.append(
+                {
+                    "type": str(issue.get("type", "CustomIssue")),
+                    "line": int(issue.get("line", 1)),
+                    "description": str(issue.get("description", "")),
+                    "suggestion": str(issue.get("suggestion", "")),
+                    "severity": str(issue.get("severity", "warning")),
+                }
+            )
+
+        conn.send({"success": True, "issues": sanitized})
+    except Exception as exc:
+        import traceback
+        conn.send(
+            {
+                "success": False,
+                "error": str(exc),
+                "traceback": traceback.format_exc(),
+            }
+        )
+    finally:
+        conn.close()
+
+
+class PluginManager:
+    """Manages discoverability, loading, and safe execution of third-party plugins."""
+
+    def __init__(self, plugins_dir: str | None = None, enabled: bool = True) -> None:
+        from ..config import settings
+        self.plugins_dir = plugins_dir or settings.plugins_dir
+        self.enabled = enabled if enabled is not None else settings.plugins_enabled
+        self._plugins: dict[str, PluginInfo] = {}
+
+        # Scan and load plugins on creation if enabled
+        if self.enabled:
+            self.load_plugins()
+
+    def load_plugins(self) -> None:
+        """Scan plugins directory and load all valid plugins."""
+        self._plugins.clear()
+        if not os.path.exists(self.plugins_dir):
+            try:
+                os.makedirs(self.plugins_dir, exist_ok=True)
+            except Exception:
+                logger.warning("Could not create plugins directory at %s", self.plugins_dir)
+                return
+
+        logger.info("Scanning for plugins in %s", self.plugins_dir)
+        backend_dir = os.path.dirname(os.path.dirname(os.path.dirname(os.path.abspath(__file__))))
+
+        # Temporarily append backend_dir to path so scanning imports work
+        if backend_dir not in sys.path:
+            sys.path.insert(0, backend_dir)
+
+        for filename in os.listdir(self.plugins_dir):
+            if not filename.endswith("_plugin.py"):
+                continue
+
+            file_path = os.path.join(self.plugins_dir, filename)
+            module_name = filename[:-3]
+
+            try:
+                spec = importlib.util.spec_from_file_location(module_name, file_path)
+                if spec is None or spec.loader is None:
+                    continue
+
+                module = importlib.util.module_from_spec(spec)
+                spec.loader.exec_module(module)
+
+                # Inspect module for any class subclassing BasePlugin
+                for name, cls in inspect.getmembers(module, inspect.isclass):
+                    if issubclass(cls, BasePlugin) and cls is not BasePlugin:
+                        # Instantiate temporarily to validate and read metadata properties
+                        plugin_inst = cls()
+                        plugin_info = PluginInfo(
+                            name=plugin_inst.name,
+                            version=plugin_inst.version,
+                            description=plugin_inst.description,
+                            supported_languages=plugin_inst.supported_languages,
+                            file_path=file_path,
+                            class_name=name,
+                        )
+                        self._plugins[plugin_info.name] = plugin_info
+                        logger.info("Registered plugin: %s (%s)", plugin_info.name, plugin_info.version)
+            except Exception as exc:
+                logger.error("Failed to load plugin from %s: %s", filename, exc)
+
+    def get_plugins(self) -> list[PluginInfo]:
+        """Return a list of all registered plugins."""
+        return list(self._plugins.values())
+
+    def get_plugins_for_language(self, language: str) -> list[PluginInfo]:
+        """Return list of plugins that support the specified language."""
+        matching = []
+        for plugin in self._plugins.values():
+            if "*" in plugin.supported_languages or "All" in plugin.supported_languages:
+                matching.append(plugin)
+            elif language in plugin.supported_languages:
+                matching.append(plugin)
+        return matching
+
+    def execute_plugin(
+        self, plugin: PluginInfo, code: str, language: str, timeout: float = 2.0
+    ) -> list[dict]:
+        """Execute a plugin safely in an isolated subprocess with a timeout."""
+        backend_dir = os.path.dirname(os.path.dirname(os.path.dirname(os.path.abspath(__file__))))
+        
+        # We use spawn context for safety and cross-platform compatibility
+        ctx = multiprocessing.get_context("spawn")
+        parent_conn, child_conn = ctx.Pipe()
+
+        p = ctx.Process(
+            target=_run_plugin_subprocess_target,
+            args=(plugin.file_path, plugin.class_name, code, language, child_conn, backend_dir),
+        )
+
+        try:
+            p.start()
+            # Wait for results
+            if parent_conn.poll(timeout):
+                result = parent_conn.recv()
+                if result.get("success"):
+                    return result["issues"]
+                else:
+                    logger.error(
+                        "Plugin '%s' crashed inside subprocess: %s",
+                        plugin.name,
+                        result.get("error"),
+                    )
+                    return [
+                        {
+                            "type": "PluginExecutionError",
+                            "line": 1,
+                            "description": f"Plugin '{plugin.name}' crashed during execution.",
+                            "suggestion": "Check plugin logic for bugs or unhandled errors.",
+                            "severity": "warning",
+                        }
+                    ]
+            else:
+                # Timeout exceeded
+                p.terminate()
+                p.join()
+                logger.warning("Plugin '%s' timed out after %s seconds.", plugin.name, timeout)
+                return [
+                    {
+                        "type": "PluginTimeout",
+                        "line": 1,
+                        "description": f"Plugin '{plugin.name}' timed out after {timeout} seconds.",
+                        "suggestion": "Optimize plugin analysis routines.",
+                        "severity": "warning",
+                    }
+                ]
+        except Exception as exc:
+            logger.exception("Failed to run plugin '%s'", plugin.name)
+            return [
+                {
+                    "type": "PluginError",
+                    "line": 1,
+                    "description": f"Failed to execute plugin '{plugin.name}': {exc}",
+                    "suggestion": "Report this issue to the plugin maintainer.",
+                    "severity": "warning",
+                }
+            ]
+        finally:
+            if p.is_alive():
+                p.terminate()
+                p.join()
+
+    def run_all_plugins(self, code: str, language: str) -> list[dict]:
+        """Find and execute all matching plugins for the language, aggregating findings."""
+        if not self.enabled:
+            return []
+
+        issues = []
+        plugins = self.get_plugins_for_language(language)
+        for plugin in plugins:
+            plugin_issues = self.execute_plugin(plugin, code, language)
+            issues.extend(plugin_issues)
+        return issues
+
+
+# Global plugin manager instance
+plugin_manager = PluginManager()

--- a/backend/plugins/custom_todo_plugin.py
+++ b/backend/plugins/custom_todo_plugin.py
@@ -1,0 +1,43 @@
+import re
+from app.services.plugin_manager import BasePlugin
+
+
+class CustomTodoPlugin(BasePlugin):
+    """A sample plugin that identifies outstanding TODO and FIXME comments."""
+
+    @property
+    def name(self) -> str:
+        return "CustomTodoPlugin"
+
+    @property
+    def version(self) -> str:
+        return "1.0.0"
+
+    @property
+    def description(self) -> str:
+        return "Scans code for outstanding TODO and FIXME comments."
+
+    @property
+    def supported_languages(self) -> list[str]:
+        return ["Python", "JavaScript", "TypeScript"]
+
+    def analyze(self, code: str, language: str) -> list[dict]:
+        issues = []
+        # Match TODO or FIXME inside comment lines
+        pattern = re.compile(r"#\s*\b(TODO|FIXME)\b|//\s*\b(TODO|FIXME)\b", re.IGNORECASE)
+
+        for i, line in enumerate(code.splitlines(), start=1):
+            match = pattern.search(line)
+            if match:
+                # Find which group matched
+                matched_word = (match.group(1) or match.group(2) or "TODO").upper()
+                issues.append(
+                    {
+                        "type": f"Pending {matched_word}",
+                        "line": i,
+                        "description": f"Found a pending {matched_word} comment: '{line.strip()}'",
+                        "suggestion": f"Address the {matched_word} item or remove the comment if resolved.",
+                        "severity": "info",
+                    }
+                )
+        return issues

--- a/backend/tests/test_plugin_manager.py
+++ b/backend/tests/test_plugin_manager.py
@@ -1,0 +1,315 @@
+import os
+import shutil
+import tempfile
+import time
+from fastapi.testclient import TestClient
+from app.main import app
+from app.services.plugin_manager import BasePlugin, PluginManager, PluginInfo
+
+
+def test_plugin_interface_structure():
+    """Verify metadata and type contract on custom mock plugin classes."""
+    class ValidPlugin(BasePlugin):
+        @property
+        def name(self) -> str:
+            return "TestValid"
+        @property
+        def version(self) -> str:
+            return "0.1.0"
+        @property
+        def description(self) -> str:
+            return "Description"
+        @property
+        def supported_languages(self) -> list[str]:
+            return ["Python"]
+        def analyze(self, code: str, language: str) -> list[dict]:
+            return [{"type": "Issue", "line": 1, "description": "X", "suggestion": "Y", "severity": "info"}]
+
+    plugin = ValidPlugin()
+    assert plugin.name == "TestValid"
+    assert plugin.version == "0.1.0"
+    assert plugin.description == "Description"
+    assert plugin.supported_languages == ["Python"]
+    assert len(plugin.analyze("", "Python")) == 1
+
+
+def test_plugin_discovery_and_loading():
+    """Verify scanning and loading dynamically from a directory."""
+    temp_dir = tempfile.mkdtemp()
+    try:
+        # Write mock plugin code
+        plugin_code = """
+from app.services.plugin_manager import BasePlugin
+
+class MockDiscoveryPlugin(BasePlugin):
+    @property
+    def name(self) -> str:
+        return "MockDiscovery"
+    @property
+    def version(self) -> str:
+        return "1.2.3"
+    @property
+    def description(self) -> str:
+        return "Discovery Mock"
+    @property
+    def supported_languages(self) -> list[str]:
+        return ["Python", "All"]
+    def analyze(self, code: str, language: str) -> list[dict]:
+        return []
+"""
+        plugin_file = os.path.join(temp_dir, "discovery_plugin.py")
+        with open(plugin_file, "w") as f:
+            f.write(plugin_code)
+
+        manager = PluginManager(plugins_dir=temp_dir, enabled=True)
+        plugins = manager.get_plugins()
+        assert len(plugins) == 1
+        assert plugins[0].name == "MockDiscovery"
+        assert plugins[0].version == "1.2.3"
+        assert plugins[0].supported_languages == ["Python", "All"]
+
+        # Check language filtering
+        py_plugins = manager.get_plugins_for_language("Python")
+        assert len(py_plugins) == 1
+
+        js_plugins = manager.get_plugins_for_language("JavaScript")
+        assert len(js_plugins) == 1  # Matches "All"
+    finally:
+        shutil.rmtree(temp_dir)
+
+
+def test_plugin_execution_timeout():
+    """Verify that a plugin which hangs or runs too long times out safely."""
+    temp_dir = tempfile.mkdtemp()
+    try:
+        plugin_code = """
+import time
+from app.services.plugin_manager import BasePlugin
+
+class HangPlugin(BasePlugin):
+    @property
+    def name(self) -> str:
+        return "HangPlugin"
+    @property
+    def version(self) -> str:
+        return "1.0.0"
+    @property
+    def description(self) -> str:
+        return "Hangs"
+    @property
+    def supported_languages(self) -> list[str]:
+        return ["Python"]
+    def analyze(self, code: str, language: str) -> list[dict]:
+        while True:
+            time.sleep(0.1)
+"""
+        plugin_file = os.path.join(temp_dir, "hang_plugin.py")
+        with open(plugin_file, "w") as f:
+            f.write(plugin_code)
+
+        manager = PluginManager(plugins_dir=temp_dir, enabled=True)
+        plugins = manager.get_plugins()
+        assert len(plugins) == 1
+
+        issues = manager.execute_plugin(plugins[0], "print(1)", "Python", timeout=0.5)
+        assert len(issues) == 1
+        assert issues[0]["type"] == "PluginTimeout"
+        assert "timed out" in issues[0]["description"]
+    finally:
+        shutil.rmtree(temp_dir)
+
+
+def test_plugin_execution_crashes():
+    """Verify that a plugin which raises an exception is caught and returns an error issue."""
+    temp_dir = tempfile.mkdtemp()
+    try:
+        plugin_code = """
+from app.services.plugin_manager import BasePlugin
+
+class CrashPlugin(BasePlugin):
+    @property
+    def name(self) -> str:
+        return "CrashPlugin"
+    @property
+    def version(self) -> str:
+        return "1.0.0"
+    @property
+    def description(self) -> str:
+        return "Crashes"
+    @property
+    def supported_languages(self) -> list[str]:
+        return ["Python"]
+    def analyze(self, code: str, language: str) -> list[dict]:
+        raise ValueError("Simulated crash")
+"""
+        plugin_file = os.path.join(temp_dir, "crash_plugin.py")
+        with open(plugin_file, "w") as f:
+            f.write(plugin_code)
+
+        manager = PluginManager(plugins_dir=temp_dir, enabled=True)
+        plugins = manager.get_plugins()
+        assert len(plugins) == 1
+
+        issues = manager.execute_plugin(plugins[0], "print(1)", "Python")
+        assert len(issues) == 1
+        assert issues[0]["type"] == "PluginExecutionError"
+        assert "crashed" in issues[0]["description"]
+    finally:
+        shutil.rmtree(temp_dir)
+
+
+def test_plugin_security_sandbox_file_write():
+    """Verify that a plugin trying to write to the filesystem is blocked by the audit hook."""
+    temp_dir = tempfile.mkdtemp()
+    from pathlib import Path
+    temp_dir_posix = Path(temp_dir).as_posix()
+    try:
+        plugin_code = f"""
+from app.services.plugin_manager import BasePlugin
+
+class WritePlugin(BasePlugin):
+    @property
+    def name(self) -> str:
+        return "WritePlugin"
+    @property
+    def version(self) -> str:
+        return "1.0.0"
+    @property
+    def description(self) -> str:
+        return "Tries to write"
+    @property
+    def supported_languages(self) -> list[str]:
+        return ["Python"]
+    def analyze(self, code: str, language: str) -> list[dict]:
+        with open("{temp_dir_posix}/blocked.txt", "w") as f:
+            f.write("data")
+        return []
+"""
+        plugin_file = os.path.join(temp_dir, "write_plugin.py")
+        with open(plugin_file, "w") as f:
+            f.write(plugin_code)
+
+        manager = PluginManager(plugins_dir=temp_dir, enabled=True)
+        plugins = manager.get_plugins()
+        issues = manager.execute_plugin(plugins[0], "print(1)", "Python")
+        
+        assert len(issues) == 1
+        assert issues[0]["type"] == "PluginExecutionError"
+        # The hook will raise a PermissionError, causing the execution to crash
+        # Verify the file was not written
+        assert not os.path.exists(os.path.join(temp_dir, "blocked.txt"))
+    finally:
+        shutil.rmtree(temp_dir)
+
+
+def test_plugin_security_sandbox_network():
+    """Verify that a plugin trying to open socket connections is blocked."""
+    temp_dir = tempfile.mkdtemp()
+    try:
+        plugin_code = """
+import socket
+from app.services.plugin_manager import BasePlugin
+
+class NetworkPlugin(BasePlugin):
+    @property
+    def name(self) -> str:
+        return "NetworkPlugin"
+    @property
+    def version(self) -> str:
+        return "1.0.0"
+    @property
+    def description(self) -> str:
+        return "Tries to call home"
+    @property
+    def supported_languages(self) -> list[str]:
+        return ["Python"]
+    def analyze(self, code: str, language: str) -> list[dict]:
+        s = socket.socket(socket.AF_INET, socket.SOCK_STREAM)
+        s.connect(("127.0.0.1", 9999))
+        return []
+"""
+        plugin_file = os.path.join(temp_dir, "network_plugin.py")
+        with open(plugin_file, "w") as f:
+            f.write(plugin_code)
+
+        manager = PluginManager(plugins_dir=temp_dir, enabled=True)
+        plugins = manager.get_plugins()
+        issues = manager.execute_plugin(plugins[0], "print(1)", "Python")
+        
+        assert len(issues) == 1
+        assert issues[0]["type"] == "PluginExecutionError"
+    finally:
+        shutil.rmtree(temp_dir)
+
+
+def test_plugin_security_sandbox_subprocess():
+    """Verify that a plugin trying to spawn a subprocess is blocked."""
+    temp_dir = tempfile.mkdtemp()
+    try:
+        plugin_code = """
+import subprocess
+from app.services.plugin_manager import BasePlugin
+
+class CmdPlugin(BasePlugin):
+    @property
+    def name(self) -> str:
+        return "CmdPlugin"
+    @property
+    def version(self) -> str:
+        return "1.0.0"
+    @property
+    def description(self) -> str:
+        return "Tries to run cmd"
+    @property
+    def supported_languages(self) -> list[str]:
+        return ["Python"]
+    def analyze(self, code: str, language: str) -> list[dict]:
+        subprocess.run(["echo", "hello"], shell=True)
+        return []
+"""
+        plugin_file = os.path.join(temp_dir, "cmd_plugin.py")
+        with open(plugin_file, "w") as f:
+            f.write(plugin_code)
+
+        manager = PluginManager(plugins_dir=temp_dir, enabled=True)
+        plugins = manager.get_plugins()
+        issues = manager.execute_plugin(plugins[0], "print(1)", "Python")
+        
+        assert len(issues) == 1
+        assert issues[0]["type"] == "PluginExecutionError"
+    finally:
+        shutil.rmtree(temp_dir)
+
+
+def test_api_list_plugins_endpoint():
+    """Verify GET /analyze/plugins API endpoint returns loaded plugins metadata."""
+    client = TestClient(app)
+    response = client.get("/analyze/plugins")
+    assert response.status_code == 200
+    data = response.json()
+    assert isinstance(data, list)
+    # Since our mock/example custom_todo_plugin.py is active under backend/plugins/
+    # it should be in the list!
+    todo_plugin = next((p for p in data if p["name"] == "CustomTodoPlugin"), None)
+    assert todo_plugin is not None
+    assert todo_plugin["version"] == "1.0.0"
+    assert "TODO" in todo_plugin["description"]
+
+
+def test_full_analysis_runs_plugins():
+    """Verify POST /analyze/ executes plugins and merges issues."""
+    client = TestClient(app)
+    # The CustomTodoPlugin scans for TODO comments
+    code_with_todo = "# TODO: Implement this method\ndef calculate(x):\n    return x * 2\n"
+    response = client.post(
+        "/analyze/",
+        json={"code": code_with_todo, "language": "Python"}
+    )
+    assert response.status_code == 200
+    data = response.json()
+    issues = data["debugging"]["issues"]
+    
+    todo_issue = next((i for i in issues if i["type"] == "Pending TODO"), None)
+    assert todo_issue is not None
+    assert todo_issue["line"] == 1
+    assert "pending TODO comment" in todo_issue["description"]

--- a/docs/plugins_guide.md
+++ b/docs/plugins_guide.md
@@ -1,0 +1,84 @@
+# QyverixAI Plugin Development Guide
+
+This guide explains how to build, install, and run third-party plugins that extend the analysis capabilities of QyverixAI.
+
+---
+
+## Architecture Overview
+
+QyverixAI supports Python-based plugins. Plugins are loaded dynamically from a designated directory and executed within a secure, sandboxed environment:
+1. **Isolated Subprocess**: Plugins run in an isolated subprocess with a strict time limit (default: 2.0s).
+2. **Security Sandboxing**: A runtime audit hook blocks plugins from:
+   - Performing network operations (`socket.connect`, `socket.bind`).
+   - Executing system commands or spawning subprocesses (`subprocess.Popen`, `os.system`).
+   - Modifying or writing files on the local disk (opening files in write modes).
+
+---
+
+## Writing a Plugin
+
+To create a plugin, create a Python file ending with `_plugin.py` (e.g. `my_custom_plugin.py`) and place it in the `plugins` folder.
+
+The file must define a class subclassing `BasePlugin` from `app.services.plugin_manager`:
+
+```python
+from app.services.plugin_manager import BasePlugin
+
+class MyCustomPlugin(BasePlugin):
+    @property
+    def name(self) -> str:
+        """Return a unique name for the plugin."""
+        return "MyCustomPlugin"
+
+    @property
+    def version(self) -> str:
+        """Return the semantic version of your plugin."""
+        return "1.0.0"
+
+    @property
+    def description(self) -> str:
+        """Describe what issues this plugin detects."""
+        return "Detects forbidden terms or patterns."
+
+    @property
+    def supported_languages(self) -> list[str]:
+        """List the languages your plugin supports.
+        Use specific names like ["Python", "JavaScript", "TypeScript"], or ["*"] for all.
+        """
+        return ["Python", "JavaScript"]
+
+    def analyze(self, code: str, language: str) -> list[dict]:
+        """Perform analysis on the provided code and return a list of issue dicts.
+        
+        Each issue dict should follow this shape:
+        {
+            "type": str,          # The type/rule name of the issue
+            "line": int,          # 1-indexed line number of the issue
+            "description": str,   # Explanation of why this is flagged
+            "suggestion": str,    # Actionable guidance on how to fix it
+            "severity": str,      # Severity level: "error", "warning", or "info"
+        }
+        """
+        issues = []
+        # Your custom logic here
+        return issues
+```
+
+---
+
+## Configuration
+
+You can configure the plugin system via environment variables:
+
+| Variable | Description | Default |
+|---|---|---|
+| `PLUGINS_ENABLED` | Set to `true` to enable third-party plugins, `false` to disable. | `true` |
+| `PLUGINS_DIR` | Absolute or relative path to the directory containing plugins. | `backend/plugins/` |
+
+---
+
+## API Endpoints
+
+Once registered, you can verify and inspect your plugin:
+- **List registered plugins**: Send a `GET` request to `/analyze/plugins`.
+- **Run analysis**: Send a `POST` request to `/analyze/` or `/debugging/`. The plugins matching the code language will run automatically.


### PR DESCRIPTION
## Description
This PR implements a third-party plugin system that allows extending QyverixAI's analysis capabilities.

Key additions:
1. **Plugin Interface & Registry**: Defined `BasePlugin` and implemented `PluginManager` in [plugin_manager.py](file:///c:/Users/abhi/AI-dev-assistant/backend/app/services/plugin_manager.py) to dynamically scan, validate, and register plugin scripts from `backend/plugins/`.
2. **Safe Isolated Execution**: To prevent untrusted plugins from freezing the server or compromising security, they are executed in isolated `multiprocessing` subprocesses under strict timeouts (default: 2.0s).
3. **Sandbox Audit Hooks**: In the runner subprocess, a Python runtime audit hook (`sys.addaudithook`) is registered to block plugins from writing to the filesystem, spawning subprocesses, or making network/socket connections.
4. **Integration**: Integrated custom plugin issues inside `run_bug_detection` in [code_assistant.py](file:///c:/Users/abhi/AI-dev-assistant/backend/app/services/code_assistant.py).
5. **List API Route**: Added a `GET /analyze/plugins` route in [analyze.py](file:///c:/Users/abhi/AI-dev-assistant/backend/app/routers/analyze.py) to list active plugins.
6. **Documentation & Examples**: Added a developer guide in [plugins_guide.md](file:///c:/Users/abhi/AI-dev-assistant/docs/plugins_guide.md) and an example comment-scanner plugin in [custom_todo_plugin.py](file:///c:/Users/abhi/AI-dev-assistant/backend/plugins/custom_todo_plugin.py).

## Related Issue
## Fixes #664 

## Type of change
- [ ] Bug fix
- [x] New feature / enhancement
- [x] Documentation update
- [x] Test addition
- [ ] Refactor

## Checklist
- [x] I have read [CONTRIBUTING.md](../CONTRIBUTING.md)
- [x] My branch is up to date with `main`
- [x] I have run `pytest -v` and all tests pass
- [x] I have not introduced duplicate issues or features
- [x] My PR title follows the format: `feat/fix/docs/test: short description`
- [x] I have added tests for new features (Level 2 and 3 issues)
- [x] No hardcoded secrets or API keys in my code
- [x] This PR is linked to a GSSoC 2026 issue

## Screenshots (if frontend change)
N/A (Backend feature)

## Test evidence
```bash
$ python -m pytest
============================= test session starts =============================
platform win32 -- Python 3.12.10, pytest-9.0.3, pluggy-1.6.0
rootdir: C:\Users\abhi\AI-dev-assistant\backend
plugins: anyio-4.13.0, asyncio-1.4.0
asyncio: mode=Mode.STRICT, debug=False, asyncio_default_fixture_loop_scope=None, asyncio_default_test_loop_scope=function
collected 408 items

tests\test_ai_provider.py ........................                       [  5%]
tests\test_ast_analyzer.py ........................................      [ 15%]
tests\test_auth_endpoints.py ....                                        [ 16%]
tests\test_cache.py ..                                                   [ 17%]
tests\test_code_assistant.py ...                                         [ 17%]
tests\test_digest.py .............                                       [ 21%]
tests\test_endpoints.py ................................................ [ 32%]
.......                                                                  [ 34%]
tests\test_file_upload.py ................                               [ 38%]
tests\test_frontend_quiet_startup_ping.py ....                           [ 39%]
tests\test_frontend_saved_entry_restore.py ...                           [ 40%]
tests\test_health_metrics.py ........                                    [ 42%]
tests\test_history.py ........                                           [ 44%]
tests\test_ping.py .                                                     [ 44%]
tests\test_plugin_manager.py .........                                   [ 46%]
tests\test_python_ast_analyzer.py .......                                [ 48%]
tests\test_sanitization.py .....................                         [ 53%]
tests\test_sanitization_payloads.py .................................... [ 62%]
........................................................................ [ 79%]
........................................................................ [ 97%]
....                                                                     [ 98%]
tests\test_share.py ..                                                   [ 99%]
tests\test_vscode_extension_package.py .                                 [ 99%]
tests\test_zip_dos.py ...                                                [100%]

============================== warnings summary ===============================
app\schemas.py:276
  C:\Users\abhi\AI-dev-assistant\backend\app\schemas.py:276: PydanticDeprecatedSince212: Using `@model_validator` with mode='after' on a classmethod is deprecated. Instead, use an instance method. See the documentation at https://docs.pydantic.dev/2.13/concepts/validators/#model-after-validator. Deprecated in Pydantic V2.12 to be removed in V3.0.
    @model_validator(mode="after")

-- Docs: https://docs.pytest.org/en/stable/how-to/capture-warnings.html
================== 408 passed, 1 warning in 66.45s (0:01:06) ==================