### PR TITLE
feat(ci): add large files check workflow (#574)

### DIFF
--- a/.github/workflows/check-large-files.yml
+++ b/.github/workflows/check-large-files.yml
@@ -1,8 +1,6 @@
 name: Check Large Files
 
 on:
-  push:
-    branches: [main, develop]
   pull_request:
     branches: [main]
 
@@ -13,22 +11,33 @@ jobs:
 
     steps:
       - uses: actions/checkout@v4
+        with:
+          fetch-depth: 0
 
-      - name: Check for oversized files
+      - name: Check for oversized files in PR changes
         env:
           THRESHOLD_MB: 5
         run: |
-          LARGE_FILES=$(find . -type f -size +${THRESHOLD_MB}M \
-            -not -path './.git/*' \
-            -print)
-          if [ -n "$LARGE_FILES" ]; then
-            echo "::error::Files exceeding ${THRESHOLD_MB}MB found:"
-            echo "$LARGE_FILES" | while IFS= read -r f; do
-              echo "::error::  $(du -h "$f" | cut -f1)  $f"
-            done
+          git fetch origin main
+          CHANGED=$(git diff --name-only --diff-filter=AM origin/main...HEAD)
+          if [ -z "$CHANGED" ]; then
+            echo "✓ No files added or modified in this PR"
+            exit 0
+          fi
+          FAILED=""
+          while IFS= read -r f; do
+            if [ -f "$f" ]; then
+              SIZE=$(stat --format=%s "$f")
+              if [ "$SIZE" -gt $(( THRESHOLD_MB * 1024 * 1024 )) ]; then
+                echo "::error::$(du -h "$f" | cut -f1)  $f"
+                FAILED=1
+              fi
+            fi
+          done <<< "$CHANGED"
+          if [ -n "$FAILED" ]; then
             echo ""
             echo "Large files bloat repo size and slow CI."
             echo "Remove them or use Git LFS / external storage."
             exit 1
           fi
-          echo "✓ No files exceed ${THRESHOLD_MB}MB"
+          echo "✓ No files exceed ${THRESHOLD_MB}MB in this PR"

--- a/.github/workflows/check-large-files.yml
+++ b/.github/workflows/check-large-files.yml
@@ -1,0 +1,34 @@
+name: Check Large Files
+
+on:
+  push:
+    branches: [main, develop]
+  pull_request:
+    branches: [main]
+
+jobs:
+  check:
+    runs-on: ubuntu-latest
+    timeout-minutes: 5
+
+    steps:
+      - uses: actions/checkout@v4
+
+      - name: Check for oversized files
+        env:
+          THRESHOLD_MB: 5
+        run: |
+          LARGE_FILES=$(find . -type f -size +${THRESHOLD_MB}M \
+            -not -path './.git/*' \
+            -print)
+          if [ -n "$LARGE_FILES" ]; then
+            echo "::error::Files exceeding ${THRESHOLD_MB}MB found:"
+            echo "$LARGE_FILES" | while IFS= read -r f; do
+              echo "::error::  $(du -h "$f" | cut -f1)  $f"
+            done
+            echo ""
+            echo "Large files bloat repo size and slow CI."
+            echo "Remove them or use Git LFS / external storage."
+            exit 1
+          fi
+          echo "✓ No files exceed ${THRESHOLD_MB}MB"

--- a/.github/workflows/check-large-files.yml
+++ b/.github/workflows/check-large-files.yml
@@ -24,7 +24,7 @@ jobs:
             echo "✓ No files added or modified in this PR"
             exit 0
           fi
-          FAILED=""
+          FAILED=0
           while IFS= read -r f; do
             if [ -f "$f" ]; then
               SIZE=$(stat --format=%s "$f")
@@ -34,7 +34,7 @@ jobs:
               fi
             fi
           done <<< "$CHANGED"
-          if [ -n "$FAILED" ]; then
+          if [ "$FAILED" -eq 1 ]; then
             echo ""
             echo "Large files bloat repo size and slow CI."
             echo "Remove them or use Git LFS / external storage."

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -100,7 +100,7 @@ CI automatically rejects PRs that contain files larger than **5 MB**. This keeps
 
 ### Configure exceptions
 
-If you believe a file legitimately needs to exceed 5 MB (e.g., a bundled model or a large screenshot), add an exception path to `.github/workflows/check-large-files.yml` in the `find` command using `-not -path './path/to/exclude/*'`.
+If you believe a file legitimately needs to exceed 5 MB (e.g., a bundled model or a large screenshot), add an exception to the check by modifying the comparison in `.github/workflows/check-large-files.yml`.
 
 ---
 

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -88,6 +88,22 @@ The entire frontend is `frontend/index.html` — one self-contained file. No bui
 
 ---
 
+## Large Files Policy
+
+CI automatically rejects PRs that contain files larger than **5 MB**. This keeps the repo lean and CI fast.
+
+### What to do if your PR fails
+
+- Check which files triggered the failure in the CI logs
+- Remove the oversized files from the commit
+- For large assets (screenshots, datasets, binaries), use **Git LFS** or an external hosting service and link to them in the README
+
+### Configure exceptions
+
+If you believe a file legitimately needs to exceed 5 MB (e.g., a bundled model or a large screenshot), add an exception path to `.github/workflows/check-large-files.yml` in the `find` command using `-not -path './path/to/exclude/*'`.
+
+---
+
 ## Code Formatting
 
 CI enforces consistent Python formatting on every pull request using
@@ -132,6 +148,7 @@ Before opening a PR, confirm:
 - [ ] README updated if behavior changed
 - [ ] Branch is up-to-date with `main`
 - [ ] PR description explains *what* and *why*
+- [ ] No files exceed 5 MB (checked by CI)
 
 ---
 ## PR Process Examples


### PR DESCRIPTION
## Description

Adds a CI workflow that checks files added or modified in a PR and fails if any exceed 5 MB. Also documents the policy in CONTRIBUTING.md with guidance on using Git LFS or external storage for large assets.

## Related Issue

Fixes #574

## Type of change
- [ ] Bug fix
- [x] New feature / enhancement
- [x] Documentation update
- [ ] Test addition
- [ ] Refactor

## Checklist
- [x] I have read [CONTRIBUTING.md](../CONTRIBUTING.md)
- [x] My branch is up to date with `main`
- [x] I have run `pytest -v` and all tests pass
- [x] I have not introduced duplicate issues or features
- [x] My PR title follows the format: `feat/fix/docs/test: short description`
- [ ] I have added tests for new features (Level 2 and 3 issues)
- [x] No hardcoded secrets or API keys in my code
- [x] This PR is linked to a GSSoC 2026 issue

## Screenshots (if frontend change)

N/A — CI workflow change

## Test evidence

```
No tests needed — workflow is a CI pipeline change. Verified by pushing to the fork's main branch and checking the action runs correctly on pull_request trigger.
```
