### PR TITLE
feat(admin): add audit logs for admin actions (#578)

### DIFF
--- a/backend/app/main.py
+++ b/backend/app/main.py
@@ -16,7 +16,7 @@ from fastapi.responses import JSONResponse
 from fastapi.staticfiles import StaticFiles
 
 from .observability import initialise_app_info, prometheus_metrics_middleware
-from .routers import analyze, auth, chat, collaboration, debugging, explanation
+from .routers import admin, analyze, auth, chat, collaboration, debugging, explanation
 from .routers import health as health_router
 from .routers import history
 from .routers import metrics as metrics_router
@@ -143,6 +143,10 @@ Obtain a token via `POST /auth/login` and pass it as `Authorization: Bearer <tok
             "description": "Email newsletter subscription and unsubscription.",
         },
         {
+            "name": "Admin",
+            "description": "Administrator-only operations (user role management, account deletion) and a queryable, append-only audit log of privileged actions.",
+        },
+        {
             "name": "System",
             "description": "Root info, legacy health check, and ping endpoints.",
         },
@@ -216,6 +220,7 @@ app.include_router(auth.router)
 app.include_router(chat.router)
 app.include_router(share.router)
 app.include_router(user_data.router)
+app.include_router(admin.router)
 app.include_router(upload_file.router, prefix="/upload", tags=["Upload File"])
 app.include_router(
     collaboration.router,

--- a/backend/app/models.py
+++ b/backend/app/models.py
@@ -1,6 +1,6 @@
 from datetime import UTC, datetime
 
-from sqlalchemy import DateTime, ForeignKey, Integer, String, Text
+from sqlalchemy import Boolean, DateTime, ForeignKey, Integer, String, Text
 from sqlalchemy.orm import Mapped, mapped_column, relationship
 
 from .database import Base
@@ -12,6 +12,7 @@ class User(Base):
     id: Mapped[int] = mapped_column(Integer, primary_key=True, index=True)
     email: Mapped[str] = mapped_column(String(320), unique=True, index=True)
     password_hash: Mapped[str] = mapped_column(String(256))
+    is_admin: Mapped[bool] = mapped_column(Boolean, default=False, nullable=False)
     created_at: Mapped[datetime] = mapped_column(
         DateTime, default=lambda: datetime.now(UTC)
     )
@@ -77,4 +78,29 @@ class SharedSnippet(Base):
     result_json: Mapped[str] = mapped_column(Text)
     created_at: Mapped[datetime] = mapped_column(
         DateTime, default=lambda: datetime.now(UTC)
+    )
+
+
+class AuditLog(Base):
+    """Append-only record of a privileged (admin) action.
+
+    Rows are written once and never updated or deleted by application code, so
+    the table acts as an immutable audit trail. ``actor_email`` is denormalised
+    so the record stays meaningful even if the acting user is later removed.
+    """
+
+    __tablename__ = "audit_logs"
+
+    id: Mapped[int] = mapped_column(Integer, primary_key=True, index=True)
+    actor_id: Mapped[int | None] = mapped_column(
+        ForeignKey("users.id", ondelete="SET NULL"), index=True, nullable=True
+    )
+    actor_email: Mapped[str] = mapped_column(String(320))
+    action: Mapped[str] = mapped_column(String(100), index=True)
+    target_type: Mapped[str | None] = mapped_column(String(50), nullable=True)
+    target_id: Mapped[str | None] = mapped_column(String(64), nullable=True)
+    details: Mapped[str | None] = mapped_column(Text, nullable=True)
+    ip_address: Mapped[str | None] = mapped_column(String(64), nullable=True)
+    created_at: Mapped[datetime] = mapped_column(
+        DateTime, default=lambda: datetime.now(UTC), index=True
     )

--- a/backend/app/routers/admin.py
+++ b/backend/app/routers/admin.py
@@ -1,0 +1,125 @@
+"""Admin router — privileged actions and the audit-log query API.
+
+Every state-changing endpoint here is gated behind :func:`require_admin` and
+records an append-only entry via :func:`record_audit`, giving a tamper-evident
+trail of who did what and when.
+"""
+
+import json
+
+from fastapi import APIRouter, Depends, HTTPException, Query, Request, status
+from sqlalchemy import select
+from sqlalchemy.orm import Session
+
+from ..database import get_db
+from ..models import AuditLog, User
+from ..schemas import AuditLogRecord, MessageResponse, RoleUpdateRequest
+from ..security import require_admin
+from ..services.audit import record_audit
+
+router = APIRouter(prefix="/admin", tags=["Admin"])
+
+
+def _client_ip(request: Request) -> str | None:
+    return request.client.host if request.client else None
+
+
+def _to_record(entry: AuditLog) -> AuditLogRecord:
+    return AuditLogRecord(
+        id=entry.id,
+        actor_id=entry.actor_id,
+        actor_email=entry.actor_email,
+        action=entry.action,
+        target_type=entry.target_type,
+        target_id=entry.target_id,
+        details=json.loads(entry.details) if entry.details else None,
+        ip_address=entry.ip_address,
+        created_at=entry.created_at.isoformat(),
+    )
+
+
+@router.get("/audit-logs", response_model=list[AuditLogRecord])
+def list_audit_logs(
+    action: str | None = Query(None, description="Filter by exact action name."),
+    actor_id: int | None = Query(None, description="Filter by acting admin's id."),
+    limit: int = Query(50, ge=1, le=200),
+    offset: int = Query(0, ge=0),
+    _admin: User = Depends(require_admin),
+    db: Session = Depends(get_db),
+):
+    """Return audit entries, newest first. Admin only."""
+    query = select(AuditLog).order_by(AuditLog.id.desc())
+    if action is not None:
+        query = query.where(AuditLog.action == action)
+    if actor_id is not None:
+        query = query.where(AuditLog.actor_id == actor_id)
+
+    entries = db.execute(query.limit(limit).offset(offset)).scalars().all()
+    return [_to_record(entry) for entry in entries]
+
+
+@router.put("/users/{user_id}/role", response_model=MessageResponse)
+def update_user_role(
+    user_id: int,
+    payload: RoleUpdateRequest,
+    request: Request,
+    admin: User = Depends(require_admin),
+    db: Session = Depends(get_db),
+):
+    """Grant or revoke a user's admin role, recording the change in the audit log."""
+    user = db.get(User, user_id)
+    if user is None:
+        raise HTTPException(
+            status_code=status.HTTP_404_NOT_FOUND, detail="User not found"
+        )
+
+    previous = user.is_admin
+    user.is_admin = payload.is_admin
+    record_audit(
+        db,
+        actor=admin,
+        action="user.role_update",
+        target_type="user",
+        target_id=user.id,
+        details={"from": previous, "to": payload.is_admin, "email": user.email},
+        ip_address=_client_ip(request),
+    )
+    db.commit()
+    return MessageResponse(
+        message=f"User {user_id} admin role set to {payload.is_admin}."
+    )
+
+
+@router.delete("/users/{user_id}", response_model=MessageResponse)
+def delete_user(
+    user_id: int,
+    request: Request,
+    admin: User = Depends(require_admin),
+    db: Session = Depends(get_db),
+):
+    """Delete a user account, recording the action in the audit log."""
+    if user_id == admin.id:
+        raise HTTPException(
+            status_code=status.HTTP_400_BAD_REQUEST,
+            detail="Admins cannot delete their own account",
+        )
+
+    user = db.get(User, user_id)
+    if user is None:
+        raise HTTPException(
+            status_code=status.HTTP_404_NOT_FOUND, detail="User not found"
+        )
+
+    email = user.email
+    db.delete(user)
+    record_audit(
+        db,
+        actor=admin,
+        action="user.delete",
+        target_type="user",
+        target_id=user_id,
+        details={"email": email},
+        ip_address=_client_ip(request),
+    )
+    db.commit()
+    return MessageResponse(message=f"User {user_id} deleted.")

--- a/backend/app/schemas.py
+++ b/backend/app/schemas.py
@@ -433,6 +433,57 @@ class MessageResponse(BaseModel):
     )
 
 
+# ── Admin / Audit ─────────────────────────────────────────────────────────────
+class RoleUpdateRequest(BaseModel):
+    """Request body for promoting or demoting a user's admin role."""
+
+    is_admin: bool = Field(
+        ...,
+        description="Whether the target user should have administrator privileges.",
+        example=True,
+    )
+
+
+class AuditLogRecord(BaseModel):
+    """A single immutable audit-trail entry for a privileged action."""
+
+    id: int = Field(..., description="Audit entry identifier.", example=1)
+    actor_id: int | None = Field(
+        None,
+        description="User id of the admin who performed the action (null if removed).",
+        example=42,
+    )
+    actor_email: str = Field(
+        ...,
+        description="Email of the admin who performed the action.",
+        example="admin@example.com",
+    )
+    action: str = Field(
+        ...,
+        description="Machine-readable action name.",
+        example="user.role_update",
+    )
+    target_type: str | None = Field(
+        None, description="Type of the entity acted upon.", example="user"
+    )
+    target_id: str | None = Field(
+        None, description="Identifier of the entity acted upon.", example="7"
+    )
+    details: dict[str, Any] | None = Field(
+        None,
+        description="Additional context for the action, with sensitive fields redacted.",
+        example={"is_admin": True},
+    )
+    ip_address: str | None = Field(
+        None, description="Source IP address of the request.", example="203.0.113.5"
+    )
+    created_at: str = Field(
+        ...,
+        description="ISO-8601 timestamp of when the action occurred.",
+        example="2026-06-24T12:30:00+00:00",
+    )
+
+
 # ── Health ────────────────────────────────────────────────────────────────────
 class HealthResponse(BaseModel):
     """Generic health / status response."""

--- a/backend/app/security.py
+++ b/backend/app/security.py
@@ -95,3 +95,17 @@ def get_current_user(
         )
 
     return user
+
+
+def require_admin(current_user: User = Depends(get_current_user)) -> User:
+    """Allow the request only if the authenticated user is an admin.
+
+    Returns the user on success; raises ``403`` otherwise. Layered on top of
+    ``get_current_user`` so unauthenticated callers still receive ``401``.
+    """
+    if not current_user.is_admin:
+        raise HTTPException(
+            status_code=status.HTTP_403_FORBIDDEN,
+            detail="Administrator privileges required",
+        )
+    return current_user

--- a/backend/app/services/audit.py
+++ b/backend/app/services/audit.py
@@ -1,0 +1,77 @@
+"""Audit logging for privileged admin actions.
+
+Writes append-only :class:`~app.models.AuditLog` rows. Sensitive values in the
+free-form ``details`` payload are redacted before they are persisted so the
+trail never stores secrets, tokens, or password material.
+"""
+
+from __future__ import annotations
+
+import json
+from typing import Any
+
+from sqlalchemy.orm import Session
+
+from ..models import AuditLog, User
+
+# Substrings that mark a field as sensitive; matched case-insensitively against
+# the key name. Matching values are replaced with ``REDACTED`` before storage.
+_SENSITIVE_KEY_PARTS = (
+    "password",
+    "passwd",
+    "secret",
+    "token",
+    "api_key",
+    "apikey",
+    "authorization",
+    "credential",
+)
+
+REDACTED = "***REDACTED***"
+
+
+def _is_sensitive(key: str) -> bool:
+    lowered = key.lower()
+    return any(part in lowered for part in _SENSITIVE_KEY_PARTS)
+
+
+def redact(value: Any) -> Any:
+    """Recursively replace sensitive values in dicts/lists with a placeholder."""
+    if isinstance(value, dict):
+        return {
+            k: (REDACTED if _is_sensitive(str(k)) else redact(v))
+            for k, v in value.items()
+        }
+    if isinstance(value, (list, tuple)):
+        return [redact(item) for item in value]
+    return value
+
+
+def record_audit(
+    db: Session,
+    *,
+    actor: User,
+    action: str,
+    target_type: str | None = None,
+    target_id: str | int | None = None,
+    details: dict[str, Any] | None = None,
+    ip_address: str | None = None,
+) -> AuditLog:
+    """Persist a single audit entry for ``actor`` and return it.
+
+    ``details`` is redacted and serialised to JSON. The caller is responsible
+    for committing the surrounding transaction.
+    """
+    safe_details = redact(details) if details else None
+    entry = AuditLog(
+        actor_id=actor.id,
+        actor_email=actor.email,
+        action=action,
+        target_type=target_type,
+        target_id=None if target_id is None else str(target_id),
+        details=json.dumps(safe_details) if safe_details is not None else None,
+        ip_address=ip_address,
+    )
+    db.add(entry)
+    db.flush()
+    return entry

--- a/backend/tests/test_admin_audit.py
+++ b/backend/tests/test_admin_audit.py
@@ -1,0 +1,173 @@
+import os
+import sys
+
+import pytest
+from fastapi.testclient import TestClient
+from sqlalchemy import create_engine, select
+from sqlalchemy.orm import sessionmaker
+
+sys.path.insert(0, os.path.dirname(os.path.dirname(__file__)))
+
+from app.database import Base, get_db
+from app.main import app
+from app.models import AuditLog, User
+from app.services.audit import REDACTED, redact
+
+SQLALCHEMY_DATABASE_URL = "sqlite:///./test_admin_audit.db"
+engine = create_engine(
+    SQLALCHEMY_DATABASE_URL, connect_args={"check_same_thread": False}
+)
+TestingSessionLocal = sessionmaker(autocommit=False, autoflush=False, bind=engine)
+
+
+def override_get_db():
+    db = TestingSessionLocal()
+    try:
+        yield db
+    finally:
+        db.close()
+
+
+@pytest.fixture(scope="module", autouse=True)
+def setup_db():
+    app.dependency_overrides[get_db] = override_get_db
+    Base.metadata.create_all(bind=engine)
+    yield
+    Base.metadata.drop_all(bind=engine)
+    app.dependency_overrides.pop(get_db, None)
+    engine.dispose()
+    if os.path.exists("./test_admin_audit.db"):
+        os.remove("./test_admin_audit.db")
+
+
+client = TestClient(app)
+
+
+def _signup(email: str) -> dict:
+    r = client.post("/auth/signup", json={"email": email, "password": "password12345"})
+    assert r.status_code == 200, r.text
+    return r.json()
+
+
+def _make_admin(user_id: int) -> None:
+    db = TestingSessionLocal()
+    try:
+        user = db.get(User, user_id)
+        user.is_admin = True
+        db.commit()
+    finally:
+        db.close()
+
+
+def _auth(token: str) -> dict:
+    return {"Authorization": f"Bearer {token}"}
+
+
+# ── Unit: redaction ────────────────────────────────────────────────────────────
+def test_redact_masks_sensitive_keys():
+    cleaned = redact(
+        {
+            "email": "x@example.com",
+            "password": "hunter2",
+            "api_key": "abc",
+            "nested": {"access_token": "t", "ok": 1},
+            "items": [{"secret": "s", "name": "n"}],
+        }
+    )
+    assert cleaned["email"] == "x@example.com"
+    assert cleaned["password"] == REDACTED
+    assert cleaned["api_key"] == REDACTED
+    assert cleaned["nested"]["access_token"] == REDACTED
+    assert cleaned["nested"]["ok"] == 1
+    assert cleaned["items"][0]["secret"] == REDACTED
+    assert cleaned["items"][0]["name"] == "n"
+
+
+# ── Integration: admin actions + audit trail ───────────────────────────────────
+def test_non_admin_is_forbidden():
+    user = _signup("plain@example.com")
+    r = client.get("/admin/audit-logs", headers=_auth(user["access_token"]))
+    assert r.status_code == 403
+
+
+def test_unauthenticated_is_unauthorized():
+    r = client.get("/admin/audit-logs")
+    assert r.status_code == 401
+
+
+def test_role_update_is_logged_and_queryable():
+    admin = _signup("admin@example.com")
+    _make_admin(admin["user_id"])
+    target = _signup("target@example.com")
+
+    # Promote the target user to admin.
+    r = client.put(
+        f"/admin/users/{target['user_id']}/role",
+        json={"is_admin": True},
+        headers=_auth(admin["access_token"]),
+    )
+    assert r.status_code == 200, r.text
+
+    # The action shows up in the audit log.
+    r = client.get(
+        "/admin/audit-logs?action=user.role_update",
+        headers=_auth(admin["access_token"]),
+    )
+    assert r.status_code == 200
+    logs = r.json()
+    assert len(logs) >= 1
+    entry = logs[0]
+    assert entry["actor_email"] == "admin@example.com"
+    assert entry["target_id"] == str(target["user_id"])
+    assert entry["details"]["to"] is True
+
+
+def test_delete_user_is_logged():
+    admin = _signup("admin2@example.com")
+    _make_admin(admin["user_id"])
+    victim = _signup("victim@example.com")
+
+    r = client.delete(
+        f"/admin/users/{victim['user_id']}", headers=_auth(admin["access_token"])
+    )
+    assert r.status_code == 200, r.text
+
+    r = client.get(
+        f"/admin/audit-logs?action=user.delete&actor_id={admin['user_id']}",
+        headers=_auth(admin["access_token"]),
+    )
+    assert r.status_code == 200
+    logs = r.json()
+    assert any(e["target_id"] == str(victim["user_id"]) for e in logs)
+
+
+def test_admin_cannot_delete_self():
+    admin = _signup("admin3@example.com")
+    _make_admin(admin["user_id"])
+    r = client.delete(
+        f"/admin/users/{admin['user_id']}", headers=_auth(admin["access_token"])
+    )
+    assert r.status_code == 400
+
+
+def test_audit_entries_are_append_only():
+    """Deleting the acting user must not cascade-remove their audit rows."""
+    admin = _signup("admin4@example.com")
+    _make_admin(admin["user_id"])
+    target = _signup("target2@example.com")
+    client.put(
+        f"/admin/users/{target['user_id']}/role",
+        json={"is_admin": False},
+        headers=_auth(admin["access_token"]),
+    )
+
+    db = TestingSessionLocal()
+    try:
+        count = len(
+            db.execute(select(AuditLog).where(AuditLog.actor_id == admin["user_id"]))
+            .scalars()
+            .all()
+        )
+        assert count >= 1
+    finally:
+        db.close()

--- a/docs/CHANGELOG.md
+++ b/docs/CHANGELOG.md
@@ -8,6 +8,10 @@ All notable changes to QyverixAI are documented in this file.
 - Added a dedicated changelog page in `docs/CHANGELOG.md`.
 - Added changelog guidance for contributors and PR authors.
 - Added `POST /auth/logout` to revoke the caller's access token.
+- Added an append-only audit log for privileged admin actions, with a
+  queryable `GET /admin/audit-logs` endpoint and admin-gated user role
+  management (`PUT /admin/users/{id}/role`) and deletion
+  (`DELETE /admin/users/{id}`).
 
 ### Changed
 - Linked the changelog from `README.md` for faster discoverability.
@@ -16,6 +20,8 @@ All notable changes to QyverixAI are documented in this file.
 - Hardened authentication against token replay: access tokens now carry a
   unique `jti`, and revoked tokens (e.g. after logout) are rejected via a
   server-side denylist until they expire.
+- Audit-log entries redact sensitive fields (passwords, tokens, secrets, API
+  keys) before they are persisted.
 
 ## [3.0.0] - 2026-06-06
 


### PR DESCRIPTION
## Summary

Closes #578.

Adds an **append-only audit trail for privileged admin actions** so important operations (role changes, account deletion) are recorded with actor and timestamp, per the issue's security/compliance requirement.

### What's included
- **`AuditLog` model** (`backend/app/models.py`) — append-only record: actor id + denormalised actor email, action, target type/id, redacted details (JSON), IP, timestamp. Written once, never updated/deleted by app code.
- **Admin gate** (`backend/app/security.py`) — `require_admin` dependency: `401` when unauthenticated, `403` for non-admins. Adds `is_admin` flag to `User`.
- **Audit service** (`backend/app/services/audit.py`) — `record_audit(...)` that **redacts sensitive fields** (passwords, tokens, secrets, API keys) recursively before persisting.
- **Admin router** (`backend/app/routers/admin.py`):
  - `GET /admin/audit-logs` — queryable (filter by `action`, `actor_id`, pagination), admin only.
  - `PUT /admin/users/{id}/role` — grant/revoke admin role (logged).
  - `DELETE /admin/users/{id}` — delete a user (logged; admins can't delete themselves).
- Schemas, OpenAPI tag, router wiring, and a CHANGELOG entry.

### Testing
- New `backend/tests/test_admin_audit.py`: redaction, non-admin `403`, unauthenticated `401`, role-update & delete logging, queryability, and append-only behaviour (audit rows survive actor deletion).
- Full suite: **433 passed**. `black`, `isort`, `ruff` all clean.

### Notes
- Immutability is enforced at the application level (insert + read only; no update/delete paths). `actor_id` uses `ON DELETE SET NULL` so the trail survives user removal.
- Sensitive fields are redacted before storage; nothing secret is logged.