### PR TITLE
docs: add NOTICE file for asset license attribution #640

### DIFF
--- a/assets/NOTICE
+++ b/assets/NOTICE
@@ -1,0 +1,17 @@
+# Asset Attributions and Licenses
+
+## SVG Assets
+
+### icon.svg
+- Author: Partharora07, imDarshanGK
+- License: MIT License
+- Source: Created for AI-dev-assistant
+
+### logo-dark.svg
+- Author: Partharora07, imDarshanGK
+- License: MIT License
+- Source: Created for AI-dev-assistant
+
+## Project License
+All assets are covered under MIT License.
+See LICENSE file for details.


### PR DESCRIPTION
## Problem 
The assets folder contained SVG files (icon.svg and logo-dark.svg) without any explicit license documentation. This creates legal uncertainty for downstream users of the project.

## Fix
Created NOTICE file that documents:
- License information for all SVG assets
- Author attribution for each asset
- Reference to the main project MIT License

## Description
This PR adds an explicit NOTICE file inside the assets folder to document the license and attribution details for all SVG assets used in the AI-dev-assistant project. 
The assets folder contained two SVG files:
- icon.svg 
- logo-dark.svg

Both files were created by the project maintainers but had no explicit documentation. The new NOTICE file clarifies that all assets are covered under MIT License.

## Related Issue
Fixes #640

## Type of change
- [ ] Bug fix
- [ ] New feature / enhancement
- [ x ] Documentation update
- [ ] Test addition
- [ ] Refactor

## Checklist
<!-- All boxes must be checked before requesting review -->
- [ x ] I have read [CONTRIBUTING.md](../CONTRIBUTING.md)
- [ x ] My branch is up to date with `main`
- [ ] I have run `pytest -v` and all tests pass
- [ x ] I have not introduced duplicate issues or features
- [ x  ] My PR title follows the format: `feat/fix/docs/test: short description`
- [ ] I have added tests for new features (Level 2 and 3 issues)
- [ ] No hardcoded secrets or API keys in my code
- [ x ] This PR is linked to a GSSoC 2026 issue

## Screenshots (if frontend change)
No frontend changes - documentation only.

## Test evidence
No tests needed - documentation only.
