### PR TITLE
refactor(backend): replace custom email validation with Pydantic EmailStr (#971)

### DIFF
--- a/backend/app/schemas.py
+++ b/backend/app/schemas.py
@@ -13,6 +13,7 @@ from .schema_validators import (
     validate_stored_result_json,
 )
 
+
 class CodeRequest(BaseModel):
     code: str
     language: str | None = None
@@ -230,6 +231,7 @@ class ReadinessResponse(BaseModel):
     status: str
     checks: dict[str, dict[str, Any]]
 
+
 class ShareCreateRequest(BaseModel):
     action: str = Field("share", min_length=3, max_length=50)
     code: str = Field(..., min_length=1, max_length=settings.max_code_chars)
@@ -355,11 +357,13 @@ class ExplanationResponse(BaseModel):
     cyclomatic_complexity: int
     complexity_risk: str
 
+
 class SuggestionsResponse(BaseModel):
     suggestions: list[Suggestion]
     overall_score: int
     grade: str
     next_step: str
+
 
 class AnalyzeResponse(BaseModel):
     provider: str

--- a/backend/app/schemas.py
+++ b/backend/app/schemas.py
@@ -1,7 +1,7 @@
 """Pydantic request / response models for QyverixAI."""
 
 from __future__ import annotations
-from pydantic import BaseModel, Field, field_validator, model_validator
+from pydantic import BaseModel, EmailStr, Field, field_validator, model_validator
 import json
 from typing import Any
 
@@ -79,17 +79,7 @@ class ZipAnalyzeResponse(BaseModel):
 
 
 class SubscribeRequest(BaseModel):
-    email: str
-
-    @field_validator("email")
-    @classmethod
-    def email_must_be_valid(cls, v: str) -> str:
-        v = v.strip().lower()
-        if "@" not in v or "." not in v.split("@")[-1]:
-            raise ValueError("Invalid email address")
-        if len(v) > 320:
-            raise ValueError("Email too long")
-        return v
+    email: EmailStr
 
 
 class SubscribeResponse(BaseModel):

--- a/backend/requirements.txt
+++ b/backend/requirements.txt
@@ -2,6 +2,7 @@ aiosqlite>=0.20.0
 fastapi>=0.115.0
 uvicorn[standard]>=0.30.0
 pydantic>=2.7.0
+email-validator>=2.1.0
 sqlalchemy>=2.0.0
 pyjwt>=2.0.0
 python-dotenv>=1.0.0


### PR DESCRIPTION
## Description

The SubscribeRequest schema used custom string-based email validation that only checked for @ and . characters, which can incorrectly accept invalid emails and reject valid formats.

## Changes
- Replaced custom `field_validator` with Pydantic's built-in `EmailStr` type
- Added `email-validator>=2.1.0` dependency to requirements.txt
- Removed 10 lines of redundant validation code

## Benefits
- More accurate RFC-compliant email validation
- Reduced custom validation code
- Better maintainability
- Leverages well-tested Pydantic feature

## Related Issue
Fixes #971

## Type of change
- [x] Refactor