### PR TITLE
fix(backend): cleanup expired share snippets from database on read (#980)

### DIFF
--- a/backend/app/routers/share.py
+++ b/backend/app/routers/share.py
@@ -86,6 +86,10 @@ def get_share(token: str, db: Session = Depends(get_db)):
             created_at = created_at.replace(tzinfo=_dt.timezone.utc)
 
         if created_at < _dt.datetime.now(_dt.timezone.utc) - _dt.timedelta(days=7):
+            # cleanup expired share from DB to prevent unbounded growth
+            from sqlalchemy import delete as _delete
+            db.execute(_delete(SharedSnippet).where(SharedSnippet.token == token_val))
+            db.commit()
             raise HTTPException(status_code=status.HTTP_404_NOT_FOUND, detail="Shared result expired")
 
         return ShareRecord(id=token_val, action="share", code=code_val, result=json.loads(result_json_val), created_at=created_at.isoformat())
@@ -98,6 +102,10 @@ def get_share(token: str, db: Session = Depends(get_db)):
         created_at = created_at.replace(tzinfo=timezone.utc)
 
     if created_at < datetime.now(timezone.utc) - timedelta(days=7):
+        # cleanup expired share from DB to prevent unbounded growth
+        from sqlalchemy import delete as _delete
+        db.execute(_delete(SharedSnippet).where(SharedSnippet.token == token))
+        db.commit()
         raise HTTPException(status_code=status.HTTP_404_NOT_FOUND, detail="Shared result expired")
 
     return ShareRecord(

--- a/backend/app/routers/share.py
+++ b/backend/app/routers/share.py
@@ -23,13 +23,18 @@ def create_share(payload: ShareCreateRequest, db: Session = Depends(get_db)):
     token = ""
     for _ in range(5):
         candidate = secrets.token_urlsafe(8)
-        exists = db.execute(select(SharedSnippet).where(SharedSnippet.token == candidate)).scalar_one_or_none()
+        exists = db.execute(
+            select(SharedSnippet).where(SharedSnippet.token == candidate)
+        ).scalar_one_or_none()
         if exists is None:
             token = candidate
             break
 
     if not token:
-        raise HTTPException(status_code=status.HTTP_500_INTERNAL_SERVER_ERROR, detail="Could not create share token")
+        raise HTTPException(
+            status_code=status.HTTP_500_INTERNAL_SERVER_ERROR,
+            detail="Could not create share token",
+        )
 
     record = SharedSnippet(
         token=token,
@@ -57,13 +62,24 @@ def get_share(token: str, db: Session = Depends(get_db)):
 
     _Base.metadata.create_all(bind=db.get_bind())
 
-    record = db.execute(select(SharedSnippet).where(SharedSnippet.token == token)).scalar_one_or_none()
+    record = db.execute(
+        select(SharedSnippet).where(SharedSnippet.token == token)
+    ).scalar_one_or_none()
     if record is None:
         # fallback: try raw SQL in case ORM mapping/env differences hide the record
         from sqlalchemy import text
-        raw = db.execute(text("SELECT token, code, result_json, created_at FROM shares WHERE token = :t"), {"t": token}).first()
+
+        raw = db.execute(
+            text(
+                "SELECT token, code, result_json, created_at FROM shares WHERE token = :t"
+            ),
+            {"t": token},
+        ).first()
         if raw is None:
-            raise HTTPException(status_code=status.HTTP_404_NOT_FOUND, detail="Shared result not found or expired")
+            raise HTTPException(
+                status_code=status.HTTP_404_NOT_FOUND,
+                detail="Shared result not found or expired",
+            )
 
         # parse created_at which may be string or datetime
         token_val, code_val, result_json_val, created_at_val = raw
@@ -75,12 +91,17 @@ def get_share(token: str, db: Session = Depends(get_db)):
                 created_at = _dt.datetime.fromisoformat(created_at)
             except Exception:
                 try:
-                    created_at = _dt.datetime.strptime(created_at, "%Y-%m-%d %H:%M:%S.%f")
+                    created_at = _dt.datetime.strptime(
+                        created_at, "%Y-%m-%d %H:%M:%S.%f"
+                    )
                 except Exception:
                     created_at = None
 
         if created_at is None:
-            raise HTTPException(status_code=status.HTTP_404_NOT_FOUND, detail="Shared result not found or expired")
+            raise HTTPException(
+                status_code=status.HTTP_404_NOT_FOUND,
+                detail="Shared result not found or expired",
+            )
 
         if created_at.tzinfo is None:
             created_at = created_at.replace(tzinfo=_dt.timezone.utc)
@@ -88,11 +109,20 @@ def get_share(token: str, db: Session = Depends(get_db)):
         if created_at < _dt.datetime.now(_dt.timezone.utc) - _dt.timedelta(days=7):
             # cleanup expired share from DB to prevent unbounded growth
             from sqlalchemy import delete as _delete
+
             db.execute(_delete(SharedSnippet).where(SharedSnippet.token == token_val))
             db.commit()
-            raise HTTPException(status_code=status.HTTP_404_NOT_FOUND, detail="Shared result expired")
+            raise HTTPException(
+                status_code=status.HTTP_404_NOT_FOUND, detail="Shared result expired"
+            )
 
-        return ShareRecord(id=token_val, action="share", code=code_val, result=json.loads(result_json_val), created_at=created_at.isoformat())
+        return ShareRecord(
+            id=token_val,
+            action="share",
+            code=code_val,
+            result=json.loads(result_json_val),
+            created_at=created_at.isoformat(),
+        )
 
     # expire shares older than 7 days — normalize tzinfo if necessary
     from datetime import datetime, timezone, timedelta
@@ -104,9 +134,12 @@ def get_share(token: str, db: Session = Depends(get_db)):
     if created_at < datetime.now(timezone.utc) - timedelta(days=7):
         # cleanup expired share from DB to prevent unbounded growth
         from sqlalchemy import delete as _delete
+
         db.execute(_delete(SharedSnippet).where(SharedSnippet.token == token))
         db.commit()
-        raise HTTPException(status_code=status.HTTP_404_NOT_FOUND, detail="Shared result expired")
+        raise HTTPException(
+            status_code=status.HTTP_404_NOT_FOUND, detail="Shared result expired"
+        )
 
     return ShareRecord(
         id=record.token,


### PR DESCRIPTION
## Description

Expired share snippet records (>7 days old) were accumulating in the database indefinitely with no cleanup mechanism. This caused unnecessary database bloat as every new share created a permanent record.

## Changes
- Added delete-on-read cleanup: when get_share detects an expired token (>7 days), it now deletes the row from the shares table before returning 404
- Applied to both the ORM code path and the raw SQL fallback path

## Related Issue
Fixes #980

## Type of change
- [x] Bug fix / Enhancement