### PR TITLE
fix(security): add authentication to history routes

### DIFF
--- a/backend/app/routers/history.py
+++ b/backend/app/routers/history.py
@@ -4,9 +4,11 @@ History router — save, retrieve, search and delete analysis history entries.
 
 from __future__ import annotations
 
-from fastapi import APIRouter, HTTPException, Query
+from fastapi import APIRouter, Depends, HTTPException, Query
 from pydantic import BaseModel, Field
 
+from ..models import User
+from ..security import get_current_user
 from ..services import database
 
 router = APIRouter()
@@ -56,8 +58,12 @@ class HistoryResponse(BaseModel):
 
 
 @router.post("/", response_model=dict, status_code=201)
-async def save_history(body: HistorySaveRequest):
+async def save_history(
+    body: HistorySaveRequest,
+    current_user: User = Depends(get_current_user),
+):
     entry_id = await database.save_entry(
+        user_id=current_user.id,
         code=body.code,
         language=body.language,
         score=body.score,
@@ -71,8 +77,9 @@ async def save_history(body: HistorySaveRequest):
 async def search_history(
     q: str = Query(..., min_length=1),
     limit: int = Query(20, ge=1, le=100),
+    current_user: User = Depends(get_current_user),
 ):
-    return await database.search_entries(q=q, limit=limit)
+    return await database.search_entries(user_id=current_user.id, q=q, limit=limit)
 
 
 @router.get("/", response_model=HistoryResponse)
@@ -81,10 +88,15 @@ async def get_history(
     offset: int = Query(0, ge=0),
     sort_by: str = Query("timestamp", pattern="^(timestamp|score|issue_count|id)$"),
     order: str = Query("desc", pattern="^(asc|desc)$"),
+    current_user: User = Depends(get_current_user),
 ):
-    total = await database.count_entries()
+    total = await database.count_entries(user_id=current_user.id)
     items = await database.get_entries(
-        limit=limit, offset=offset, sort_by=sort_by, order=order
+        user_id=current_user.id,
+        limit=limit,
+        offset=offset,
+        sort_by=sort_by,
+        order=order,
     )
     return {
         "items": items,
@@ -99,22 +111,28 @@ async def get_history(
 
 
 @router.get("/{entry_id}", response_model=HistoryDetailResponse)
-async def get_history_entry(entry_id: int):
-    entry = await database.get_entry(entry_id)
+async def get_history_entry(
+    entry_id: int,
+    current_user: User = Depends(get_current_user),
+):
+    entry = await database.get_entry(entry_id, user_id=current_user.id)
     if not entry:
         raise HTTPException(status_code=404, detail="History entry not found.")
     return entry
 
 
 @router.delete("/", response_model=dict)
-async def clear_history():
-    await database.clear_entries()
+async def clear_history(current_user: User = Depends(get_current_user)):
+    await database.clear_entries(user_id=current_user.id)
     return {"status": "cleared"}
 
 
 @router.delete("/{entry_id}", response_model=dict)
-async def delete_history(entry_id: int):
-    deleted = await database.delete_entry(entry_id)
+async def delete_history(
+    entry_id: int,
+    current_user: User = Depends(get_current_user),
+):
+    deleted = await database.delete_entry(entry_id, user_id=current_user.id)
     if not deleted:
         raise HTTPException(status_code=404, detail="History entry not found.")
     return {"id": entry_id, "status": "deleted"}

--- a/backend/app/services/database.py
+++ b/backend/app/services/database.py
@@ -19,6 +19,7 @@ async def init_db() -> None:
             """
             CREATE TABLE IF NOT EXISTS history (
                 id          INTEGER PRIMARY KEY AUTOINCREMENT,
+                user_id     INTEGER NOT NULL DEFAULT 0,
                 code_hash   TEXT NOT NULL,
                 language    TEXT NOT NULL,
                 score       INTEGER,
@@ -38,6 +39,12 @@ async def init_db() -> None:
             await db.execute("ALTER TABLE history ADD COLUMN result_json TEXT")
         except Exception:
             pass
+        try:
+            await db.execute(
+                "ALTER TABLE history ADD COLUMN user_id INTEGER NOT NULL DEFAULT 0"
+            )
+        except Exception:
+            pass
         await db.execute(
             """
             CREATE VIRTUAL TABLE IF NOT EXISTS fts_history
@@ -47,6 +54,7 @@ async def init_db() -> None:
         await db.execute(
             "CREATE INDEX IF NOT EXISTS idx_timestamp ON history(timestamp DESC)"
         )
+        await db.execute("CREATE INDEX IF NOT EXISTS idx_user_id ON history(user_id)")
         await db.commit()
 
 
@@ -55,6 +63,7 @@ def hash_code(code: str) -> str:
 
 
 async def save_entry(
+    user_id: int,
     code: str,
     language: str,
     score: int | None,
@@ -66,10 +75,19 @@ async def save_entry(
     async with aiosqlite.connect(DB_PATH) as db:
         cursor = await db.execute(
             """
-            INSERT INTO history (code_hash, language, score, issue_count, code_preview, code, result_json)
-            VALUES (?, ?, ?, ?, ?, ?, ?)
+            INSERT INTO history (user_id, code_hash, language, score, issue_count, code_preview, code, result_json)
+            VALUES (?, ?, ?, ?, ?, ?, ?, ?)
             """,
-            (code_hash, language, score, issue_count, preview, code, result_json),
+            (
+                user_id,
+                code_hash,
+                language,
+                score,
+                issue_count,
+                preview,
+                code,
+                result_json,
+            ),
         )
         row_id = cursor.lastrowid
         await db.execute(
@@ -80,15 +98,21 @@ async def save_entry(
         return row_id
 
 
-async def count_entries() -> int:
+async def count_entries(user_id: int) -> int:
     async with aiosqlite.connect(DB_PATH) as db:
-        cursor = await db.execute("SELECT COUNT(*) FROM history")
+        cursor = await db.execute(
+            "SELECT COUNT(*) FROM history WHERE user_id = ?", (user_id,)
+        )
         row = await cursor.fetchone()
         return row[0] if row else 0
 
 
 async def get_entries(
-    limit: int = 20, offset: int = 0, sort_by: str = "timestamp", order: str = "desc"
+    user_id: int,
+    limit: int = 20,
+    offset: int = 0,
+    sort_by: str = "timestamp",
+    order: str = "desc",
 ) -> list[dict]:
     allowed_sort_columns = {"timestamp", "score", "issue_count", "id"}
     allowed_orders = {"asc", "desc"}
@@ -101,16 +125,17 @@ async def get_entries(
         query = f"""
             SELECT id, code_hash, language, score, issue_count, timestamp, code_preview
             FROM history
+            WHERE user_id = ?
             ORDER BY {sort_by} {order}, id DESC
             LIMIT ? OFFSET ?
         """
 
-        cursor = await db.execute(query, (limit, offset))
+        cursor = await db.execute(query, (user_id, limit, offset))
         rows = await cursor.fetchall()
         return [dict(row) for row in rows]
 
 
-async def search_entries(q: str, limit: int = 20) -> list[dict]:
+async def search_entries(user_id: int, q: str, limit: int = 20) -> list[dict]:
     async with aiosqlite.connect(DB_PATH) as db:
         db.row_factory = aiosqlite.Row
         cursor = await db.execute(
@@ -118,44 +143,51 @@ async def search_entries(q: str, limit: int = 20) -> list[dict]:
             SELECT h.id, h.code_hash, h.language, h.score,
                    h.issue_count, h.timestamp, h.code_preview
             FROM history h
-            WHERE h.id IN (
+            WHERE h.user_id = ?
+              AND h.id IN (
                 SELECT rowid FROM fts_history WHERE fts_history MATCH ?
             )
             ORDER BY h.timestamp DESC
             LIMIT ?
             """,
-            (q, limit),
+            (user_id, q, limit),
         )
         rows = await cursor.fetchall()
         return [dict(row) for row in rows]
 
 
-async def delete_entry(entry_id: int) -> bool:
+async def delete_entry(entry_id: int, user_id: int) -> bool:
     async with aiosqlite.connect(DB_PATH) as db:
-        cursor = await db.execute("DELETE FROM history WHERE id = ?", (entry_id,))
+        cursor = await db.execute(
+            "DELETE FROM history WHERE id = ? AND user_id = ?", (entry_id, user_id)
+        )
         await db.execute("DELETE FROM fts_history WHERE rowid = ?", (entry_id,))
         await db.commit()
         return cursor.rowcount > 0
 
 
-async def get_entry(entry_id: int) -> dict | None:
+async def get_entry(entry_id: int, user_id: int) -> dict | None:
     async with aiosqlite.connect(DB_PATH) as db:
         db.row_factory = aiosqlite.Row
         cursor = await db.execute(
             """
             SELECT id, code_hash, language, score, issue_count, timestamp, code_preview, code, result_json
             FROM history
-            WHERE id = ?
+            WHERE id = ? AND user_id = ?
             """,
-            (entry_id,),
+            (entry_id, user_id),
         )
         row = await cursor.fetchone()
         return dict(row) if row else None
 
 
-async def clear_entries() -> int:
+async def clear_entries(user_id: int) -> int:
     async with aiosqlite.connect(DB_PATH) as db:
-        cursor = await db.execute("DELETE FROM history")
-        await db.execute("DELETE FROM fts_history")
+        cursor = await db.execute("DELETE FROM history WHERE user_id = ?", (user_id,))
+        await db.execute(
+            """
+            DELETE FROM fts_history WHERE rowid NOT IN (SELECT id FROM history)
+            """
+        )
         await db.commit()
         return cursor.rowcount

--- a/backend/tests/test_history.py
+++ b/backend/tests/test_history.py
@@ -7,9 +7,12 @@ import os
 import sys
 import tempfile
 
+import pytest
+
 sys.path.insert(0, os.path.dirname(os.path.dirname(__file__)))
 
 from app.main import app
+from app.security import get_current_user
 from app.services import database
 from fastapi.testclient import TestClient
 
@@ -18,6 +21,27 @@ _tmp.close()
 database.DB_PATH = _tmp.name
 
 asyncio.run(database.init_db())
+
+
+class _StubUser:
+    """Lightweight stand-in for an authenticated user in history tests."""
+
+    def __init__(self, user_id: int):
+        self.id = user_id
+
+
+# History routes now require authentication. Override the dependency so the
+# suite runs as a fixed user, then switch users where isolation is tested.
+def _override_current_user():
+    return _StubUser(1)
+
+
+@pytest.fixture(autouse=True)
+def _auth_as_default_user():
+    app.dependency_overrides[get_current_user] = _override_current_user
+    yield
+    app.dependency_overrides.pop(get_current_user, None)
+
 
 client = TestClient(app, raise_server_exceptions=True)
 
@@ -179,3 +203,50 @@ def test_clear_all_history():
 
     get_r = client.get("/history/")
     assert get_r.json()["meta"]["total"] == 0
+
+
+def test_history_requires_authentication():
+    app.dependency_overrides.pop(get_current_user, None)
+    try:
+        r = client.get("/history/")
+        assert r.status_code == 401
+        r = client.post("/history/", json={"code": "x", "language": "Python"})
+        assert r.status_code == 401
+    finally:
+        app.dependency_overrides[get_current_user] = _override_current_user
+
+
+def test_history_is_isolated_per_user():
+    # Clear any existing entries for the default user.
+    client.delete("/history/")
+
+    # User 1 saves an entry.
+    save_r = client.post(
+        "/history/",
+        json={"code": "user one secret code", "language": "Python"},
+    )
+    assert save_r.status_code == 201
+    user_one_entry_id = save_r.json()["id"]
+
+    # Switch to user 2 and confirm none of user 1's history is visible.
+    app.dependency_overrides[get_current_user] = lambda: _StubUser(2)
+    try:
+        list_r = client.get("/history/")
+        assert list_r.status_code == 200
+        assert list_r.json()["meta"]["total"] == 0
+
+        detail_r = client.get(f"/history/{user_one_entry_id}")
+        assert detail_r.status_code == 404
+
+        search_r = client.get("/history/search?q=secret")
+        assert search_r.status_code == 200
+        assert search_r.json() == []
+
+        delete_r = client.delete(f"/history/{user_one_entry_id}")
+        assert delete_r.status_code == 404
+    finally:
+        app.dependency_overrides[get_current_user] = _override_current_user
+
+    # User 1 still sees their own entry.
+    own_r = client.get(f"/history/{user_one_entry_id}")
+    assert own_r.status_code == 200

--- a/backend/tests/test_schema_smoke.py
+++ b/backend/tests/test_schema_smoke.py
@@ -239,10 +239,12 @@ def test_history_db_init():
 def test_history_save_and_retrieve():
     """save_entry() and get_entries() must round-trip a record."""
     asyncio.run(_hist_db_module.init_db())
-    row_id = asyncio.run(_hist_db_module.save_entry("print('smoke')", "python", 95, 1))
+    row_id = asyncio.run(
+        _hist_db_module.save_entry(1, "print('smoke')", "python", 95, 1)
+    )
     assert isinstance(row_id, int) and row_id > 0
 
-    entries = asyncio.run(_hist_db_module.get_entries(limit=10))
+    entries = asyncio.run(_hist_db_module.get_entries(user_id=1, limit=10))
     assert any(e["language"] == "python" for e in entries)
 
 
@@ -250,9 +252,11 @@ def test_history_fts5_search():
     """FTS5 MATCH query must return rows containing the search term."""
     asyncio.run(_hist_db_module.init_db())
     asyncio.run(
-        _hist_db_module.save_entry("def unique_smoke_fn(): pass", "python", 80, 0)
+        _hist_db_module.save_entry(1, "def unique_smoke_fn(): pass", "python", 80, 0)
     )
-    results = asyncio.run(_hist_db_module.search_entries("unique_smoke_fn"))
+    results = asyncio.run(
+        _hist_db_module.search_entries(user_id=1, q="unique_smoke_fn")
+    )
     assert any("unique_smoke_fn" in e["code_preview"] for e in results)
 
 
@@ -260,7 +264,7 @@ def test_history_delete():
     """delete_entry() must remove a record and return True."""
     asyncio.run(_hist_db_module.init_db())
     row_id = asyncio.run(
-        _hist_db_module.save_entry("to_be_deleted = True", "python", 50, 3)
+        _hist_db_module.save_entry(1, "to_be_deleted = True", "python", 50, 3)
     )
-    deleted = asyncio.run(_hist_db_module.delete_entry(row_id))
+    deleted = asyncio.run(_hist_db_module.delete_entry(row_id, user_id=1))
     assert deleted is True


### PR DESCRIPTION
## Summary

This PR fixes the critical authentication gap in history routes by requiring authentication on all endpoints and filtering history records by current user. Users can now only access their own analysis history.

## Problem

The history routes in backend/app/routers/history.py lacked authentication, exposing all users' code analysis history to any client. Unauthenticated requests could retrieve, search, and delete history entries belonging to other users.

## Solution

1. **Added authentication requirement** using Depends(get_current_user) to all history endpoints
2. **User-scoped filtering** - history records filtered by current_user.id
3. **User tracking** - save_entry() now stores user_id for proper data isolation
4. **Delete protection** - delete operations now verify user ownership via user_id

## Changes

- backend/app/routers/history.py:
  - Import Depends and get_current_user from security
  - Add current_user parameter to all route handlers
  - Filter all database queries by user_id
  - Include user_id when saving new entries

## Security Impact

- Prevents unauthorized access to other users' analysis history
- Ensures complete user data isolation
- Protects sensitive code snippets from exposure

## Testing

- Authenticated users can access only their own history
- Unauthenticated requests return 401 Unauthorized
- Users cannot delete or search history belonging to other users
- History entries are properly associated with creating user

## Related Issue

Closes #708

---

This contribution is part of GSSoC 2026. Please consider adding the **gssoc-approved** label when reviewed.