### PR TITLE
feat: Add Clear Code button with toast notification to reset input area

### DIFF
--- a/frontend/index.html
+++ b/frontend/index.html
@@ -3324,6 +3324,7 @@
         editor.value = '';
         updateEditor();
         resetResults();
+        toast('Code cleared!', 'info');
       });
       document.getElementById('copyBtn').addEventListener('click', () => {
         if (!editor.value.trim()) return;


### PR DESCRIPTION
Description
Added a toast notification to the existing Clear Code button so users get visual feedback when the input area and results are cleared.

Related Issue
Fixes #734 

Type of change
- [x] New feature / enhancement

Checklist
- [x] I have read [CONTRIBUTING.md](../CONTRIBUTING.md)
- [x] My branch is up to date with `main`
- [x] I have not introduced duplicate issues or features
- [x] My PR title follows the format: `feat/fix/docs/test: short description`
- [x] No hardcoded secrets or API keys in my code
- [x] This PR is linked to a GSSoC 2026 issue

Screenshots (if frontend change)
<img width="1920" height="1020" alt="image" src="https://github.com/user-attachments/assets/28ca015e-4814-42e8-93d4-7238d867eb3f" />

<img width="1920" height="1047" alt="image" src="https://github.com/user-attachments/assets/4a780a5c-5302-45ab-a99e-af1c0dcb49b5" />



Test evidence
This is a frontend-only change with no backend logic. No pytest tests required for this change.
