### PR TITLE
feat: add thumbnail generation for shared analysis results

### DIFF
--- a/README.md
+++ b/README.md
@@ -69,6 +69,7 @@ No account required. No API key needed. Works fully offline. Fully open source.
 | **Rate Limiting** | 30 requests/minute per IP - configurable |
 | **Swagger Docs** | Interactive API docs at `/docs` |
 | **Gzip Compression** | Automatic response compression |
+| **Thumbnail Previews** | Auto-generated thumbnails for shared analysis results |
 
 ### Languages and patterns
 

--- a/backend/app/routers/share.py
+++ b/backend/app/routers/share.py
@@ -8,16 +8,14 @@ from sqlalchemy.orm import Session
 from ..database import get_db
 from ..models import SharedSnippet
 from ..schemas import ShareCreateRequest, ShareRecord
+from ..services.thumbnail import generate_thumbnail
 
 router = APIRouter(prefix="/share", tags=["Share"])
 
 
 @router.post("/", response_model=ShareRecord)
 def create_share(payload: ShareCreateRequest, db: Session = Depends(get_db)):
-    # ensure tables exist on the engine (tests monkeypatch `database.engine`)
-    # ensure tables exist on the current DB bind (use the session's bind)
     from ..database import Base as _Base
-
     _Base.metadata.create_all(bind=db.get_bind())
 
     token = ""
@@ -31,10 +29,14 @@ def create_share(payload: ShareCreateRequest, db: Session = Depends(get_db)):
     if not token:
         raise HTTPException(status_code=status.HTTP_500_INTERNAL_SERVER_ERROR, detail="Could not create share token")
 
+    # ← generate thumbnail from first image if provided
+    thumbnail = generate_thumbnail(payload.images[0]) if payload.images else None
+
     record = SharedSnippet(
         token=token,
         code=payload.code,
         result_json=json.dumps(payload.result),
+        thumbnail=thumbnail,   
     )
     db.add(record)
     db.commit()
@@ -46,6 +48,7 @@ def create_share(payload: ShareCreateRequest, db: Session = Depends(get_db)):
         code=record.code,
         result=json.loads(record.result_json),
         created_at=record.created_at.isoformat(),
+        thumbnail=record.thumbnail,  
     )
 
 

--- a/backend/app/schemas.py
+++ b/backend/app/schemas.py
@@ -245,6 +245,7 @@ class ShareCreateRequest(BaseModel):
     code: str = Field(..., min_length=1, max_length=settings.max_code_chars)
     result: dict[str, Any] | None = Field(default=None)
     result_json: str | None = Field(default=None)
+    images: list[str] = Field(default_factory=list) 
 
     @field_validator("action")
     @classmethod
@@ -287,7 +288,7 @@ class ShareRecord(BaseModel):
     code: str
     result: dict[str, Any]
     created_at: str
-
+    thumbnail: str | None = None
 
 # ── Chat ──────────────────────────────────────────────────────────────────────
 class ChatRequest(BaseModel):

--- a/backend/app/services/thumbnail.py
+++ b/backend/app/services/thumbnail.py
@@ -1,0 +1,49 @@
+# backend/app/services/thumbnail.py
+import base64
+import io
+import re
+from typing import Optional
+
+try:
+    from PIL import Image
+    PIL_AVAILABLE = True
+except ImportError:
+    PIL_AVAILABLE = False
+
+THUMB_SIZE = (320, 180)   # 16:9, suitable for list-view cards
+THUMB_FORMAT = "WEBP"     # best size/quality ratio; fall back to JPEG
+THUMB_QUALITY = 72
+
+
+def _b64_to_pil(data_url: str) -> Optional[Image.Image]:
+    """Convert a data URL or raw base64 PNG/JPEG to a Pillow Image."""
+    match = re.match(r"data:image/[^;]+;base64,(.+)", data_url)
+    raw = match.group(1) if match else data_url
+    try:
+        return Image.open(io.BytesIO(base64.b64decode(raw)))
+    except Exception:
+        return None
+
+
+def generate_thumbnail(image_b64: str) -> Optional[str]:
+    """
+    Downscale an embedded image to THUMB_SIZE.
+    Returns a WebP data-URL string, or None on failure.
+    """
+    if not PIL_AVAILABLE:
+        return None
+    img = _b64_to_pil(image_b64)
+    if img is None:
+        return None
+    img.thumbnail(THUMB_SIZE, Image.LANCZOS)
+    buf = io.BytesIO()
+    fmt = THUMB_FORMAT
+    try:
+        img.save(buf, format=fmt, quality=THUMB_QUALITY)
+    except Exception:
+        fmt = "JPEG"
+        img = img.convert("RGB")
+        img.save(buf, format=fmt, quality=THUMB_QUALITY)
+    encoded = base64.b64encode(buf.getvalue()).decode()
+    mime = "image/webp" if fmt == "WEBP" else "image/jpeg"
+    return f"data:{mime};base64,{encoded}"

--- a/backend/requirements.txt
+++ b/backend/requirements.txt
@@ -13,3 +13,4 @@ apscheduler>=3.10.0
 python-magic-bin>=0.4.14; platform_system == "Windows"
 python-magic>=0.4.27; platform_system != "Windows"
 prometheus-client>=0.20.0
+Pillow>=10.0.0

--- a/backend/tests/test_thumbnail.py
+++ b/backend/tests/test_thumbnail.py
@@ -1,0 +1,7 @@
+from app.services.thumbnail import generate_thumbnail
+
+def test_generate_thumbnail_returns_none_for_invalid_input():
+    assert generate_thumbnail("not_valid_base64") is None
+
+def test_generate_thumbnail_returns_none_for_empty_string():
+    assert generate_thumbnail("") is None

--- a/frontend/index.html
+++ b/frontend/index.html
@@ -4024,7 +4024,7 @@
           historyList.innerHTML = `<div class="list-empty" data-i18n="empty_history">${getTranslation('empty_history')}</div>`;
           return;
         }
-        hhistoryList.innerHTML = history.map(h => `
+        historyList.innerHTML = history.map(h => `
     <div class="history-item" onclick="loadEntry('${h.id}')" tabindex="0" role="button" aria-label="${getTranslation('history_entry_label').replace('{lang}', h.lang || '?').replace('{time}', h.ts)}" onkeydown="if(event.key==='Enter'||event.key===' ') { event.preventDefault(); loadEntry('${h.id}'); }">
       ${h.thumbnail ? `<img src="${h.thumbnail}" alt="preview" style="width:56px;height:32px;object-fit:cover;border-radius:4px;flex-shrink:0;">` : ''}
       <span class="history-lang">${h.lang || '?'}</span>

--- a/frontend/index.html
+++ b/frontend/index.html
@@ -3425,9 +3425,16 @@
           const { response: res, baseUsed, fallbackUsed } = await fetchWithApiFallback(base, endpoint, {
             method: 'POST',
             headers: { 'Content-Type': 'application/json' },
-            body: JSON.stringify({ code, language: selectedLang }),
-            signal: AbortSignal.timeout(30000),
-          });
+            body: JSON.stringify({
+              code,
+              language: selectedLang,
+              images: [...document.querySelectorAll('#explainResult img, #debugResult img, #suggestResult img')]
+               .map(img => img.src)
+               .filter(src => src.startsWith('data:image')),
+              }),
+                  signal: AbortSignal.timeout(30000),
+  });
+          
           if (fallbackUsed) {
             persistApiBase(baseUsed);
           }
@@ -4004,6 +4011,7 @@
           lang,
           ts: new Date().toLocaleTimeString(),
           preview: code.slice(0, 60).replace(/\n/g, ' '),
+          thumbnail: result.thumbnail || null,
         };
         history.unshift(entry);
         if (history.length > MAX_HISTORY) history = history.slice(0, MAX_HISTORY);
@@ -4016,8 +4024,9 @@
           historyList.innerHTML = `<div class="list-empty" data-i18n="empty_history">${getTranslation('empty_history')}</div>`;
           return;
         }
-        historyList.innerHTML = history.map(h => `
+        hhistoryList.innerHTML = history.map(h => `
     <div class="history-item" onclick="loadEntry('${h.id}')" tabindex="0" role="button" aria-label="${getTranslation('history_entry_label').replace('{lang}', h.lang || '?').replace('{time}', h.ts)}" onkeydown="if(event.key==='Enter'||event.key===' ') { event.preventDefault(); loadEntry('${h.id}'); }">
+      ${h.thumbnail ? `<img src="${h.thumbnail}" alt="preview" style="width:56px;height:32px;object-fit:cover;border-radius:4px;flex-shrink:0;">` : ''}
       <span class="history-lang">${h.lang || '?'}</span>
       <span class="history-thumb">${escHtml(h.preview)}…</span>
       <span class="history-meta">${h.ts}</span>


### PR DESCRIPTION
Implements a thumbnail generation pipeline for shared analyses. When a user shares an analysis result that contains embedded images, a small preview thumbnail is automatically generated and stored alongside the share record. Thumbnails are displayed in the query history list view for quick visual identification.

Shared analyses containing images had no preview, making list views and sharing previews unhelpful. This addresses the issue by adding a server-side image processing pipeline using Pillow to downscale embedded images into lightweight WebP thumbnails.

**Changes made:**
- `backend/app/services/thumbnail.py` — new Pillow-based image downscaler (320×180 WebP)
- `backend/requirements.txt` — added `Pillow>=10.0.0`
- `backend/app/schemas.py` — added `images` field to `ShareCreateRequest`, `thumbnail` field to `ShareRecord`
- `backend/app/models.py` — added nullable `thumbnail` column to `SharedSnippet`
- `backend/app/routers/share.py` — calls `generate_thumbnail` on share creation, stores and returns result
- `frontend/index.html` — collects embedded images on share, saves thumbnail to history, displays thumbnail in history list
- `backend/tests/test_thumbnail.py` — basic tests for the thumbnail service

**Screenshots**
<img width="1440" height="633" alt="Screenshot 2026-06-08 at 11 58 23 AM" src="https://github.com/user-attachments/assets/62346542-6727-4d6b-b6f3-2c6a6e825f19" />

<img width="1440" height="531" alt="Screenshot 2026-06-08 at 11 58 31 AM" src="https://github.com/user-attachments/assets/4937a7e9-59af-4fca-9222-ec5a217087fc" />



<img width="1204" height="180" alt="Screenshot 2026-06-08 at 11 50 21 AM" src="https://github.com/user-attachments/assets/25d1c335-1882-44da-bbc0-a8ea680fadd1" />




