### PR TITLE
feat(auth): add password change endpoint

### DIFF
--- a/backend/app/routers/auth.py
+++ b/backend/app/routers/auth.py
@@ -4,7 +4,13 @@ from sqlalchemy.orm import Session
 
 from ..database import get_db
 from ..models import User
-from ..schemas import AuthResponse, LoginRequest, SignupRequest, UserProfileResponse
+from ..schemas import (
+    AuthResponse,
+    LoginRequest,
+    PasswordChangeRequest,
+    SignupRequest,
+    UserProfileResponse,
+)
 from ..security import (
     create_access_token,
     get_current_user,
@@ -54,3 +60,19 @@ def login(payload: LoginRequest, db: Session = Depends(get_db)):
 @router.get("/me", response_model=UserProfileResponse)
 def me(current_user: User = Depends(get_current_user)):
     return UserProfileResponse(user_id=current_user.id, email=current_user.email)
+
+
+@router.patch("/password", status_code=status.HTTP_204_NO_CONTENT)
+def change_password(
+    payload: PasswordChangeRequest,
+    current_user: User = Depends(get_current_user),
+    db: Session = Depends(get_db),
+):
+    if not verify_password(payload.current_password, current_user.password_hash):
+        raise HTTPException(
+            status_code=status.HTTP_400_BAD_REQUEST,
+            detail="Current password is incorrect",
+        )
+
+    current_user.password_hash = hash_password(payload.new_password)
+    db.commit()

--- a/backend/app/schemas.py
+++ b/backend/app/schemas.py
@@ -126,6 +126,13 @@ class LoginRequest(BaseModel):
     password: str = Field(..., min_length=8, max_length=128)
 
 
+class PasswordChangeRequest(BaseModel):
+    """Request body for rotating the current user's password."""
+
+    current_password: str = Field(..., min_length=8, max_length=128)
+    new_password: str = Field(..., min_length=8, max_length=128)
+
+
 class AuthResponse(BaseModel):
     """Response returned after successful authentication.
 

--- a/backend/tests/test_auth_endpoints.py
+++ b/backend/tests/test_auth_endpoints.py
@@ -58,6 +58,7 @@ def test_auth_routes_are_exposed_in_openapi(client):
     assert "/auth/signup" in paths
     assert "/auth/login" in paths
     assert "/auth/me" in paths
+    assert "/auth/password" in paths
 
 
 def test_signup_login_and_me_happy_path(client):
@@ -111,3 +112,73 @@ def test_me_rejects_missing_and_invalid_token(client):
     )
     assert invalid_token_response.status_code == 401
     assert "invalid token" in invalid_token_response.json()["detail"].lower()
+
+
+def test_authenticated_user_can_change_password(client):
+    signup_response = client.post(
+        "/auth/signup",
+        json={"email": "rotate@example.com", "password": "OldPass123!"},
+    )
+    assert signup_response.status_code == 200
+    token = signup_response.json()["access_token"]
+
+    change_response = client.patch(
+        "/auth/password",
+        json={
+            "current_password": "OldPass123!",
+            "new_password": "NewPass123!",
+        },
+        headers={"Authorization": f"Bearer {token}"},
+    )
+    assert change_response.status_code == 204
+    assert change_response.content == b""
+
+    old_login_response = client.post(
+        "/auth/login",
+        json={"email": "rotate@example.com", "password": "OldPass123!"},
+    )
+    assert old_login_response.status_code == 401
+
+    new_login_response = client.post(
+        "/auth/login",
+        json={"email": "rotate@example.com", "password": "NewPass123!"},
+    )
+    assert new_login_response.status_code == 200
+
+
+def test_change_password_rejects_incorrect_current_password(client):
+    signup_response = client.post(
+        "/auth/signup",
+        json={"email": "wrong-current@example.com", "password": "OldPass123!"},
+    )
+    assert signup_response.status_code == 200
+    token = signup_response.json()["access_token"]
+
+    change_response = client.patch(
+        "/auth/password",
+        json={
+            "current_password": "WrongPass123!",
+            "new_password": "NewPass123!",
+        },
+        headers={"Authorization": f"Bearer {token}"},
+    )
+    assert change_response.status_code == 400
+    assert "current password" in change_response.json()["detail"].lower()
+
+    old_login_response = client.post(
+        "/auth/login",
+        json={"email": "wrong-current@example.com", "password": "OldPass123!"},
+    )
+    assert old_login_response.status_code == 200
+
+
+def test_change_password_requires_authentication(client):
+    response = client.patch(
+        "/auth/password",
+        json={
+            "current_password": "OldPass123!",
+            "new_password": "NewPass123!",
+        },
+    )
+    assert response.status_code == 401
+    assert "authentication required" in response.json()["detail"].lower()


### PR DESCRIPTION
## Summary
- add authenticated PATCH /auth/password for rotating the current user's password
- validate the current password before hashing and saving the new password
- cover OpenAPI exposure, success, incorrect-current-password, and unauthenticated flows in auth route tests

Fixes #953

## Validation
- uv run --with-requirements backend/requirements.txt python -m py_compile backend/app/routers/auth.py backend/app/schemas.py backend/tests/test_auth_endpoints.py
- Auth-router smoke test passed for signup -> password change -> old password rejected -> new password accepted
- Note: full backend/tests/test_auth_endpoints.py collection is blocked locally by missing system libmagic from existing upload_file import path: ImportError: failed to find libmagic. Check your installation