### PR TITLE
fix(history): require auth and scope entries per user

### DIFF
--- a/backend/app/routers/history.py
+++ b/backend/app/routers/history.py
@@ -3,9 +3,11 @@ History router — save, retrieve, search and delete analysis history entries.
 """
 
 from __future__ import annotations
-from fastapi import APIRouter, HTTPException, Query
+from fastapi import APIRouter, Depends, HTTPException, Query
 from pydantic import BaseModel, Field
 
+from ..models import User
+from ..security import get_current_user
 from ..services import database
 
 router = APIRouter()
@@ -29,8 +31,12 @@ class HistoryEntry(BaseModel):
 
 
 @router.post("/", response_model=dict, status_code=201)
-async def save_history(body: HistorySaveRequest):
+async def save_history(
+    body: HistorySaveRequest,
+    current_user: User = Depends(get_current_user),
+):
     entry_id = await database.save_entry(
+        user_id=current_user.id,
         code=body.code,
         language=body.language,
         score=body.score,
@@ -43,21 +49,34 @@ async def save_history(body: HistorySaveRequest):
 async def get_history(
     limit: int = Query(20, ge=1, le=100),
     offset: int = Query(0, ge=0),
+    current_user: User = Depends(get_current_user),
 ):
-    return await database.get_entries(limit=limit, offset=offset)
+    return await database.get_entries(
+        user_id=current_user.id,
+        limit=limit,
+        offset=offset,
+    )
 
 
 @router.get("/search", response_model=list[HistoryEntry])
 async def search_history(
     q: str = Query(..., min_length=1),
     limit: int = Query(20, ge=1, le=100),
+    current_user: User = Depends(get_current_user),
 ):
-    return await database.search_entries(q=q, limit=limit)
+    return await database.search_entries(
+        user_id=current_user.id,
+        q=q,
+        limit=limit,
+    )
 
 
 @router.delete("/{entry_id}", response_model=dict)
-async def delete_history(entry_id: int):
-    deleted = await database.delete_entry(entry_id)
+async def delete_history(
+    entry_id: int,
+    current_user: User = Depends(get_current_user),
+):
+    deleted = await database.delete_entry(entry_id, user_id=current_user.id)
     if not deleted:
         raise HTTPException(status_code=404, detail="History entry not found.")
     return {"id": entry_id, "status": "deleted"}

--- a/backend/app/services/database.py
+++ b/backend/app/services/database.py
@@ -16,6 +16,7 @@ async def init_db() -> None:
         await db.execute("""
             CREATE TABLE IF NOT EXISTS history (
                 id          INTEGER PRIMARY KEY AUTOINCREMENT,
+                user_id     INTEGER,
                 code_hash   TEXT NOT NULL,
                 language    TEXT NOT NULL,
                 score       INTEGER,
@@ -28,8 +29,16 @@ async def init_db() -> None:
             CREATE VIRTUAL TABLE IF NOT EXISTS fts_history
             USING fts5(code_preview, content=history, content_rowid=id)
         """)
+        columns = await db.execute("PRAGMA table_info(history)")
+        column_names = {row[1] for row in await columns.fetchall()}
+        if "user_id" not in column_names:
+            await db.execute("ALTER TABLE history ADD COLUMN user_id INTEGER")
         await db.execute(
             "CREATE INDEX IF NOT EXISTS idx_timestamp ON history(timestamp DESC)"
+        )
+        await db.execute(
+            "CREATE INDEX IF NOT EXISTS idx_history_user_timestamp "
+            "ON history(user_id, timestamp DESC)"
         )
         await db.commit()
 
@@ -39,6 +48,7 @@ def hash_code(code: str) -> str:
 
 
 async def save_entry(
+    user_id: int,
     code: str,
     language: str,
     score: int | None,
@@ -49,10 +59,12 @@ async def save_entry(
     async with aiosqlite.connect(DB_PATH) as db:
         cursor = await db.execute(
             """
-            INSERT INTO history (code_hash, language, score, issue_count, code_preview)
-            VALUES (?, ?, ?, ?, ?)
+            INSERT INTO history (
+                user_id, code_hash, language, score, issue_count, code_preview
+            )
+            VALUES (?, ?, ?, ?, ?, ?)
             """,
-            (code_hash, language, score, issue_count, preview),
+            (user_id, code_hash, language, score, issue_count, preview),
         )
         row_id = cursor.lastrowid
         await db.execute(
@@ -63,23 +75,24 @@ async def save_entry(
         return row_id
 
 
-async def get_entries(limit: int = 20, offset: int = 0) -> list[dict]:
+async def get_entries(user_id: int, limit: int = 20, offset: int = 0) -> list[dict]:
     async with aiosqlite.connect(DB_PATH) as db:
         db.row_factory = aiosqlite.Row
         cursor = await db.execute(
             """
             SELECT id, code_hash, language, score, issue_count, timestamp, code_preview
             FROM history
+            WHERE user_id = ?
             ORDER BY timestamp DESC
             LIMIT ? OFFSET ?
             """,
-            (limit, offset),
+            (user_id, limit, offset),
         )
         rows = await cursor.fetchall()
         return [dict(row) for row in rows]
 
 
-async def search_entries(q: str, limit: int = 20) -> list[dict]:
+async def search_entries(user_id: int, q: str, limit: int = 20) -> list[dict]:
     async with aiosqlite.connect(DB_PATH) as db:
         db.row_factory = aiosqlite.Row
         cursor = await db.execute(
@@ -87,25 +100,27 @@ async def search_entries(q: str, limit: int = 20) -> list[dict]:
             SELECT h.id, h.code_hash, h.language, h.score,
                    h.issue_count, h.timestamp, h.code_preview
             FROM history h
-            WHERE h.id IN (
+            WHERE h.user_id = ?
+              AND h.id IN (
                 SELECT rowid FROM fts_history WHERE fts_history MATCH ?
             )
             ORDER BY h.timestamp DESC
             LIMIT ?
             """,
-            (q, limit),
+            (user_id, q, limit),
         )
         rows = await cursor.fetchall()
         return [dict(row) for row in rows]
 
 
-async def delete_entry(entry_id: int) -> bool:
+async def delete_entry(entry_id: int, user_id: int) -> bool:
     async with aiosqlite.connect(DB_PATH) as db:
         cursor = await db.execute(
-            "DELETE FROM history WHERE id = ?", (entry_id,)
+            "DELETE FROM history WHERE id = ? AND user_id = ?", (entry_id, user_id)
         )
-        await db.execute(
-            "DELETE FROM fts_history WHERE rowid = ?", (entry_id,)
-        )
+        if cursor.rowcount > 0:
+            await db.execute(
+                "DELETE FROM fts_history WHERE rowid = ?", (entry_id,)
+            )
         await db.commit()
         return cursor.rowcount > 0

--- a/backend/tests/test_history.py
+++ b/backend/tests/test_history.py
@@ -8,9 +8,15 @@ import asyncio
 
 sys.path.insert(0, os.path.dirname(os.path.dirname(__file__)))
 
+import pytest
+from sqlalchemy import create_engine
+from sqlalchemy.orm import sessionmaker
+from sqlalchemy.pool import StaticPool
+
+from app.database import Base, get_db
+from app.main import app
 from app.services import database
 from fastapi.testclient import TestClient
-from app.main import app
 
 _tmp = tempfile.NamedTemporaryFile(suffix=".db", delete=False)
 _tmp.close()
@@ -18,60 +24,138 @@ database.DB_PATH = _tmp.name
 
 asyncio.run(database.init_db())
 
-client = TestClient(app, raise_server_exceptions=True)
+TEST_ENGINE = create_engine(
+    "sqlite:///:memory:",
+    connect_args={"check_same_thread": False},
+    poolclass=StaticPool,
+)
+TEST_SESSION_LOCAL = sessionmaker(bind=TEST_ENGINE)
 
 
-def test_save_history():
+def _override_db():
+    db = TEST_SESSION_LOCAL()
+    try:
+        yield db
+    finally:
+        db.close()
+
+
+@pytest.fixture
+def client():
+    previous_override = app.dependency_overrides.get(get_db)
+    app.dependency_overrides[get_db] = _override_db
+    with TestClient(app, raise_server_exceptions=True) as test_client:
+        yield test_client
+    if previous_override is None:
+        app.dependency_overrides.pop(get_db, None)
+    else:
+        app.dependency_overrides[get_db] = previous_override
+
+
+@pytest.fixture(autouse=True)
+def _reset_databases():
+    Base.metadata.create_all(bind=TEST_ENGINE)
+    if os.path.exists(database.DB_PATH):
+        os.remove(database.DB_PATH)
+    asyncio.run(database.init_db())
+    yield
+    Base.metadata.drop_all(bind=TEST_ENGINE)
+
+
+def auth_headers(client: TestClient, email: str = "history.user@example.com") -> dict[str, str]:
+    response = client.post(
+        "/auth/signup",
+        json={"email": email, "password": "StrongPass123!"},
+    )
+    assert response.status_code == 200
+    token = response.json()["access_token"]
+    return {"Authorization": f"Bearer {token}"}
+
+
+def test_history_requires_authentication(client):
+    assert client.get("/history/").status_code == 401
+    assert client.get("/history/search?q=print").status_code == 401
+    assert client.post(
+        "/history/",
+        json={"code": "print('hello')", "language": "Python"},
+    ).status_code == 401
+    assert client.delete("/history/1").status_code == 401
+
+
+def test_save_history(client):
+    headers = auth_headers(client)
     r = client.post("/history/", json={
         "code": "print('hello')",
         "language": "Python",
         "score": 85,
         "issue_count": 1,
-    })
+    }, headers=headers)
     assert r.status_code == 201
     d = r.json()
     assert d["status"] == "saved"
     assert "id" in d
 
 
-def test_get_history():
-    client.post("/history/", json={"code": "x = 1", "language": "Python", "score": 90, "issue_count": 0})
-    r = client.get("/history/")
+def test_get_history(client):
+    headers = auth_headers(client)
+    client.post(
+        "/history/",
+        json={"code": "x = 1", "language": "Python", "score": 90, "issue_count": 0},
+        headers=headers,
+    )
+    r = client.get("/history/", headers=headers)
     assert r.status_code == 200
     assert isinstance(r.json(), list)
     assert len(r.json()) > 0
 
 
-def test_get_history_pagination():
-    r = client.get("/history/?limit=1&offset=0")
+def test_get_history_pagination(client):
+    headers = auth_headers(client)
+    r = client.get("/history/?limit=1&offset=0", headers=headers)
     assert r.status_code == 200
     assert len(r.json()) <= 1
 
 
-def test_search_history():
-    client.post("/history/", json={"code": "def my_unique_function(): pass", "language": "Python"})
-    r = client.get("/history/search?q=my_unique_function")
+def test_search_history(client):
+    headers = auth_headers(client)
+    client.post(
+        "/history/",
+        json={"code": "def my_unique_function(): pass", "language": "Python"},
+        headers=headers,
+    )
+    r = client.get("/history/search?q=my_unique_function", headers=headers)
     assert r.status_code == 200
     results = r.json()
     assert any("my_unique_function" in e["code_preview"] for e in results)
 
 
-def test_delete_history():
-    r = client.post("/history/", json={"code": "to be deleted", "language": "Python"})
+def test_delete_history(client):
+    headers = auth_headers(client)
+    r = client.post(
+        "/history/",
+        json={"code": "to be deleted", "language": "Python"},
+        headers=headers,
+    )
     entry_id = r.json()["id"]
-    r = client.delete(f"/history/{entry_id}")
+    r = client.delete(f"/history/{entry_id}", headers=headers)
     assert r.status_code == 200
     assert r.json()["status"] == "deleted"
 
 
-def test_delete_nonexistent():
-    r = client.delete("/history/999999")
+def test_delete_nonexistent(client):
+    headers = auth_headers(client)
+    r = client.delete("/history/999999", headers=headers)
     assert r.status_code == 404
 
 
-def test_history_entry_fields():
-    client.post("/history/", json={"code": "let x = 1;", "language": "JavaScript", "score": 70, "issue_count": 2})
-    r = client.get("/history/")
+def test_history_entry_fields(client):
+    headers = auth_headers(client)
+    client.post(
+        "/history/",
+        json={"code": "let x = 1;", "language": "JavaScript", "score": 70, "issue_count": 2},
+        headers=headers,
+    )
+    r = client.get("/history/", headers=headers)
     assert r.status_code == 200
     entry = r.json()[0]
     assert "id" in entry
@@ -83,7 +167,42 @@ def test_history_entry_fields():
     assert "code_preview" in entry
 
 
-def test_search_no_results():
-    r = client.get("/history/search?q=xyznotfoundever")
+def test_search_no_results(client):
+    headers = auth_headers(client)
+    r = client.get("/history/search?q=xyznotfoundever", headers=headers)
     assert r.status_code == 200
     assert r.json() == []
+
+
+def test_history_entries_are_scoped_per_user(client):
+    alice_headers = auth_headers(client, "alice@example.com")
+    bob_headers = auth_headers(client, "bob@example.com")
+
+    alice_save = client.post(
+        "/history/",
+        json={"code": "print('alice_secret')", "language": "Python"},
+        headers=alice_headers,
+    )
+    assert alice_save.status_code == 201
+    alice_entry_id = alice_save.json()["id"]
+
+    bob_save = client.post(
+        "/history/",
+        json={"code": "print('bob_secret')", "language": "Python"},
+        headers=bob_headers,
+    )
+    assert bob_save.status_code == 201
+
+    bob_history = client.get("/history/", headers=bob_headers)
+    assert bob_history.status_code == 200
+    assert all("alice_secret" not in entry["code_preview"] for entry in bob_history.json())
+
+    bob_search = client.get("/history/search?q=alice_secret", headers=bob_headers)
+    assert bob_search.status_code == 200
+    assert bob_search.json() == []
+
+    bob_delete = client.delete(f"/history/{alice_entry_id}", headers=bob_headers)
+    assert bob_delete.status_code == 404
+
+    alice_history = client.get("/history/", headers=alice_headers)
+    assert any("alice_secret" in entry["code_preview"] for entry in alice_history.json())


### PR DESCRIPTION
## Summary\n- require JWT authentication on the legacy /history routes\n- persist user_id on flat-file history rows and migrate existing SQLite files safely\n- filter list/search/delete operations by the authenticated user\n- add regression coverage for unauthenticated access and cross-user read/search/delete isolation\n\nFixes #952\n\n## Validation\n- uv run --with-requirements backend/requirements.txt python -m py_compile backend/app/routers/history.py backend/app/services/database.py backend/tests/test_history.py\n- direct async SQLite smoke test for save/list/search/delete user isolation\n- uv run --with-requirements backend/requirements.txt python -m pytest backend/tests/test_history.py -q (blocked locally during collection by missing system libmagic imported by upload_file.py)\n- uv run --with-requirements backend/requirements.txt python -m pytest backend/tests/test_auth_endpoints.py -q (same local libmagic blocker)