### PR TITLE
feat(auth): harden authentication against token replay

### DIFF
--- a/backend/app/routers/auth.py
+++ b/backend/app/routers/auth.py
@@ -1,16 +1,28 @@
+import time
+
 from fastapi import APIRouter, Depends, HTTPException, status
+from fastapi.security import HTTPAuthorizationCredentials
 from sqlalchemy import select
 from sqlalchemy.orm import Session
 
 from ..database import get_db
 from ..models import User
-from ..schemas import AuthResponse, LoginRequest, SignupRequest, UserProfileResponse
+from ..schemas import (
+    AuthResponse,
+    LoginRequest,
+    MessageResponse,
+    SignupRequest,
+    UserProfileResponse,
+)
 from ..security import (
+    bearer_scheme,
     create_access_token,
+    decode_token,
     get_current_user,
     hash_password,
     verify_password,
 )
+from ..token_denylist import token_denylist
 
 router = APIRouter(prefix="/auth", tags=["Auth"])
 
@@ -54,3 +66,23 @@ def login(payload: LoginRequest, db: Session = Depends(get_db)):
 @router.get("/me", response_model=UserProfileResponse)
 def me(current_user: User = Depends(get_current_user)):
     return UserProfileResponse(user_id=current_user.id, email=current_user.email)
+
+
+@router.post("/logout", response_model=MessageResponse)
+def logout(
+    current_user: User = Depends(get_current_user),
+    credentials: HTTPAuthorizationCredentials = Depends(bearer_scheme),
+):
+    """Revoke the caller's current access token.
+
+    The token's ``jti`` is added to the server-side denylist until the token's
+    own expiry, so any later replay of the same token is rejected with 401. The
+    ``get_current_user`` dependency guarantees the token is valid here, so
+    decoding it again cannot fail.
+    """
+    claims = decode_token(credentials.credentials)
+    jti = claims.get("jti")
+    if jti:
+        expires_at = float(claims.get("exp", time.time()))
+        token_denylist.revoke(jti, expires_at)
+    return MessageResponse(message="Logged out; token revoked.")

--- a/backend/app/schemas.py
+++ b/backend/app/schemas.py
@@ -408,6 +408,16 @@ class UserProfileResponse(BaseModel):
     )
 
 
+class MessageResponse(BaseModel):
+    """Generic success message returned by actions without a richer payload."""
+
+    message: str = Field(
+        ...,
+        description="Human-readable description of the action's outcome.",
+        example="Logged out; token revoked.",
+    )
+
+
 # ── Health ────────────────────────────────────────────────────────────────────
 class HealthResponse(BaseModel):
     """Generic health / status response."""

--- a/backend/app/security.py
+++ b/backend/app/security.py
@@ -1,7 +1,8 @@
-from datetime import datetime, timedelta, timezone
 import hashlib
 import hmac
 import os
+import uuid
+from datetime import datetime, timedelta, timezone
 
 import jwt
 from fastapi import Depends, HTTPException, status
@@ -11,6 +12,7 @@ from sqlalchemy.orm import Session
 from .config import settings
 from .database import get_db
 from .models import User
+from .token_denylist import token_denylist
 
 bearer_scheme = HTTPBearer(auto_error=False)
 
@@ -34,18 +36,34 @@ def verify_password(password: str, encoded: str) -> bool:
 
 
 def create_access_token(user_id: int) -> str:
-    expires = datetime.now(timezone.utc) + timedelta(
-        minutes=settings.access_token_minutes
-    )
-    payload = {"sub": str(user_id), "exp": expires}
+    """Mint a signed access token for ``user_id``.
+
+    Each token carries a unique ``jti`` so it can be individually revoked (see
+    ``token_denylist``), plus ``iat`` to record when it was issued.
+    """
+    now = datetime.now(timezone.utc)
+    expires = now + timedelta(minutes=settings.access_token_minutes)
+    payload = {
+        "sub": str(user_id),
+        "iat": now,
+        "exp": expires,
+        "jti": uuid.uuid4().hex,
+    }
     return jwt.encode(payload, settings.jwt_secret, algorithm=settings.jwt_algorithm)
 
 
+def decode_token(token: str) -> dict:
+    """Decode and verify a JWT, returning its claims.
+
+    Raises ``jwt.PyJWTError`` (or a subclass) if the token is malformed, has an
+    invalid signature, or has expired.
+    """
+    return jwt.decode(token, settings.jwt_secret, algorithms=[settings.jwt_algorithm])
+
+
 def decode_access_token(token: str) -> int:
-    payload = jwt.decode(
-        token, settings.jwt_secret, algorithms=[settings.jwt_algorithm]
-    )
-    return int(payload["sub"])
+    """Return the user id (``sub``) encoded in a valid access token."""
+    return int(decode_token(token)["sub"])
 
 
 def get_current_user(
@@ -58,10 +76,16 @@ def get_current_user(
         )
 
     try:
-        user_id = decode_access_token(credentials.credentials)
+        claims = decode_token(credentials.credentials)
+        user_id = int(claims["sub"])
     except Exception:
         raise HTTPException(
             status_code=status.HTTP_401_UNAUTHORIZED, detail="Invalid token"
+        )
+
+    if token_denylist.is_revoked(claims.get("jti", "")):
+        raise HTTPException(
+            status_code=status.HTTP_401_UNAUTHORIZED, detail="Token has been revoked"
         )
 
     user = db.get(User, user_id)

--- a/backend/app/token_denylist.py
+++ b/backend/app/token_denylist.py
@@ -1,0 +1,80 @@
+"""In-memory revocation store for JWT identifiers (``jti``).
+
+Access tokens are revoked by recording their ``jti`` here. ``get_current_user``
+consults this store on every authenticated request and rejects any token whose
+``jti`` has been revoked. This defeats *replay* of a captured-but-revoked token
+— for example, a token a user explicitly invalidated by logging out can no
+longer be reused even though its signature and ``exp`` are still valid.
+
+Design notes:
+
+* Each entry carries the revoked token's own expiry, so a ``jti`` only needs to
+  be remembered until the moment the token would have expired anyway. After that
+  the standard signature/``exp`` check rejects it for free, so the entry is
+  purged to keep memory bounded.
+* The store is process-local and guarded by a lock so it is safe to call from
+  the threadpool FastAPI uses for synchronous route handlers.
+* It is intentionally a thin seam: the same ``revoke`` / ``is_revoked`` API can
+  later be backed by Redis (the project already exposes ``settings.redis_url``)
+  without touching any call sites.
+"""
+
+from __future__ import annotations
+
+import threading
+import time
+
+
+class TokenDenylist:
+    """A TTL-bounded set of revoked JWT ``jti`` values."""
+
+    def __init__(self) -> None:
+        # Maps jti -> epoch-seconds expiry of the revoked token.
+        self._revoked: dict[str, float] = {}
+        self._lock = threading.Lock()
+
+    def revoke(self, jti: str, expires_at: float) -> None:
+        """Mark ``jti`` as revoked until ``expires_at`` (epoch seconds).
+
+        A falsy ``jti`` is ignored so callers need not special-case tokens that
+        predate the ``jti`` claim.
+        """
+        if not jti:
+            return
+        with self._lock:
+            self._purge_expired()
+            self._revoked[jti] = expires_at
+
+    def is_revoked(self, jti: str) -> bool:
+        """Return ``True`` if ``jti`` is currently revoked and not yet expired."""
+        if not jti:
+            return False
+        now = time.time()
+        with self._lock:
+            expires_at = self._revoked.get(jti)
+            if expires_at is None:
+                return False
+            if expires_at <= now:
+                # The token has expired on its own; drop the bookkeeping entry.
+                self._revoked.pop(jti, None)
+                return False
+            return True
+
+    def _purge_expired(self) -> None:
+        """Drop entries whose tokens have already expired. Caller holds the lock."""
+        now = time.time()
+        expired = [
+            jti for jti, expires_at in self._revoked.items() if expires_at <= now
+        ]
+        for jti in expired:
+            self._revoked.pop(jti, None)
+
+    def clear(self) -> None:
+        """Forget all revoked tokens. Primarily a test helper."""
+        with self._lock:
+            self._revoked.clear()
+
+
+# Process-wide singleton. Swap for a Redis-backed implementation behind the same
+# interface to share revocations across workers.
+token_denylist = TokenDenylist()

--- a/backend/tests/test_auth_endpoints.py
+++ b/backend/tests/test_auth_endpoints.py
@@ -13,7 +13,8 @@ sys.path.insert(0, os.path.dirname(os.path.dirname(__file__)))
 
 from app.database import Base, get_db
 from app.main import app as fastapi_app
-
+from app.security import decode_token
+from app.token_denylist import token_denylist
 
 TEST_ENGINE = create_engine(
     "sqlite:///:memory:",
@@ -50,6 +51,15 @@ def _recreate_tables():
     Base.metadata.drop_all(bind=TEST_ENGINE)
 
 
+@pytest.fixture(autouse=True)
+def _reset_denylist():
+    # The denylist is a process-wide singleton; reset it so revocations from one
+    # test never leak into another.
+    token_denylist.clear()
+    yield
+    token_denylist.clear()
+
+
 def test_auth_routes_are_exposed_in_openapi(client):
     response = client.get("/openapi.json")
     assert response.status_code == 200
@@ -58,6 +68,7 @@ def test_auth_routes_are_exposed_in_openapi(client):
     assert "/auth/signup" in paths
     assert "/auth/login" in paths
     assert "/auth/me" in paths
+    assert "/auth/logout" in paths
 
 
 def test_signup_login_and_me_happy_path(client):
@@ -111,3 +122,74 @@ def test_me_rejects_missing_and_invalid_token(client):
     )
     assert invalid_token_response.status_code == 401
     assert "invalid token" in invalid_token_response.json()["detail"].lower()
+
+
+def _signup_and_get_token(client, email: str = "replay@example.com") -> str:
+    response = client.post(
+        "/auth/signup",
+        json={"email": email, "password": "StrongPass123!"},
+    )
+    assert response.status_code == 200
+    return response.json()["access_token"]
+
+
+def test_access_token_carries_unique_jti_and_iat(client):
+    first = decode_token(_signup_and_get_token(client, "jti.one@example.com"))
+    second_token = client.post(
+        "/auth/login",
+        json={"email": "jti.one@example.com", "password": "StrongPass123!"},
+    ).json()["access_token"]
+    second = decode_token(second_token)
+
+    assert first["jti"] and second["jti"]
+    assert "iat" in first
+    # Every minted token must have a distinct id so it can be revoked on its own.
+    assert first["jti"] != second["jti"]
+
+
+def test_logout_revokes_token_and_blocks_replay(client):
+    token = _signup_and_get_token(client)
+    headers = {"Authorization": f"Bearer {token}"}
+
+    # The token works before logout.
+    assert client.get("/auth/me", headers=headers).status_code == 200
+
+    logout_response = client.post("/auth/logout", headers=headers)
+    assert logout_response.status_code == 200
+    assert "revoked" in logout_response.json()["message"].lower()
+
+    # Replaying the exact same (still cryptographically valid) token now fails.
+    replay_response = client.get("/auth/me", headers=headers)
+    assert replay_response.status_code == 401
+    assert "revoked" in replay_response.json()["detail"].lower()
+
+
+def test_logout_requires_authentication(client):
+    assert client.post("/auth/logout").status_code == 401
+
+
+def test_revoking_one_token_leaves_other_sessions_valid(client):
+    first = _signup_and_get_token(client, "multi@example.com")
+    second = client.post(
+        "/auth/login",
+        json={"email": "multi@example.com", "password": "StrongPass123!"},
+    ).json()["access_token"]
+
+    # Log out only the first session.
+    assert (
+        client.post(
+            "/auth/logout", headers={"Authorization": f"Bearer {first}"}
+        ).status_code
+        == 200
+    )
+
+    assert (
+        client.get("/auth/me", headers={"Authorization": f"Bearer {first}"}).status_code
+        == 401
+    )
+    assert (
+        client.get(
+            "/auth/me", headers={"Authorization": f"Bearer {second}"}
+        ).status_code
+        == 200
+    )

--- a/docs/CHANGELOG.md
+++ b/docs/CHANGELOG.md
@@ -7,9 +7,15 @@ All notable changes to QyverixAI are documented in this file.
 ### Added
 - Added a dedicated changelog page in `docs/CHANGELOG.md`.
 - Added changelog guidance for contributors and PR authors.
+- Added `POST /auth/logout` to revoke the caller's access token.
 
 ### Changed
 - Linked the changelog from `README.md` for faster discoverability.
+
+### Security
+- Hardened authentication against token replay: access tokens now carry a
+  unique `jti`, and revoked tokens (e.g. after logout) are rejected via a
+  server-side denylist until they expire.
 
 ## [3.0.0] - 2026-06-06
 


### PR DESCRIPTION
## Summary

Closes #490.

A valid access token that gets captured can currently be replayed until it expires, and there's no way to invalidate one early (e.g. on logout). This PR adds a way to revoke individual tokens and rejects revoked ones.

## What changed

- Every access token now carries a unique `jti` (token id) and an `iat` (issued-at) claim.
- New `token_denylist` module: a TTL-bounded, thread-safe in-memory store of revoked `jti`s. Entries are only kept until the token's own `exp`, then purged, so memory stays bounded. The interface is small on purpose so it can be backed by Redis later (the project already exposes `settings.redis_url`) without touching call sites.
- New `POST /auth/logout` endpoint that revokes the caller's current token.
- `get_current_user` now rejects any revoked token with `401`.

## Behaviour

- Replaying a token after logout → `401 Token has been revoked`.
- Other active sessions/tokens for the same user keep working.
- Tokens issued before this change (no `jti`) are handled gracefully.

## Tests

Added to `backend/tests/test_auth_endpoints.py` (8 passing):
- logout then reuse the same token → 401
- a second token stays valid after the first is revoked
- issued tokens carry a unique `jti` / `iat`

## Checklist

- [x] My PR title follows the format: `feat/fix/docs/test: short description`
- [x] I have added tests for new features
- [x] No hardcoded secrets or API keys in my code
- [x] This PR is linked to a GSSoC 2026 issue
- [x] I have updated `docs/CHANGELOG.md`