### PR TITLE
fix: localize mode selector buttons

### DIFF
--- a/frontend/index.html
+++ b/frontend/index.html
@@ -2309,10 +2309,10 @@ details.issue-card[open] {
           <div id="charCount">0 chars · 0 lines</div>
           <div style="display:flex;gap:8px">
             <div class="mode-row" role="tablist" aria-label="Mode selector">
-              <button class="mode-btn active" data-mode="analyze" aria-pressed="true">Full</button>
-              <button class="mode-btn" data-mode="explain" aria-pressed="false">Explain</button>
-              <button class="mode-btn" data-mode="debug" aria-pressed="false">Debug</button>
-              <button class="mode-btn" data-mode="suggest" aria-pressed="false">Improve</button>
+              <button class="mode-btn active" data-mode="analyze" aria-pressed="true" data-i18n="mode_full">Full</button>
+              <button class="mode-btn" data-mode="explain" aria-pressed="false" data-i18n="tab_explain">Explain</button>
+              <button class="mode-btn" data-mode="debug" aria-pressed="false" data-i18n="mode_debug">Debug</button>
+              <button class="mode-btn" data-mode="suggest" aria-pressed="false" data-i18n="tab_improve">Improve</button>
             </div>
           </div>
         </div>


### PR DESCRIPTION
## Description

Localized the mode selector buttons below the editor by connecting them to the existing i18n system.

Previously, the following buttons remained in English after switching the application language:

* Full
* Explain
* Debug
* Improve

The buttons were using hardcoded text in `frontend/index.html`, so they were not being updated by the existing localization mechanism.

This PR adds the appropriate `data-i18n` attributes to these buttons so that they are translated according to the selected application language.

## Related Issue

Fixes #1080

## Type of change

* [x] Bug fix
* [ ] New feature / enhancement
* [ ] Documentation update
* [ ] Test addition
* [ ] Refactor

## Checklist

* [ ] I have read CONTRIBUTING.md
* [ ] My branch is up to date with `main`
* [ ] I have run `pytest -v` and all tests pass
* [x] I have not introduced duplicate issues or features
* [x] My PR title follows the format: `feat/fix/docs/test: short description`
* [ ] I have added tests for new features (Level 2 and 3 issues)
* [x] No hardcoded secrets or API keys in my code
* [x] This PR is linked to a GSSoC 2026 issue

## Screenshot
<img width="1853" height="901" alt="Screenshot 2026-06-19 183231" src="https://github.com/user-attachments/assets/077c928f-f104-47ea-80d8-74e3860e5394" />


Before:
Mode selector buttons remained in English even after changing the application language.

After:
Mode selector buttons are translated correctly according to the selected language.

## Test evidence

Manual testing completed:

* Switched application language from English to Hindi.
* Verified that Full, Explain, Debug, and Improve buttons were translated correctly.
* Switched back to English and confirmed the original labels were restored.
* Confirmed that other existing localized UI elements continued to work correctly.
