### PR TITLE
feat: add POST /export/jsonl endpoint for JSONL streaming

### DIFF
--- a/.agents/workflows/code-review-and-security.md
+++ b/.agents/workflows/code-review-and-security.md
@@ -1,0 +1,4 @@
+---
+description:
+---
+

--- a/.agents/workflows/code-review-and-security.md
+++ b/.agents/workflows/code-review-and-security.md
@@ -1,4 +1,0 @@
----
-description:
----
-

--- a/backend/app/main.py
+++ b/backend/app/main.py
@@ -16,7 +16,7 @@ from fastapi.responses import JSONResponse
 from fastapi.staticfiles import StaticFiles
 
 from .observability import initialise_app_info, prometheus_metrics_middleware
-from .routers import analyze, auth, chat, collaboration, debugging, explanation
+from .routers import analyze, auth, chat, collaboration, debugging, explanation, export
 from .routers import health as health_router
 from .routers import history
 from .routers import metrics as metrics_router
@@ -173,6 +173,7 @@ async def add_process_time_header(request: Request, call_next):
         "/debugging/",
         "/suggestions/",
         "/analyze/",
+        "/export/jsonl",
     ):
         remaining = check_rate_limit(ip)
         if remaining < 0:
@@ -210,6 +211,7 @@ app.include_router(explanation.router, prefix="/explanation", tags=["Explanation
 app.include_router(debugging.router, prefix="/debugging", tags=["Debugging"])
 app.include_router(suggestions.router, prefix="/suggestions", tags=["Suggestions"])
 app.include_router(analyze.router, prefix="/analyze", tags=["Full Analysis"])
+app.include_router(export.router, prefix="/export", tags=["Export"])
 app.include_router(subscribe.router, prefix="/subscribe", tags=["Subscription"])
 app.include_router(history.router, prefix="/history", tags=["History"])
 app.include_router(auth.router)

--- a/backend/app/routers/export.py
+++ b/backend/app/routers/export.py
@@ -1,0 +1,65 @@
+from __future__ import annotations
+
+import asyncio
+import json
+
+from fastapi import APIRouter
+from fastapi.responses import StreamingResponse
+
+from ..sanitize import sanitize_code_input, sanitize_language_hint
+from ..schemas import CodeRequest
+from ..services.code_assistant import detect_language, run_bug_detection, run_explanation, run_suggestions
+
+router = APIRouter()
+
+
+async def _stream_jsonl(code: str, language_hint: str | None):
+    code = sanitize_code_input(code)
+    language_hint = sanitize_language_hint(language_hint)
+
+    language = detect_language(code, language_hint)
+
+    explanation = run_explanation(code, language)
+    yield json.dumps({"type": "explanation", "data": explanation}) + "\n"
+    await asyncio.sleep(0)
+
+    raw_issues = run_bug_detection(code, language)
+
+    errors = [i for i in raw_issues if i["severity"] == "error"]
+    warnings = [i for i in raw_issues if i["severity"] == "warning"]
+    infos = [i for i in raw_issues if i["severity"] == "info"]
+
+    debugging = {
+        "issues": raw_issues,
+        "summary": (
+            f"Found {len(raw_issues)} issue(s): "
+            f"{len(errors)} error(s), "
+            f"{len(warnings)} warning(s), "
+            f"{len(infos)} info."
+            if raw_issues
+            else "✅ No issues detected!"
+        ),
+        "clean": len(raw_issues) == 0,
+        "error_count": len(errors),
+        "warning_count": len(warnings),
+        "info_count": len(infos),
+    }
+
+    yield json.dumps({"type": "debugging", "data": debugging}) + "\n"
+    await asyncio.sleep(0)
+
+    suggestions = run_suggestions(code, language)
+    yield json.dumps({"type": "suggestions", "data": suggestions}) + "\n"
+    await asyncio.sleep(0)
+
+
+@router.post(
+    "/jsonl",
+    summary="Stream analysis results as JSONL (NDJSON)",
+    response_class=StreamingResponse,
+)
+async def export_jsonl(req: CodeRequest):
+    return StreamingResponse(
+        _stream_jsonl(req.code, req.language),
+        media_type="application/x-ndjson",
+    )

--- a/backend/app/routers/export.py
+++ b/backend/app/routers/export.py
@@ -62,4 +62,5 @@ async def export_jsonl(req: CodeRequest):
     return StreamingResponse(
         _stream_jsonl(req.code, req.language),
         media_type="application/x-ndjson",
+        headers={"Cache-Control": "no-cache", "X-Accel-Buffering": "no"},
     )

--- a/backend/app/routers/export.py
+++ b/backend/app/routers/export.py
@@ -8,7 +8,12 @@ from fastapi.responses import StreamingResponse
 
 from ..sanitize import sanitize_code_input, sanitize_language_hint
 from ..schemas import CodeRequest
-from ..services.code_assistant import detect_language, run_bug_detection, run_explanation, run_suggestions
+from ..services.code_assistant import (
+    detect_language,
+    run_bug_detection,
+    run_explanation,
+    run_suggestions,
+)
 
 router = APIRouter()
 

--- a/backend/sample_jsonl_client.py
+++ b/backend/sample_jsonl_client.py
@@ -7,7 +7,7 @@ def divide(a, b):
     return a / b
 
 result = divide(10, 0)
-password = "supersecret123"
+password = "example_password"
 
 try:
     pass
@@ -18,11 +18,17 @@ except:
 url = "http://localhost:8000/export/jsonl"
 payload = {"code": SAMPLE_CODE}
 
-with httpx.stream("POST", url, json=payload, timeout=30) as response:
-    response.raise_for_status()
-    for line in response.iter_lines():
-        if line.strip():
-            obj = json.loads(line)
-            print(f"[{obj['type']}]")
-            print(json.dumps(obj["data"], indent=2))
-            print()
+
+def main():
+    with httpx.stream("POST", url, json=payload, timeout=30) as response:
+        response.raise_for_status()
+        for line in response.iter_lines():
+            if line.strip():
+                obj = json.loads(line)
+                print(f"[{obj['type']}]")
+                print(json.dumps(obj["data"], indent=2))
+                print()
+
+
+if __name__ == "__main__":
+    main()

--- a/backend/sample_jsonl_client.py
+++ b/backend/sample_jsonl_client.py
@@ -1,0 +1,28 @@
+import json
+
+import httpx
+
+SAMPLE_CODE = """
+def divide(a, b):
+    return a / b
+
+result = divide(10, 0)
+password = "supersecret123"
+
+try:
+    pass
+except:
+    pass
+"""
+
+url = "http://localhost:8000/export/jsonl"
+payload = {"code": SAMPLE_CODE}
+
+with httpx.stream("POST", url, json=payload, timeout=30) as response:
+    response.raise_for_status()
+    for line in response.iter_lines():
+        if line.strip():
+            obj = json.loads(line)
+            print(f"[{obj['type']}]")
+            print(json.dumps(obj["data"], indent=2))
+            print()

--- a/backend/tests/test_endpoints.py
+++ b/backend/tests/test_endpoints.py
@@ -734,3 +734,29 @@ def test_get_stream_with_language_hint():
 def test_get_stream_empty_code_rejected():
     r = client.get("/analyze/stream", params={"code": "   "})
     assert r.status_code in (400, 422)
+
+
+# ── JSONL Export ──────────────────────────────────────────────────────────────
+def test_export_jsonl_returns_ndjson_content_type():
+    r = client.post("/export/jsonl", json={"code": PYTHON_BUGGY})
+    assert r.status_code == 200
+    assert "application/x-ndjson" in r.headers.get("content-type", "")
+
+
+def test_export_jsonl_emits_three_lines():
+    r = client.post("/export/jsonl", json={"code": PYTHON_BUGGY})
+    assert r.status_code == 200
+    lines = [ln for ln in r.text.split("\n") if ln.strip()]
+    parsed = [json.loads(ln) for ln in lines]
+    types = [obj["type"] for obj in parsed]
+    assert types == ["explanation", "debugging", "suggestions"]
+
+
+def test_export_jsonl_empty_code_rejected():
+    r = client.post("/export/jsonl", json={"code": "  "})
+    assert r.status_code == 422
+
+
+def test_export_jsonl_missing_code_rejected():
+    r = client.post("/export/jsonl", json={})
+    assert r.status_code == 422

--- a/backend/tests/test_endpoints.py
+++ b/backend/tests/test_endpoints.py
@@ -4,12 +4,12 @@ Run: cd backend && pytest -v
 """
 
 import json
+import os
+import sys
+from pathlib import Path
 
 import pytest
-from pathlib import Path
 from fastapi.testclient import TestClient
-import sys
-import os
 
 sys.path.insert(0, os.path.dirname(os.path.dirname(__file__)))
 from app import main as app_main

--- a/backend/tests/test_endpoints.py
+++ b/backend/tests/test_endpoints.py
@@ -18,8 +18,11 @@ client = TestClient(app_main.app)
 
 FIXTURES_DIR = Path(__file__).parent / "fixtures"
 
+
 def load_fixture(filename: str) -> str:
     return (FIXTURES_DIR / filename).read_text(encoding="utf-8")
+
+
 @pytest.fixture(autouse=True)
 def reset_rate_limit_state():
     app_main._request_counts.clear()
@@ -481,7 +484,6 @@ def test_debug_kotlin():
     assert d is not None
 
 
-
 def test_debug_cpp_syntax_errors():
     code = "void main() {\n    cout << 'Hello World'\n}"
     r = client.post("/debugging/", json={"code": code, "language": "cpp"})
@@ -562,15 +564,20 @@ def test_add():
     d = r.json()
     assert d["overall_score"] >= 60  # clean code should score reasonably
 
+
 def test_suggestions_observability_print_only_python():
     # Pasting code with print() in Java should NOT trigger the Observability suggestion
-    r_java = client.post("/suggestions/", json={"code": 'print("hello");', "language": "java"})
+    r_java = client.post(
+        "/suggestions/", json={"code": 'print("hello");', "language": "java"}
+    )
     assert r_java.status_code == 200
     s_java = [s["category"] for s in r_java.json()["suggestions"]]
     assert "Observability" not in s_java
 
     # Pasting code with print() in Python SHOULD trigger the Observability suggestion
-    r_py = client.post("/suggestions/", json={"code": 'print("hello")', "language": "python"})
+    r_py = client.post(
+        "/suggestions/", json={"code": 'print("hello")', "language": "python"}
+    )
     assert r_py.status_code == 200
     s_py = [s["category"] for s in r_py.json()["suggestions"]]
     assert "Observability" in s_py
@@ -724,7 +731,9 @@ def test_get_stream_done_event_present():
 
 
 def test_get_stream_with_language_hint():
-    r = client.get("/analyze/stream", params={"code": JS_CODE, "language": "javascript"})
+    r = client.get(
+        "/analyze/stream", params={"code": JS_CODE, "language": "javascript"}
+    )
     assert r.status_code == 200
     events = _parse_sse_events(r.text)
     exp = next(e["data"] for e in events if e["type"] == "explanation")


### PR DESCRIPTION
## Summary
Closes #623

Adds support for exporting analysis results as JSONL (newline-delimited JSON) 
via a new `POST /export/jsonl` endpoint, enabling incremental streaming and 
processing of large result sets.

## Changes Made
- `backend/app/routers/export.py` — new router with async JSONL streaming 
  endpoint using an async generator with proper `asyncio.sleep(0)` yield 
  points to keep the event loop non-blocking between chunks
- `backend/app/main.py` — imported export router, registered it at `/export` 
  with tag `"Export"`, and added `/export/jsonl` to the rate-limit middleware 
  path tuple
- `backend/tests/test_endpoints.py` — added 4 tests covering:
  - Content-type header is `application/x-ndjson`
  - Response body contains exactly 3 JSONL lines with types 
    `["explanation", "debugging", "suggestions"]`
  - Empty/whitespace code returns HTTP 422
  - Missing `code` field returns HTTP 422
- `backend/sample_jsonl_client.py` — standalone `httpx` script demonstrating 
  how to stream and parse the JSONL response line by line

## Endpoint Details
- **Route:** `POST /export/jsonl`
- **Input:** `{"code": "...", "language": "python"}` (same `CodeRequest` schema 
  as all existing endpoints)
- **Output:** `application/x-ndjson` — 3 newline-delimited JSON objects:
  - Line 1: `{"type": "explanation", "data": {...}}`
  - Line 2: `{"type": "debugging", "data": {...}}`
  - Line 3: `{"type": "suggestions", "data": {...}}`

## Streaming Design
Uses an `async` generator (`_stream_jsonl`) with `await asyncio.sleep(0)` 
after each yield, identical to the pattern in `analyze.py::_stream_analysis`. 
This yields control back to the event loop between chunks so the client 
receives data progressively, not all at once.

Format is intentionally **different from SSE** (`/analyze/stream`):
- SSE uses `"data: {...}\n\n"` prefix
- JSONL uses plain `"{...}\n"` — one JSON object per line, no prefix

## Input Handling
- Input is sanitized via existing `sanitize_code_input` and 
  `sanitize_language_hint` utilities before any processing
- `CodeRequest` Pydantic schema handles validation: empty/missing code 
  automatically returns 422 before the generator even runs
- Follows the same service layer (`detect_language`, `run_explanation`, 
  `run_bug_detection`, `run_suggestions`) and debugging dict structure as 
  `analyze.py`

## Testing
All existing tests pass. 4 new tests added.
```bash
cd backend && pytest tests/test_endpoints.py -q
