### PR TITLE
fix: use actual function name in testing suggestion example (#855)

### DIFF
--- a/backend/app/services/code_assistant.py
+++ b/backend/app/services/code_assistant.py
@@ -238,9 +238,7 @@ def chat_fallback_reply(
         )
 
     if recent_history:
-        response_parts.append(
-            f"Recent chat context: {recent_history}."
-        )
+        response_parts.append(f"Recent chat context: {recent_history}.")
 
     return " ".join(response_parts)
 
@@ -826,8 +824,12 @@ def run_bug_detection(code: str, language: str) -> list[dict]:
             if key not in seen:
                 seen.add(key)
                 line_idx = issue["line"] - 1
-                issue["code_snippet"] = lines[line_idx].strip()[:120] if 0 <= line_idx < len(lines) else ""
-                issue["code_context"] = format_code_snippet(code, [issue["line"]], context_lines=2)
+                issue["code_snippet"] = (
+                    lines[line_idx].strip()[:120] if 0 <= line_idx < len(lines) else ""
+                )
+                issue["code_context"] = format_code_snippet(
+                    code, [issue["line"]], context_lines=2
+                )
                 found.append(issue)
 
     for bp in BUG_PATTERNS:
@@ -1027,7 +1029,6 @@ def run_suggestions(code: str, language: str) -> dict:
                 }
             )
 
-  
     # ─────────────────────────────────────────────────────────────
     # SUGGESTION 6: Tests
     # ─────────────────────────────────────────────────────────────
@@ -1044,7 +1045,8 @@ def run_suggestions(code: str, language: str) -> dict:
                 "code_context": None,
                 "example": (
                     f"def test_{first_func}():\n    result = {first_func}(...)\n    assert result == expected"
-                    if first_func else None
+                    if first_func
+                    else None
                 ),
                 "priority": "high",
             }
@@ -1059,15 +1061,17 @@ def run_suggestions(code: str, language: str) -> dict:
 
         if print_lines and not has_logging:
             sample_print = print_lines[:3]
-            suggestions.append({
-                "category": "Observability",
-                "description": f"Using `print()` instead of structured logging ({len(print_lines)} line(s)).",
-                "line_number": print_lines[0],
-                "line_range": sample_print,
-                "code_context": format_code_snippet(code, sample_print),
-                "example": "import logging\nlogger = logging.getLogger(__name__)\nlogger.info('Processing %d items', n)",
-                "priority": "medium",
-            })
+            suggestions.append(
+                {
+                    "category": "Observability",
+                    "description": f"Using `print()` instead of structured logging ({len(print_lines)} line(s)).",
+                    "line_number": print_lines[0],
+                    "line_range": sample_print,
+                    "code_context": format_code_snippet(code, sample_print),
+                    "example": "import logging\nlogger = logging.getLogger(__name__)\nlogger.info('Processing %d items', n)",
+                    "priority": "medium",
+                }
+            )
 
     # ─────────────────────────────────────────────────────────────
     # SUGGESTION 8: Environment Variables (JS/TS)

--- a/backend/app/services/code_assistant.py
+++ b/backend/app/services/code_assistant.py
@@ -1027,10 +1027,14 @@ def run_suggestions(code: str, language: str) -> dict:
                 }
             )
 
+  
     # ─────────────────────────────────────────────────────────────
     # SUGGESTION 6: Tests
     # ─────────────────────────────────────────────────────────────
     if not re.search(r"\btest_\w+|\bdef test|\bunittest\b|\bpytest\b|#\[test\]", code):
+        func_names = re.findall(r"def\s+(\w+)\s*\(", code)
+        first_func = func_names[0] if func_names else None
+
         suggestions.append(
             {
                 "category": "Testing",
@@ -1038,7 +1042,10 @@ def run_suggestions(code: str, language: str) -> dict:
                 "line_number": None,
                 "line_range": None,
                 "code_context": None,
-                "example": "def test_add():\n    assert add(2, 3) == 5\n    assert add(-1, 1) == 0",  # noqa: E501
+                "example": (
+                    f"def test_{first_func}():\n    result = {first_func}(...)\n    assert result == expected"
+                    if first_func else None
+                ),
                 "priority": "high",
             }
         )

--- a/backend/tests/test_endpoints.py
+++ b/backend/tests/test_endpoints.py
@@ -734,3 +734,23 @@ def test_get_stream_with_language_hint():
 def test_get_stream_empty_code_rejected():
     r = client.get("/analyze/stream", params={"code": "   "})
     assert r.status_code in (400, 422)
+
+def test_testing_suggestion_no_example_for_no_functions():
+    from app.services.code_assistant import run_suggestions
+    result = run_suggestions('print("Hello world")', "Python")
+    testing_sugg = next(
+        (s for s in result["suggestions"] if s["category"] == "Testing"), None
+    )
+    assert testing_sugg is not None
+    assert testing_sugg["example"] is None
+
+
+def test_testing_suggestion_uses_actual_function_name():
+    from app.services.code_assistant import run_suggestions
+    code = "def greet(name):\n    print(name)"
+    result = run_suggestions(code, "Python")
+    testing_sugg = next(
+        (s for s in result["suggestions"] if s["category"] == "Testing"), None
+    )
+    assert testing_sugg is not None
+    assert "greet" in testing_sugg["example"]

--- a/frontend/index.html
+++ b/frontend/index.html
@@ -3920,7 +3920,9 @@
           <span style="font-size:0.7rem;color:var(--text3);margin-left:auto">${getTranslation('suggest_priority').replace('{priority}', s.priority)}</span>
         </div>
         <div class="suggest-desc">${s.description}</div>
-        ${exampleHtml}
+         ${exampleHtml ? `<div style="font-size:0.72rem;color:var(--text3);margin:8px 0 2px">
+          💡 Example pattern (illustrative — not specific to your code):
+        </div>${exampleHtml}` : ''}
       </div>`;
           }).join('');
 

--- a/frontend/script.js
+++ b/frontend/script.js
@@ -1,3 +1,7 @@
+// DEPRECATED: This file is not loaded by index.html.
+// All app logic lives in the inline <script> at the bottom of index.html.
+// See issue#855 for context.
+
 /** Use security-utils.js when present (production index.html loads it first). */
 const SEC = window.QyverixSecurity || {
   escHtml(s) {


### PR DESCRIPTION
## Fix: Testing suggestion example now reflects actual code (#855)

### Problem
The "Testing" suggestion always showed a hardcoded `def test_add()` 
example regardless of the input code. For `print("Hello world")`, 
this made results look completely unrelated to the actual input.

### Root Cause
`run_suggestions` had a static hardcoded string as the `example` field
for the Testing suggestion.

### Fix
- Dynamically extract function names from submitted code using regex
- Use the first real function name in the example (e.g. `def test_greet`)
- Return `None` when no functions exist — frontend skips the diff block

### Tests Added
- `test_testing_suggestion_no_example_for_no_functions`
- `test_testing_suggestion_uses_actual_function_name`

Fixes #855