### PR TITLE
fix: add logging for LLM errors and distinguish fallback modes

### DIFF
--- a/backend/app/routers/chat.py
+++ b/backend/app/routers/chat.py
@@ -1,3 +1,5 @@
+import logging
+
 from fastapi import APIRouter
 
 from ..config import settings
@@ -6,6 +8,8 @@ from ..services.code_assistant import chat_fallback_reply
 from ..services.llm_analysis import llm_analysis_client
 
 router = APIRouter(prefix="/chat", tags=["Chat"])
+
+logger = logging.getLogger(__name__)
 
 
 @router.post("", response_model=ChatResponse)
@@ -19,8 +23,8 @@ async def chat(payload: ChatRequest) -> ChatResponse:
                 level="intermediate",
             )
             return ChatResponse(response=reply)
-        except Exception:
-            pass
+        except Exception as exc:
+            logger.warning("LLM chat request failed, falling back to rule-based: %s", exc)
 
     fallback_reply = chat_fallback_reply(
         message=payload.message,
@@ -47,8 +51,10 @@ async def chat_message(payload: ChatMessageRequest) -> ChatMessageResponse:
                 mode="live-llm",
                 reply=reply,
             )
-        except Exception:
-            pass
+        except Exception as exc:
+            logger.warning(
+                "LLM chat_message request failed, falling back to rule-based: %s", exc
+            )
 
     fallback_reply = chat_fallback_reply(
         message=payload.message,
@@ -60,6 +66,6 @@ async def chat_message(payload: ChatMessageRequest) -> ChatMessageResponse:
     return ChatMessageResponse(
         provider=settings.ai_provider,
         model=settings.ai_model,
-        mode="ready+chat_fallback",
+        mode="llm_error_fallback" if llm_analysis_client.enabled else "ready+chat_fallback",
         reply=fallback_reply,
     )

--- a/backend/tests/test_zip_dos.py
+++ b/backend/tests/test_zip_dos.py
@@ -44,3 +44,33 @@ def test_analyze_zip_valid():
     assert response.status_code == 200
     assert response.json()["file_count"] == 1
     assert response.json()["files"][0]["filename"] == "hello.py"
+
+
+def test_analyze_zip_valid_multi_file():
+    """Regression test: chunked BytesIO read must seek(0) before ZipFile opens it.
+    Without the fix, any valid ZIP upload fails with 400 'Invalid ZIP file'."""
+    zip_buffer = io.BytesIO()
+    with zipfile.ZipFile(zip_buffer, "w", zipfile.ZIP_DEFLATED) as zf:
+        zf.writestr("main.py", "def hello():\n    return 'world'\n")
+        zf.writestr("utils.js", "function add(a, b) { return a + b; }")
+
+    zip_buffer.seek(0)
+    files = {"file": ("project.zip", zip_buffer, "application/zip")}
+    response = client.post("/analyze/zip/", files=files)
+
+    assert response.status_code == 200, (
+        f"Expected 200 but got {response.status_code}: {response.json()}"
+    )
+    assert response.json()["file_count"] == 2
+
+
+def test_chat_llm_error_fallback_mode():
+    """Regression test: when LLM is disabled, /chat/message must return
+    mode='ready+chat_fallback' (not silently crash or return wrong mode)."""
+    payload = {"message": "explain this code", "code": "print('hi')", "history": [], "level": "beginner"}
+    response = client.post("/chat/message", json=payload)
+
+    assert response.status_code == 200
+    data = response.json()
+    assert "reply" in data
+    assert data["mode"] in ("ready+chat_fallback", "llm_error_fallback", "live-llm")


### PR DESCRIPTION
## Description
Added import logging and a module-level logger
Both except Exception: blocks now capture the exception and log it as a warning
In /chat/message, the mode field now returns "llm_error_fallback" when the LLM is configured but threw an error, vs "ready+chat_fallback" when LLM is simply not enabled — so callers can distinguish the two cases

2 regression tests added - test_analyze_zip_valid_multi_file — uploads a real 2-file ZIP and asserts a 200 with file_count == 2 (would have caught the original bug)
test_chat_llm_error_fallback_mode — asserts /chat/message returns 200 with a valid mode and reply field

## Related Issue
<!-- Required — link the issue this PR fixes -->
Fixes #1077

## Type of change
- [x] Bug fix
- [ ] New feature / enhancement
- [ ] Documentation update
- [x] Test addition
- [ ] Refactor

## Checklist
<!-- All boxes must be checked before requesting review -->
- [x] I have read [CONTRIBUTING.md](../CONTRIBUTING.md)
- [x] My branch is up to date with `main`
- [x] I have run `pytest -v` and all tests pass
- [x] I have not introduced duplicate issues or features
- [x] My PR title follows the format: `feat/fix/docs/test: short description`
- [x] I have added tests for new features (Level 2 and 3 issues)
- [x] No hardcoded secrets or API keys in my code
- [x] This PR is linked to a GSSoC 2026 issue

