### PR TITLE
feat: add /metrics/aggregate endpoint for health metrics aggregation …

### DIFF
--- a/backend/app/main.py
+++ b/backend/app/main.py
@@ -29,6 +29,7 @@ from .routers import (
 )
 from .routers import health as health_router
 from .routers import metrics as metrics_router
+from .routers import aggregate as aggregate_router
 from .services import database
 from .services.scheduler import start_scheduler, stop_scheduler
 from .observability import (
@@ -165,6 +166,7 @@ app.include_router(upload_file.router, prefix="/upload",      tags=['Upload File
 # Operational endpoints: /healthz/live, /healthz/ready, /metrics
 app.include_router(health_router.router)
 app.include_router(metrics_router.router)
+app.include_router(aggregate_router.router)
 
 
 # ── Core Endpoints ────────────────────────────────────────────────────────────

--- a/backend/app/routers/aggregate.py
+++ b/backend/app/routers/aggregate.py
@@ -1,0 +1,98 @@
+"""
+QyverixAI — /metrics/aggregate endpoint
+
+Aggregates health and operational metrics from all subsystems into a
+single JSON response so dashboards can fetch one endpoint instead of
+polling /healthz/ready, /metrics, and other sources separately.
+
+Auth: Requires a valid Bearer token when METRICS_AUTH_TOKEN is set,
+      matching the same token used by the Prometheus /metrics endpoint.
+"""
+
+from __future__ import annotations
+
+import time
+from datetime import datetime, timezone
+
+from fastapi import APIRouter, HTTPException, Request, status
+
+from ..observability import metrics_auth_token, metrics_enabled
+from ..routers.health import _check_database
+from ..schemas import AggregateMetricsResponse, SubsystemStatus
+
+router = APIRouter(prefix="/metrics", tags=["System"])
+
+
+def _check_auth(request: Request) -> None:
+    """Raise 401 if a token is configured and the request doesn't supply it."""
+    required_token = metrics_auth_token()
+    if not required_token:
+        return
+    header = request.headers.get("authorization", "")
+    if not header.lower().startswith("bearer "):
+        raise HTTPException(
+            status_code=status.HTTP_401_UNAUTHORIZED,
+            detail="Missing bearer token",
+        )
+    provided = header.split(" ", 1)[1].strip()
+    if provided != required_token:
+        raise HTTPException(
+            status_code=status.HTTP_401_UNAUTHORIZED,
+            detail="Invalid metrics token",
+            headers={"WWW-Authenticate": "Bearer"},
+        )
+
+
+@router.get(
+    "/aggregate",
+    response_model=AggregateMetricsResponse,
+    summary="Aggregate health metrics",
+    description=(
+        "Returns a combined JSON snapshot of all subsystem statuses and "
+        "operational metrics. Protect with METRICS_AUTH_TOKEN if the endpoint "
+        "is reachable from outside the cluster."
+    ),
+    responses={
+        401: {"description": "Missing or invalid bearer token."},
+    },
+)
+async def aggregate_metrics(request: Request) -> AggregateMetricsResponse:
+    _check_auth(request)
+
+    # ── Database check ────────────────────────────────────────────────────────
+    db_ok, db_error, db_elapsed_ms = _check_database()
+    db_status = SubsystemStatus(
+        status="ok" if db_ok else "degraded",
+        elapsed_ms=round(db_elapsed_ms, 2),
+        detail=db_error,
+    )
+
+    # ── Prometheus / metrics check ────────────────────────────────────────────
+    prometheus_on = metrics_enabled()
+    prometheus_status = SubsystemStatus(
+        status="ok" if prometheus_on else "unknown",
+        detail=None if prometheus_on else "METRICS_ENABLED=false",
+    )
+
+    # ── API process check (always ok if we got here) ──────────────────────────
+    api_status = SubsystemStatus(status="ok", elapsed_ms=0.0)
+
+    subsystems = {
+        "api": api_status,
+        "database": db_status,
+        "prometheus": prometheus_status,
+    }
+
+    overall = (
+        "ok"
+        if all(s.status == "ok" for s in subsystems.values())
+        else "degraded"
+    )
+
+    return AggregateMetricsResponse(
+        overall=overall,
+        version="3.0.0",
+        subsystems=subsystems,
+        prometheus_enabled=prometheus_on,
+        timestamp=datetime.now(timezone.utc).isoformat(),
+    )

--- a/backend/app/schemas.py
+++ b/backend/app/schemas.py
@@ -378,3 +378,18 @@ class AnalyzeResponse(BaseModel):
     debugging: DebuggingResponse
     suggestions: SuggestionsResponse
     analysis_time_ms: float | None = None
+# ── Metrics Aggregate ─────────────────────────────────────────────────────────
+class SubsystemStatus(BaseModel):
+    """Status of a single subsystem returned by /metrics/aggregate."""
+    status: str          # "ok" | "degraded" | "unknown"
+    elapsed_ms: float | None = None
+    detail: str | None = None
+
+
+class AggregateMetricsResponse(BaseModel):
+    """Combined health + metrics snapshot for dashboard consumption."""
+    overall: str                              # "ok" | "degraded"
+    version: str
+    subsystems: dict[str, SubsystemStatus]
+    prometheus_enabled: bool
+    timestamp: str

--- a/backend/tests/test_aggregate_metrics.py
+++ b/backend/tests/test_aggregate_metrics.py
@@ -1,0 +1,80 @@
+"""
+Tests for GET /metrics/aggregate
+
+Covers:
+* Returns 200 with correct structure when DB is reachable.
+* overall becomes "degraded" when database check fails.
+* Returns 401 when METRICS_AUTH_TOKEN is set and token is missing/wrong.
+* Returns 200 with correct token when METRICS_AUTH_TOKEN is set.
+* prometheus_enabled reflects METRICS_ENABLED env var.
+"""
+
+from __future__ import annotations
+
+import os
+import sys
+from unittest.mock import patch
+
+from fastapi.testclient import TestClient
+
+sys.path.insert(0, os.path.dirname(os.path.dirname(__file__)))
+
+from app.main import app
+from app.routers import health
+
+client = TestClient(app)
+
+
+def test_aggregate_returns_200_with_correct_structure():
+    r = client.get("/metrics/aggregate")
+    assert r.status_code == 200
+    body = r.json()
+    assert body["overall"] == "ok"
+    assert body["version"] == "3.0.0"
+    assert "subsystems" in body
+    assert "database" in body["subsystems"]
+    assert "api" in body["subsystems"]
+    assert "prometheus" in body["subsystems"]
+    assert "timestamp" in body
+    assert "prometheus_enabled" in body
+
+
+def test_aggregate_database_ok():
+    r = client.get("/metrics/aggregate")
+    body = r.json()
+    assert body["subsystems"]["database"]["status"] == "ok"
+
+
+def test_aggregate_degraded_when_db_fails():
+    def _broken(timeout_seconds: float = 2.0):
+        return False, "OperationalError: connection refused", 1.5
+
+    with patch.object(health, "_check_database", _broken):
+        r = client.get("/metrics/aggregate")
+
+    assert r.status_code == 200
+    body = r.json()
+    assert body["overall"] == "degraded"
+    assert body["subsystems"]["database"]["status"] == "degraded"
+
+
+def test_aggregate_requires_token_when_configured(monkeypatch):
+    monkeypatch.setenv("METRICS_AUTH_TOKEN", "s3cret")
+
+    r = client.get("/metrics/aggregate")
+    assert r.status_code == 401
+
+    r = client.get("/metrics/aggregate", headers={"Authorization": "Bearer wrong"})
+    assert r.status_code == 401
+
+    r = client.get("/metrics/aggregate", headers={"Authorization": "Bearer s3cret"})
+    assert r.status_code == 200
+
+
+def test_aggregate_prometheus_disabled(monkeypatch):
+    monkeypatch.setenv("METRICS_ENABLED", "false")
+    r = client.get("/metrics/aggregate")
+    assert r.status_code == 200
+    body = r.json()
+    assert body["prometheus_enabled"] is False
+    assert body["subsystems"]["prometheus"]["status"] == "unknown"


### PR DESCRIPTION
## Summary
Closes #643

## Problem
Monitoring dashboards had to poll multiple endpoints separately
(/healthz/ready, /metrics, /health) to get a full picture of system
health, making dashboard setup complex.

## Solution
Added a single GET /metrics/aggregate endpoint that queries all
subsystems and returns a combined JSON response.

## New Files
- `backend/app/routers/aggregate.py`
  New router with GET /metrics/aggregate endpoint. Queries database,
  Prometheus, and API process subsystems. Protected by bearer token
  when METRICS_AUTH_TOKEN is set (same token as /metrics).

- `backend/tests/test_aggregate_metrics.py`
  Tests covering 200 response structure, degraded state when DB fails,
  auth token enforcement, and prometheus_enabled flag.

## Modified Files
- `backend/app/schemas.py`
  Added SubsystemStatus and AggregateMetricsResponse Pydantic models.

- `backend/app/main.py`
  Registered aggregate_router so /metrics/aggregate is served.

## Example Response
GET /metrics/aggregate → 200 OK
{
  "overall": "ok",
  "version": "3.0.0",
  "subsystems": {
    "api":        { "status": "ok", "elapsed_ms": 0.0 },
    "database":   { "status": "ok", "elapsed_ms": 1.23 },
    "prometheus": { "status": "ok" }
  },
  "prometheus_enabled": true,
  "timestamp": "2026-06-14T18:00:00+00:00"
}

## Security
- Bearer token auth via METRICS_AUTH_TOKEN env var (optional)
- Returns 401 on missing or wrong token when configured
- Safe to expose to internal dashboards without token in trusted networks
