### PR TITLE
Reset buffer cursor

### DIFF
--- a/backend/app/routers/analyze.py
+++ b/backend/app/routers/analyze.py
@@ -253,6 +253,8 @@ async def analyze_zip(request: Request, file: UploadFile = File(...)):
             detail="Uploaded ZIP file is empty",
         )
 
+    buffer.seek(0)  # reset cursor after chunked write; without this ZipFile reads from EOF
+
     try:
         archive = zipfile.ZipFile(buffer)
     except zipfile.BadZipFile as exc:


### PR DESCRIPTION
Reset buffer cursor before reading ZIP file to avoid EOF issues.

## Description
Added buffer.seek(0) after the chunked upload loop, before zipfile.ZipFile(buffer)

## Related Issue

Fixes #1076

## Type of change
- [x] Bug fix


## Checklist
<!-- All boxes must be checked before requesting review -->
- [x] I have read [CONTRIBUTING.md](../CONTRIBUTING.md)
- [x] My branch is up to date with `main`
- [x] I have run `pytest -v` and all tests pass
- [x] I have not introduced duplicate issues or features
- [x] My PR title follows the format: `feat/fix/docs/test: short description`
- [x] I have added tests for new features (Level 2 and 3 issues)
- [x] No hardcoded secrets or API keys in my code
- [x] This PR is linked to a GSSoC 2026 issue

