### PR TITLE
refactor: centralize file size error message in upload_config (#635)

### DIFF
--- a/backend/app/utils/upload_config.py
+++ b/backend/app/utils/upload_config.py
@@ -80,4 +80,5 @@ UPLOAD_ERROR_MESSAGES = {
     ),
     "blocked_file": "Executable files are not allowed.",
     "invalid_mime": "Invalid MIME type detected.",
+    "file_too_large": "File size exceeds the maximum limit of 5MB. Please upload a smaller file."
 }


### PR DESCRIPTION
### Description
This PR addresses issue #635 by refactoring the file size validation error handling. Instead of relying on a hardcoded string inside the upload router, it now utilizes the centralized `UPLOAD_ERROR_MESSAGES` dictionary located in the configuration file.

### Changes Made
- **`backend/app/utils/upload_config.py`**: Added a dedicated `"file_too_large"` key-value pair to the `UPLOAD_ERROR_MESSAGES` dictionary to explicitly communicate the 5MB size restriction.
- **`backend/app/routers/upload_file.py`**: Imported `UPLOAD_ERROR_MESSAGES` and updated the `HTTPException` detail inside the file size validation block to reference the newly created config key.

### Related Issues
Closes #635