### PR TITLE
fix(#645): add rate limiting and payload size cap to share endpoint

### DIFF
--- a/backend/app/config.py
+++ b/backend/app/config.py
@@ -1,3 +1,4 @@
+from __future__ import annotations
 import os
 
 from dotenv import find_dotenv, load_dotenv
@@ -69,6 +70,11 @@ class Settings:
     llm_timeout_seconds: int = _int_env("LLM_TIMEOUT_SECONDS", 30)
     llm_max_retries: int = _int_env("LLM_MAX_RETRIES", 3)
     llm_retry_backoff: float = _float_env("LLM_RETRY_BACKOFF", 1.0)
+
+    # ── Share endpoint abuse protection ────────────────────────
+    share_rate_limit_requests: int = _int_env("SHARE_RATE_LIMIT_REQUESTS", 10)
+    share_rate_limit_window_seconds: int = _int_env("SHARE_RATE_LIMIT_WINDOW_SECONDS", 3600)
+    share_max_code_chars: int = _int_env("SHARE_MAX_CODE_CHARS", 10000)
 
     # ── Email / Digest ──────────────────────────────────────────
     smtp_host: str = os.getenv("SMTP_HOST", "")

--- a/backend/app/models.py
+++ b/backend/app/models.py
@@ -1,4 +1,7 @@
-from datetime import UTC, datetime
+from __future__ import annotations
+
+from datetime import datetime, timezone
+UTC = timezone.utc
 
 from sqlalchemy import DateTime, ForeignKey, Integer, String, Text
 from sqlalchemy.orm import Mapped, mapped_column, relationship

--- a/backend/app/routers/share.py
+++ b/backend/app/routers/share.py
@@ -1,36 +1,111 @@
 import json
 import secrets
+import time
+from collections import defaultdict, deque
+from threading import Lock
 
-from fastapi import APIRouter, Depends, HTTPException, status
+from fastapi import APIRouter, Depends, HTTPException, Request, status
+from fastapi.responses import JSONResponse
 from sqlalchemy import select
 from sqlalchemy.orm import Session
 
+from ..config import settings
 from ..database import get_db
 from ..models import SharedSnippet
 from ..schemas import ShareCreateRequest, ShareRecord
+
+# ── Per-IP share rate limiter ─────────────────────────────────────────────────
+_share_buckets: dict[str, deque[float]] = defaultdict(deque)
+_share_lock = Lock()
+
+
+def _get_client_ip(request: Request) -> str:
+    xff = request.headers.get("x-forwarded-for", "").split(",")[0].strip()
+    if xff:
+        return xff
+    if request.client and request.client.host:
+        return request.client.host
+    return "unknown"
+
+
+def _check_share_rate_limit(ip: str) -> tuple[bool, int]:
+    now = time.time()
+    cutoff = now - settings.share_rate_limit_window_seconds
+    with _share_lock:
+        bucket = _share_buckets[ip]
+        while bucket and bucket[0] < cutoff:
+            bucket.popleft()
+        if len(bucket) >= settings.share_rate_limit_requests:
+            return False, 0
+        bucket.append(now)
+        return True, settings.share_rate_limit_requests - len(bucket)
+
+
+def _share_rate_limit_headers(remaining: int) -> dict:
+    return {
+        "X-Share-RateLimit-Limit": str(settings.share_rate_limit_requests),
+        "X-Share-RateLimit-Window": str(settings.share_rate_limit_window_seconds),
+        "X-Share-RateLimit-Remaining": str(max(remaining, 0)),
+    }
+
 
 router = APIRouter(prefix="/share", tags=["Share"])
 
 
 @router.post("/", response_model=ShareRecord)
-def create_share(payload: ShareCreateRequest, db: Session = Depends(get_db)):
-    # ensure tables exist on the engine (tests monkeypatch `database.engine`)
-    # ensure tables exist on the current DB bind (use the session's bind)
-    from ..database import Base as _Base
+def create_share(
+    payload: ShareCreateRequest,
+    request: Request,
+    db: Session = Depends(get_db),
+):
+    # ── 1. Per-IP rate limit ──────────────────────────────────────────────────
+    ip = _get_client_ip(request)
+    allowed, remaining = _check_share_rate_limit(ip)
+    if not allowed:
+        headers = _share_rate_limit_headers(0)
+        headers["Retry-After"] = str(settings.share_rate_limit_window_seconds)
+        return JSONResponse(
+            status_code=429,
+            content={
+                "error": "share_rate_limited",
+                "detail": (
+                    f"Too many share requests. Limit is "
+                    f"{settings.share_rate_limit_requests} shares per "
+                    f"{settings.share_rate_limit_window_seconds // 60} minutes."
+                ),
+            },
+            headers=headers,
+        )
 
+    # ── 2. Share-specific payload size cap ────────────────────────────────────
+    if len(payload.code) > settings.share_max_code_chars:
+        raise HTTPException(
+            status_code=status.HTTP_413_REQUEST_ENTITY_TOO_LARGE,
+            detail=f"Code exceeds share limit of {settings.share_max_code_chars} characters.",
+        )
+
+    # ── 3. Ensure tables exist (tests monkeypatch database.engine) ────────────
+    from ..database import Base as _Base
     _Base.metadata.create_all(bind=db.get_bind())
 
+    # ── 4. Generate a unique token ────────────────────────────────────────────
     token = ""
     for _ in range(5):
         candidate = secrets.token_urlsafe(8)
-        exists = db.execute(select(SharedSnippet).where(SharedSnippet.token == candidate)).scalar_one_or_none()
+        exists = db.execute(
+            select(SharedSnippet).where(SharedSnippet.token == candidate)
+        ).scalar_one_or_none()
         if exists is None:
             token = candidate
             break
 
     if not token:
-        raise HTTPException(status_code=status.HTTP_500_INTERNAL_SERVER_ERROR, detail="Could not create share token")
+        raise HTTPException(
+            status_code=status.HTTP_500_INTERNAL_SERVER_ERROR,
+            detail="Could not create share token",
+        )
 
+    # ── 5. Persist ────────────────────────────────────────────────────────────
     record = SharedSnippet(
         token=token,
         code=payload.code,
@@ -40,7 +115,7 @@ def create_share(payload: ShareCreateRequest, db: Session = Depends(get_db)):
     db.commit()
     db.refresh(record)
 
-    return ShareRecord(
+    share_record = ShareRecord(
         id=record.token,
         action=payload.action,
         code=record.code,
@@ -48,24 +123,34 @@ def create_share(payload: ShareCreateRequest, db: Session = Depends(get_db)):
         created_at=record.created_at.isoformat(),
     )
 
+    return JSONResponse(
+        status_code=200,
+        content=share_record.model_dump(),
+        headers=_share_rate_limit_headers(remaining),
+    )
+
 
 @router.get("/{token}", response_model=ShareRecord)
 def get_share(token: str, db: Session = Depends(get_db)):
-    # ensure tables exist (test environment may patch engine)
-    # ensure tables exist on the current DB bind (use the session's bind)
     from ..database import Base as _Base
-
     _Base.metadata.create_all(bind=db.get_bind())
 
-    record = db.execute(select(SharedSnippet).where(SharedSnippet.token == token)).scalar_one_or_none()
-    if record is None:
-        # fallback: try raw SQL in case ORM mapping/env differences hide the record
-        from sqlalchemy import text
-        raw = db.execute(text("SELECT token, code, result_json, created_at FROM shares WHERE token = :t"), {"t": token}).first()
-        if raw is None:
-            raise HTTPException(status_code=status.HTTP_404_NOT_FOUND, detail="Shared result not found or expired")
+    record = db.execute(
+        select(SharedSnippet).where(SharedSnippet.token == token)
+    ).scalar_one_or_none()
 
-        # parse created_at which may be string or datetime
+    if record is None:
+        from sqlalchemy import text
+        raw = db.execute(
+            text("SELECT token, code, result_json, created_at FROM shares WHERE token = :t"),
+            {"t": token},
+        ).first()
+        if raw is None:
+            raise HTTPException(
+                status_code=status.HTTP_404_NOT_FOUND,
+                detail="Shared result not found or expired",
+            )
+
         token_val, code_val, result_json_val, created_at_val = raw
         import datetime as _dt
 
@@ -80,25 +165,39 @@ def get_share(token: str, db: Session = Depends(get_db)):
                     created_at = None
 
         if created_at is None:
-            raise HTTPException(status_code=status.HTTP_404_NOT_FOUND, detail="Shared result not found or expired")
+            raise HTTPException(
+                status_code=status.HTTP_404_NOT_FOUND,
+                detail="Shared result not found or expired",
+            )
 
         if created_at.tzinfo is None:
             created_at = created_at.replace(tzinfo=_dt.timezone.utc)
 
         if created_at < _dt.datetime.now(_dt.timezone.utc) - _dt.timedelta(days=7):
-            raise HTTPException(status_code=status.HTTP_404_NOT_FOUND, detail="Shared result expired")
+            raise HTTPException(
+                status_code=status.HTTP_404_NOT_FOUND,
+                detail="Shared result expired",
+            )
 
-        return ShareRecord(id=token_val, action="share", code=code_val, result=json.loads(result_json_val), created_at=created_at.isoformat())
+        return ShareRecord(
+            id=token_val,
+            action="share",
+            code=code_val,
+            result=json.loads(result_json_val),
+            created_at=created_at.isoformat(),
+        )
 
-    # expire shares older than 7 days — normalize tzinfo if necessary
-    from datetime import datetime, timezone, timedelta
+    from datetime import datetime, timedelta, timezone
 
     created_at = record.created_at
     if created_at.tzinfo is None:
         created_at = created_at.replace(tzinfo=timezone.utc)
 
     if created_at < datetime.now(timezone.utc) - timedelta(days=7):
-        raise HTTPException(status_code=status.HTTP_404_NOT_FOUND, detail="Shared result expired")
+        raise HTTPException(
+            status_code=status.HTTP_404_NOT_FOUND,
+            detail="Shared result expired",
+        )
 
     return ShareRecord(
         id=record.token,

--- a/backend/tests/test_share_rate_limit.py
+++ b/backend/tests/test_share_rate_limit.py
@@ -1,0 +1,217 @@
+from __future__ import annotations
+
+import json
+import time
+from datetime import datetime, timedelta, timezone
+UTC = timezone.utc
+from unittest.mock import patch
+
+import pytest
+from fastapi.testclient import TestClient
+from sqlalchemy import create_engine
+from sqlalchemy.orm import sessionmaker
+
+from app import database
+from app.database import Base
+from app.main import app
+from app.models import SharedSnippet
+
+_VALID_PAYLOAD = {
+    "code": "print('hello')",
+    "result": {"provider": "rule-based", "explanation": {"summary": "ok"}},
+}
+
+
+def _configure_test_db(monkeypatch, tmp_path):
+    db_path = tmp_path / "share-rate-limit-tests.db"
+    engine = create_engine(
+        f"sqlite:///{db_path}", connect_args={"check_same_thread": False}
+    )
+    session_local = sessionmaker(autocommit=False, autoflush=False, bind=engine)
+    monkeypatch.setattr(database, "engine", engine)
+    monkeypatch.setattr(database, "SessionLocal", session_local)
+    Base.metadata.drop_all(bind=engine)
+    Base.metadata.create_all(bind=engine)
+    return session_local
+
+
+def _reset_share_buckets():
+    from app.routers.share import _share_buckets
+    _share_buckets.clear()
+
+
+# ── Header tests ──────────────────────────────────────────────────────────────
+
+def test_success_response_has_ratelimit_headers(monkeypatch, tmp_path):
+    _configure_test_db(monkeypatch, tmp_path)
+    _reset_share_buckets()
+    client = TestClient(app)
+    resp = client.post("/share/", json=_VALID_PAYLOAD)
+    assert resp.status_code == 200
+    assert "X-Share-RateLimit-Limit" in resp.headers
+    assert "X-Share-RateLimit-Remaining" in resp.headers
+    assert "X-Share-RateLimit-Window" in resp.headers
+
+
+def test_remaining_decrements_with_each_request(monkeypatch, tmp_path):
+    _configure_test_db(monkeypatch, tmp_path)
+    _reset_share_buckets()
+    monkeypatch.setattr("app.routers.share.settings.share_rate_limit_requests", 5)
+    client = TestClient(app)
+    remainders = []
+    for _ in range(3):
+        resp = client.post("/share/", json=_VALID_PAYLOAD)
+        assert resp.status_code == 200
+        remainders.append(int(resp.headers["X-Share-RateLimit-Remaining"]))
+    assert remainders == sorted(remainders, reverse=True)
+
+
+# ── Blocking tests ────────────────────────────────────────────────────────────
+
+def test_rate_limit_blocks_after_limit_reached(monkeypatch, tmp_path):
+    _configure_test_db(monkeypatch, tmp_path)
+    _reset_share_buckets()
+    monkeypatch.setattr("app.routers.share.settings.share_rate_limit_requests", 3)
+    monkeypatch.setattr("app.routers.share.settings.share_rate_limit_window_seconds", 3600)
+    client = TestClient(app)
+    for _ in range(3):
+        r = client.post("/share/", json=_VALID_PAYLOAD)
+        assert r.status_code == 200
+    blocked = client.post("/share/", json=_VALID_PAYLOAD)
+    assert blocked.status_code == 429
+
+
+def test_429_response_has_retry_after_header(monkeypatch, tmp_path):
+    _configure_test_db(monkeypatch, tmp_path)
+    _reset_share_buckets()
+    monkeypatch.setattr("app.routers.share.settings.share_rate_limit_requests", 1)
+    monkeypatch.setattr("app.routers.share.settings.share_rate_limit_window_seconds", 3600)
+    client = TestClient(app)
+    client.post("/share/", json=_VALID_PAYLOAD)
+    blocked = client.post("/share/", json=_VALID_PAYLOAD)
+    assert blocked.status_code == 429
+    assert "Retry-After" in blocked.headers
+    assert int(blocked.headers["Retry-After"]) == 3600
+
+
+def test_429_response_body_has_error_key(monkeypatch, tmp_path):
+    _configure_test_db(monkeypatch, tmp_path)
+    _reset_share_buckets()
+    monkeypatch.setattr("app.routers.share.settings.share_rate_limit_requests", 1)
+    client = TestClient(app)
+    client.post("/share/", json=_VALID_PAYLOAD)
+    blocked = client.post("/share/", json=_VALID_PAYLOAD)
+    body = blocked.json()
+    assert body.get("error") == "share_rate_limited"
+    assert "detail" in body
+
+
+# ── Isolation tests ───────────────────────────────────────────────────────────
+
+def test_different_ips_have_independent_buckets(monkeypatch, tmp_path):
+    _configure_test_db(monkeypatch, tmp_path)
+    _reset_share_buckets()
+    monkeypatch.setattr("app.routers.share.settings.share_rate_limit_requests", 2)
+    client = TestClient(app)
+    for _ in range(2):
+        r = client.post("/share/", json=_VALID_PAYLOAD, headers={"X-Forwarded-For": "1.2.3.4"})
+        assert r.status_code == 200
+    blocked = client.post("/share/", json=_VALID_PAYLOAD, headers={"X-Forwarded-For": "1.2.3.4"})
+    assert blocked.status_code == 429
+    allowed = client.post("/share/", json=_VALID_PAYLOAD, headers={"X-Forwarded-For": "9.9.9.9"})
+    assert allowed.status_code == 200
+
+
+# ── Window expiry test ────────────────────────────────────────────────────────
+
+def test_rate_limit_resets_after_window(monkeypatch, tmp_path):
+    _configure_test_db(monkeypatch, tmp_path)
+    _reset_share_buckets()
+    monkeypatch.setattr("app.routers.share.settings.share_rate_limit_requests", 2)
+    monkeypatch.setattr("app.routers.share.settings.share_rate_limit_window_seconds", 60)
+    client = TestClient(app)
+    for _ in range(2):
+        client.post("/share/", json=_VALID_PAYLOAD)
+    blocked = client.post("/share/", json=_VALID_PAYLOAD)
+    assert blocked.status_code == 429
+    future = time.time() + 61
+    with patch("app.routers.share.time.time", return_value=future):
+        allowed = client.post("/share/", json=_VALID_PAYLOAD)
+    assert allowed.status_code == 200
+
+
+# ── Payload size tests ────────────────────────────────────────────────────────
+
+def test_oversized_code_rejected(monkeypatch, tmp_path):
+    _configure_test_db(monkeypatch, tmp_path)
+    _reset_share_buckets()
+    monkeypatch.setattr("app.routers.share.settings.share_max_code_chars", 50)
+    client = TestClient(app)
+    resp = client.post("/share/", json={"code": "x" * 51, "result": {"provider": "rule-based", "explanation": {"summary": "ok"}}})
+    assert resp.status_code == 413
+
+
+def test_code_at_limit_accepted(monkeypatch, tmp_path):
+    _configure_test_db(monkeypatch, tmp_path)
+    _reset_share_buckets()
+    monkeypatch.setattr("app.routers.share.settings.share_max_code_chars", 50)
+    client = TestClient(app)
+    resp = client.post("/share/", json={"code": "x" * 50, "result": {"provider": "rule-based", "explanation": {"summary": "ok"}}})
+    assert resp.status_code == 200
+
+
+# ── GET not rate limited ──────────────────────────────────────────────────────
+
+def test_get_share_not_blocked_by_rate_limit(monkeypatch, tmp_path):
+    session_local = _configure_test_db(monkeypatch, tmp_path)
+    _reset_share_buckets()
+    db = session_local()
+    record = SharedSnippet(
+        token="readtest1",
+        code="print('hi')",
+        result_json=json.dumps({"provider": "rule-based", "explanation": {"summary": "hi"}}),
+        created_at=datetime.now(UTC),
+    )
+    db.add(record)
+    db.commit()
+    db.close()
+    monkeypatch.setattr("app.routers.share.settings.share_rate_limit_requests", 1)
+    client = TestClient(app)
+    client.post("/share/", json=_VALID_PAYLOAD)
+    resp = client.get("/share/readtest1")
+    assert resp.status_code == 200
+
+
+# ── Regression: existing behaviour unchanged ──────────────────────────────────
+
+def test_create_and_fetch_share(monkeypatch, tmp_path):
+    _configure_test_db(monkeypatch, tmp_path)
+    _reset_share_buckets()
+    client = TestClient(app)
+    create_resp = client.post("/share/", json=_VALID_PAYLOAD)
+    assert create_resp.status_code == 200
+    share_id = create_resp.json()["id"]
+    fetch_resp = client.get(f"/share/{share_id}")
+    assert fetch_resp.status_code == 200
+    data = fetch_resp.json()
+    assert data["id"] == share_id
+    assert data["code"] == _VALID_PAYLOAD["code"]
+
+
+def test_expired_share_returns_404(monkeypatch, tmp_path):
+    session_local = _configure_test_db(monkeypatch, tmp_path)
+    _reset_share_buckets()
+    db = session_local()
+    record = SharedSnippet(
+        token="expired456",
+        code="print('old')",
+        result_json='{"ok": true}',
+        created_at=datetime.now(UTC) - timedelta(days=8),
+    )
+    db.add(record)
+    db.commit()
+    db.close()
+    client = TestClient(app)
+    resp = client.get("/share/expired456")
+    assert resp.status_code == 404
+    assert "expired" in resp.json()["detail"].lower()


### PR DESCRIPTION
## Description
Adds server-side abuse protection to the public `POST /share/` endpoint by implementing a per-IP sliding-window rate limiter and a share-specific payload size cap. Authenticated and read (`GET`) paths are unaffected.

## Related Issue
Fixes #645

## Type of change
- [ ] Bug fix
- [x] New feature / enhancement
- [ ] Documentation update
- [x] Test addition
- [ ] Refactor

## Checklist
- [x] I have read [CONTRIBUTING.md](../CONTRIBUTING.md)
- [x] My branch is up to date with `main`
- [x] I have run `pytest -v` and all tests pass
- [x] I have not introduced duplicate issues or features
- [x] My PR title follows the format: `feat/fix/docs/test: short description`
- [x] I have added tests for new features (Level 2 and 3 issues)
- [x] No hardcoded secrets or API keys in my code
- [x] This PR is linked to a GSSoC 2026 issue

## Screenshots (if frontend change)
N/A — backend only change.

## Test evidence
```bash
python -m pytest tests/test_share.py tests/test_share_rate_limit.py -v

collected 14 items

tests/test_share.py::test_create_and_fetch_share PASSED
tests/test_share.py::test_expired_share_returns_404 PASSED
tests/test_share_rate_limit.py::test_success_response_has_ratelimit_headers PASSED
tests/test_share_rate_limit.py::test_remaining_decrements_with_each_request PASSED
tests/test_share_rate_limit.py::test_rate_limit_blocks_after_limit_reached PASSED
tests/test_share_rate_limit.py::test_429_response_has_retry_after_header PASSED
tests/test_share_rate_limit.py::test_429_response_body_has_error_key PASSED
tests/test_share_rate_limit.py::test_different_ips_have_independent_buckets PASSED
tests/test_share_rate_limit.py::test_rate_limit_resets_after_window PASSED
tests/test_share_rate_limit.py::test_oversized_code_rejected PASSED
tests/test_share_rate_limit.py::test_code_at_limit_accepted PASSED
tests/test_share_rate_limit.py::test_get_share_not_blocked_by_rate_limit PASSED
tests/test_share_rate_limit.py::test_create_and_fetch_share PASSED
tests/test_share_rate_limit.py::test_expired_share_returns_404 PASSED

14 passed in 3.2s
```