### PR TITLE
feat: add Markdown and PDF export buttons for reports

### DIFF
--- a/docs/CHANGELOG.md
+++ b/docs/CHANGELOG.md
@@ -5,7 +5,6 @@ All notable changes to QyverixAI are documented in this file.
 ## [Unreleased]
 
 ### Added
-- Added Markdown and PDF export options for analysis reports (#748)
 - Added a dedicated changelog page in `docs/CHANGELOG.md`.
 - Added changelog guidance for contributors and PR authors.
 

--- a/docs/CHANGELOG.md
+++ b/docs/CHANGELOG.md
@@ -5,6 +5,7 @@ All notable changes to QyverixAI are documented in this file.
 ## [Unreleased]
 
 ### Added
+- Added Markdown and PDF export options for analysis reports (#748)
 - Added a dedicated changelog page in `docs/CHANGELOG.md`.
 - Added changelog guidance for contributors and PR authors.
 

--- a/frontend/index.html
+++ b/frontend/index.html
@@ -2097,6 +2097,7 @@ details.issue-card[open] {
 }
 </style>
 <link rel="icon" href="data:,">
+<script src="https://cdnjs.cloudflare.com/ajax/libs/html2pdf.js/0.10.1/html2pdf.bundle.min.js"></script>
 </head>
 <body>
   <div class="bg-orb bg-orb-1"></div>
@@ -2328,6 +2329,8 @@ details.issue-card[open] {
         <div id="resultActions" class="result-actions" style="display:none">
           <button class="icon-btn" id="favBtn" title="Save to favorites">★</button>
           <button class="icon-btn" id="downloadBtn" title="Download results">⬇</button>
+          <button class="icon-btn" id="export-pdf-btn" title="Export as PDF">📄</button>
+          <button class="icon-btn" id="export-md-btn" title="Export as Markdown">📝</button>
         </div>
 
       </div>
@@ -4216,6 +4219,83 @@ document.getElementById('clearFavsBtn').addEventListener('click', () => {
         a.click();
         URL.revokeObjectURL(a.href);
         toast(getTranslation('toast_report_downloaded'), 'success');
+      });
+
+      // 1. Export as Markdown
+      document.getElementById('export-md-btn').addEventListener('click', () => {
+        if (!currentResult) return alert("No report generated yet!");
+        
+        try {
+            const codeContent = typeof editor !== 'undefined' ? editor.value : '';
+            const rawText = buildReport(currentResult, codeContent);
+            const mdText = "```text\n" + rawText + "\n```";
+            
+            const blob = new Blob([mdText], { type: 'text/markdown' });
+            const a = document.createElement('a');
+            a.href = URL.createObjectURL(blob);
+            a.download = `qyverixai-report-${Date.now()}.md`;
+            a.click();
+            URL.revokeObjectURL(a.href);
+            
+            if (typeof toast === 'function') toast('Downloaded as Markdown', 'success');
+        } catch (error) {
+            console.error("Markdown Error: ", error);
+            alert("Oops! Something went wrong generating the Markdown.");
+        }
+      });
+
+      // 2. Export as PDF
+      document.getElementById('export-pdf-btn').addEventListener('click', () => {
+        if (!currentResult) return alert("No report generated yet!");
+        
+        try {
+            const codeContent = typeof editor !== 'undefined' ? editor.value : '';
+            const rawText = buildReport(currentResult, codeContent);
+            
+            const lines = rawText.split('\n');
+            const linesPerPage = 45; 
+            
+            // Build a container in memory
+            const container = document.createElement('div');
+            container.style.width = '700px';
+            container.style.backgroundColor = '#ffffff';
+
+            for (let i = 0; i < lines.length; i += linesPerPage) {
+                const chunkText = lines.slice(i, i + linesPerPage).join('\n');
+                
+                const pageDiv = document.createElement('div');
+                pageDiv.style.fontFamily = 'monospace';
+                pageDiv.style.fontSize = '12px';
+                pageDiv.style.lineHeight = '1.5';
+                pageDiv.style.color = '#000000';
+                pageDiv.style.whiteSpace = 'pre-wrap';
+                pageDiv.innerText = chunkText === '' ? ' ' : chunkText;
+                
+                container.appendChild(pageDiv);
+                
+                if (i + linesPerPage < lines.length) {
+                    const pageBreak = document.createElement('div');
+                    pageBreak.className = 'html2pdf__page-break';
+                    container.appendChild(pageBreak);
+                }
+            }
+
+            const options = {
+              margin:       10,
+              filename:     `qyverixai-report-${Date.now()}.pdf`,
+              image:        { type: 'jpeg', quality: 0.98 },
+              html2canvas:  { scale: 2, scrollY: 0 }, 
+              jsPDF:        { unit: 'mm', format: 'a4', orientation: 'portrait' }
+            };
+
+            html2pdf().set(options).from(container).save().then(() => {
+              if (typeof toast === 'function') toast('Downloaded as PDF', 'success');
+            });
+            
+        } catch (error) {
+            console.error("PDF Error: ", error);
+            alert("Oops! Something went wrong generating the PDF.");
+        }
       });
 
       function buildReport(r, code) {


### PR DESCRIPTION
## Description
Added Markdown and PDF export options for the analysis report. This includes integrating `html2pdf.js` with text chunking to bypass canvas limits, and hooking up the native toast notifications.

## Related Issue
Fixes #748

## Type of change
- [ ] Bug fix
- [x] New feature / enhancement
- [ ] Documentation update
- [ ] Test addition
- [ ] Refactor

## Checklist
- [x] I have read [CONTRIBUTING.md](../CONTRIBUTING.md)
- [x] My branch is up to date with `main`
- [x] I have run `pytest -v` and all tests pass
- [x] I have not introduced duplicate issues or features
- [x] My PR title follows the format: `feat/fix/docs/test: short description`
- [x] I have added tests for new features (Level 2 and 3 issues)
- [x] No hardcoded secrets or API keys in my code
- [x] This PR is linked to a GSSoC 2026 issue

## Screenshots
Before
<img width="1366" height="674" alt="Screenshot 2026-06-19 195004" src="https://github.com/user-attachments/assets/69a6680c-17cf-4515-a7ca-dbc28f442e80" />

After
<img width="1366" height="673" alt="Screenshot 2026-06-19 195222" src="https://github.com/user-attachments/assets/7d53f8c5-d256-42a0-99cd-8e9c0460c7cc" />

## Test evidence
Since this is purely a frontend HTML/JS update, the backend 'pytest' suite is unaffected, but all existing tests pass locally.