### PR TITLE
fix(frontend): show feature card text on mobile devices

### DIFF
--- a/.github/pull_request_template.md
+++ b/.github/pull_request_template.md
@@ -20,6 +20,7 @@ Fixes #
 - [ ] I have not introduced duplicate issues or features
 - [ ] My PR title follows the format: `feat/fix/docs/test: short description`
 - [ ] I have added tests for new features (Level 2 and 3 issues)
+- [ ] I have updated `docs/CHANGELOG.md` for user-facing changes or fixes
 - [ ] No hardcoded secrets or API keys in my code
 - [ ] This PR is linked to a GSSoC 2026 issue
 

--- a/frontend/index.html
+++ b/frontend/index.html
@@ -2063,7 +2063,6 @@
 @media(max-width:400px){
   .app{padding:0 14px 60px}
   .hero h1{font-size:1.9rem}
-  .feat-pill-info p{display:none}
   .lang-tab{padding:7px 10px;font-size:0.72rem}
   .result-tab{padding:9px 12px;font-size:0.75rem}
 }

--- a/frontend/index.html
+++ b/frontend/index.html
@@ -2068,8 +2068,12 @@ details.issue-card[open] {
   .nav-links .nav-link span{display:none}
   .hero{padding:50px 0 40px}
   .hero-sub{font-size:0.98rem}
-  .features-row{gap:8px;padding:16px 0 40px}
-  .feat-pill{padding:10px 14px;min-width:140px}
+  .features-row{display:grid;grid-template-columns:repeat(2,minmax(0,1fr));gap:6px;max-width:400px;margin-inline:auto;padding:16px 0 40px}
+  .feat-pill{gap:7px;padding:6px 8px;min-width:0}
+  .feat-pill-icon{width:28px;height:28px;flex-shrink:0}
+  .feat-pill-info{min-width:0;overflow-wrap:break-word}
+  .feat-pill-info .feat-pill-title{font-size:0.76rem;line-height:1.25}
+  .feat-pill-info p{font-size:0.68rem;line-height:1.25}
   .workspace{gap:14px}
   .panel-header{padding:12px 14px}
   .mode-row{gap:6px;padding:10px 14px}


### PR DESCRIPTION
## Description

Fixed a mobile responsiveness issue where feature card titles and descriptions were hidden on screens below 400px. Removed the CSS rule that hid the feature card text, ensuring that feature icons, titles, and descriptions remain visible and readable on mobile devices.

## Related Issue

Fixes #1047 

## Type of change

* [x] Bug fix
* [ ] New feature / enhancement
* [ ] Documentation update
* [ ] Test addition
* [ ] Refactor

## Checklist

* [x] I have read [[CONTRIBUTING.md](https://chatgpt.com/CONTRIBUTING.md)](../CONTRIBUTING.md)
* [x] My branch is up to date with `main`
* [ ] I have run `pytest -v` and all tests pass
* [x] I have not introduced duplicate issues or features
* [x] My PR title follows the format: `feat/fix/docs/test: short description`
* [ ] I have added tests for new features (Level 2 and 3 issues)
* [x] No hardcoded secrets or API keys in my code
* [x] This PR is linked to a GSSoC 2026 issue

## Screenshots (if frontend change)

### Before

Feature card titles and descriptions were hidden on mobile devices, leaving only the icons visible.

### After

Feature card icons, titles, and descriptions are now visible and readable on mobile devices.

<img width="581" height="827" alt="Screenshot_17-6-2026_11179_127 0 0 1" src="https://github.com/user-attachments/assets/a64d008f-de17-4ab2-b4f9-f6a7ef66470e" />

## Test evidence

Verified manually using Chrome DevTools mobile device emulation.

Tested on multiple mobile device profiles, including iPhone and Samsung devices.

Results:

* ✓ Feature icons are visible
* ✓ Feature titles are visible
* ✓ Feature descriptions are visible
* ✓ Content remains readable on mobile screens
* ✓ No text overlap or truncation observed