### PR TITLE
fix(frontend): replace simulated digest subscription with real /subscribe API call (#979)

### DIFF
--- a/frontend/script.js
+++ b/frontend/script.js
@@ -617,20 +617,35 @@ const digestEmail = document.getElementById('digestEmail');
 const digestBtn = document.getElementById('digestBtn');
 
 if (digestForm) {
-  digestForm.addEventListener('submit', (e) => {
+  digestForm.addEventListener('submit', async (e) => {
     e.preventDefault(); // stop page reload
 
     const email = digestEmail.value.trim();
+    if (!email) {
+      return;
+    }
 
     // Show loading state
     digestBtn.textContent = 'Subscribing...';
     digestBtn.disabled = true;
 
-    // Simulate subscription (replace with real API call when backend is ready)
-    setTimeout(() => {
-      // Show success message
-      digestForm.innerHTML = `<p style="font-size:0.8rem;color:#4caf50;margin:0;">✓ You have been subscribed!</p>`;
-    }, 800);
+    try {
+      const resp = await fetch(`${getApiUrl()}/subscribe`, {
+        method: 'POST',
+        headers: { 'Content-Type': 'application/json' },
+        body: JSON.stringify({ email }),
+      });
+      if (resp.ok) {
+        digestForm.innerHTML = `<p style="font-size:0.8rem;color:#4caf50;margin:0;">✓ You have been subscribed!</p>`;
+      } else {
+        const err = await resp.json().catch(() => ({}));
+        throw new Error(err.detail || 'Subscription failed');
+      }
+    } catch (err) {
+      digestBtn.textContent = 'Subscribe';
+      digestBtn.disabled = false;
+      alert(err.message || 'Could not subscribe. Please try again.');
+    }
   });
 }
 


### PR DESCRIPTION
## Description

The digest subscription form was using setTimeout() to simulate a subscription instead of calling the actual backend endpoint. This meant users who submitted emails never actually got subscribed.

## Changes
- Replaced fake setTimeout() with real fetch() POST to /subscribe endpoint
- Added proper error handling with user feedback on failure
- Added empty email validation before sending request

## Related Issue
Fixes #979

## Type of change
- [x] Bug fix