### PR TITLE
test: add security authentication helper coverage

### DIFF
--- a/backend/tests/test_security_helpers.py
+++ b/backend/tests/test_security_helpers.py
@@ -1,0 +1,88 @@
+from datetime import datetime, timedelta, timezone
+
+import jwt
+import pytest
+
+from backend.app.config import settings
+from backend.app.security import (
+    create_access_token,
+    decode_access_token,
+    hash_password,
+    verify_password,
+)
+
+
+def test_hash_password_returns_salted_hash_and_verifies_password():
+    encoded = hash_password("strong-password")
+
+    assert encoded != "strong-password"
+    assert ":" in encoded
+    assert verify_password("strong-password", encoded) is True
+
+
+def test_verify_password_rejects_wrong_password():
+    encoded = hash_password("correct-password")
+
+    assert verify_password("wrong-password", encoded) is False
+
+
+def test_verify_password_rejects_malformed_hash():
+    assert verify_password("password", "not-a-valid-hash") is False
+
+
+def test_create_and_decode_access_token_returns_user_id():
+    token = create_access_token(user_id=42)
+
+    assert decode_access_token(token) == 42
+
+
+def test_decode_access_token_rejects_invalid_token():
+    with pytest.raises(jwt.InvalidTokenError):
+        decode_access_token("not-a-valid-token")
+
+
+def test_decode_access_token_rejects_expired_token():
+    payload = {
+        "sub": "42",
+        "exp": datetime.now(timezone.utc) - timedelta(minutes=1),
+    }
+
+    token = jwt.encode(
+        payload,
+        settings.jwt_secret,
+        algorithm=settings.jwt_algorithm,
+    )
+
+    with pytest.raises(jwt.ExpiredSignatureError):
+        decode_access_token(token)
+
+
+def test_decode_access_token_rejects_missing_subject_claim():
+    payload = {
+        "exp": datetime.now(timezone.utc) + timedelta(minutes=5),
+    }
+
+    token = jwt.encode(
+        payload,
+        settings.jwt_secret,
+        algorithm=settings.jwt_algorithm,
+    )
+
+    with pytest.raises(KeyError):
+        decode_access_token(token)
+
+
+def test_decode_access_token_rejects_non_numeric_subject_claim():
+    payload = {
+        "sub": "not-a-number",
+        "exp": datetime.now(timezone.utc) + timedelta(minutes=5),
+    }
+
+    token = jwt.encode(
+        payload,
+        settings.jwt_secret,
+        algorithm=settings.jwt_algorithm,
+    )
+
+    with pytest.raises(ValueError):
+        decode_access_token(token)


### PR DESCRIPTION
## Description

Added dedicated unit tests for `security.py` authentication helpers to improve coverage of token parsing, verification, and edge-case handling.

The test suite covers:

* Password hashing and verification.
* Invalid password rejection.
* Malformed hash handling.
* Access token creation and decoding.
* Invalid token handling.
* Expired token handling.
* Missing `sub` claim handling.
* Non-numeric `sub` claim handling.

## Related Issue

Fixes #637

## Type of change

* [ ] Bug fix
* [ ] New feature / enhancement
* [ ] Documentation update
* [x] Test addition
* [ ] Refactor

## Checklist

* [x] I have read [[CONTRIBUTING.md](https://chatgpt.com/CONTRIBUTING.md)](../CONTRIBUTING.md)
* [x] My branch is up to date with `main`
* [x] I have run `pytest -v` and all tests pass
* [x] I have not introduced duplicate issues or features
* [x] My PR title follows the format: `feat/fix/docs/test: short description`
* [x] I have added tests for new features (Level 2 and 3 issues)
* [x] No hardcoded secrets or API keys in my code
* [x] This PR is linked to a GSSoC 2026 issue

## Screenshots (if frontend change)

N/A — backend test-only change.

## Test evidence

```bash
python -m pytest backend/tests/test_security_helpers.py

============================= test session starts =============================
collected 8 items

backend/tests/test_security_helpers.py ........

============================== 8 passed ======================================
```