### PR TITLE
fix(scheduler): isolate per-subscriber DB commit to prevent duplicate emails (#1118)

### DIFF
--- a/backend/app/services/scheduler.py
+++ b/backend/app/services/scheduler.py
@@ -33,32 +33,67 @@ def _send_weekly_digests() -> None:
             log.info("No active digest subscribers")
             return
 
+        # Snapshot subscriber primitives to avoid N+1 reload queries and holding ORM objects active
+        subs_data = [
+            {
+                "id": sub.id,
+                "email": sub.email,
+                "unsubscribe_token": sub.unsubscribe_token,
+            }
+            for sub in subs
+        ]
+        # Rollback the read transaction immediately to release locks/connection
+        db.rollback()
+
         sent = 0
         failed = 0
-        for sub in subs:
+        for sub_info in subs_data:
+            sub_id = sub_info["id"]
+            email = sub_info["email"]
+            token = sub_info["unsubscribe_token"]
+
             try:
-                stats = compute_subscriber_stats(db, sub.email)
+                # 1. Fetch statistics inside a transaction
+                stats = compute_subscriber_stats(db, email)
+                
+                # Always release the database transaction immediately after the read queries
+                db.rollback()
+
                 if not stats:
-                    log.debug("No stats for %s, skipping", sub.email)
+                    log.debug("No stats for %s, skipping", email)
                     continue
-                ok = send_digest(stats, sub.unsubscribe_token)
+
+                # 2. Trigger the SMTP network call outside any open database transaction
+                ok = send_digest(stats, token)
+
                 if ok:
-                    sub.last_sent_at = datetime.now(UTC)
-                    db.commit()
-                    sent += 1
+                    # 3. Update the specific subscriber's timestamp in a fresh, isolated transaction
+                    sub_record = (
+                        db.query(DigestSubscription)
+                        .filter(DigestSubscription.id == sub_id)
+                        .first()
+                    )
+                    if sub_record:
+                        sub_record.last_sent_at = datetime.now(UTC)
+                        db.commit()
+                        sent += 1
+                    else:
+                        db.rollback()
+                        log.warning("Subscriber record ID %d not found during update", sub_id)
+                        failed += 1
                 else:
-                    log.warning("Failed to deliver digest to %s", sub.email)
+                    log.warning("Failed to deliver digest to %s", email)
                     failed += 1
             except Exception:
                 db.rollback()
-                log.exception("Error processing digest for %s — skipping", sub.email)
+                log.exception("Error processing digest for %s — skipping", email)
                 failed += 1
 
         log.info(
             "Weekly digest run complete: %d sent, %d failed, %d total",
             sent,
             failed,
-            len(subs),
+            len(subs_data),
         )
     except Exception:
         log.exception("Error in weekly digest job")

--- a/backend/app/services/scheduler.py
+++ b/backend/app/services/scheduler.py
@@ -34,20 +34,32 @@ def _send_weekly_digests() -> None:
             return
 
         sent = 0
+        failed = 0
         for sub in subs:
-            stats = compute_subscriber_stats(db, sub.email)
-            if not stats:
-                log.debug("No stats for %s, skipping", sub.email)
-                continue
-            ok = send_digest(stats, sub.unsubscribe_token)
-            if ok:
-                sub.last_sent_at = datetime.now(UTC)
-                sent += 1
-            else:
-                log.warning("Failed to deliver digest to %s", sub.email)
+            try:
+                stats = compute_subscriber_stats(db, sub.email)
+                if not stats:
+                    log.debug("No stats for %s, skipping", sub.email)
+                    continue
+                ok = send_digest(stats, sub.unsubscribe_token)
+                if ok:
+                    sub.last_sent_at = datetime.now(UTC)
+                    db.commit()
+                    sent += 1
+                else:
+                    log.warning("Failed to deliver digest to %s", sub.email)
+                    failed += 1
+            except Exception:
+                db.rollback()
+                log.exception("Error processing digest for %s — skipping", sub.email)
+                failed += 1
 
-        db.commit()
-        log.info("Weekly digest sent to %d/%d subscribers", sent, len(subs))
+        log.info(
+            "Weekly digest run complete: %d sent, %d failed, %d total",
+            sent,
+            failed,
+            len(subs),
+        )
     except Exception:
         log.exception("Error in weekly digest job")
     finally:

--- a/backend/tests/test_digest.py
+++ b/backend/tests/test_digest.py
@@ -266,3 +266,137 @@ def test_unsubscribe_url_encodes_query_parameters(monkeypatch):
     assert parsed.path == "/subscribe/unsubscribe"
     assert query["email"] == ["digest.user+weekly@example.com"]
     assert query["token"] == ["token/value+with symbols"]
+
+
+# ── Issue #1118 Regression: per-subscriber commit isolation ───────────────────
+
+def _make_sub(db, email: str) -> DigestSubscription:
+    """Helper — insert an active DigestSubscription and return it."""
+    import secrets
+
+    sub = DigestSubscription(
+        email=email,
+        is_active=True,
+        unsubscribe_token=secrets.token_urlsafe(32),
+    )
+    db.add(sub)
+    db.commit()
+    db.refresh(sub)
+    return sub
+
+
+def test_digest_partial_smtp_failure_commits_successful_subscribers(monkeypatch):
+    """
+    Regression for #1118: if one subscriber raises an SMTP error mid-loop,
+    the other subscribers must still have their last_sent_at committed to the DB.
+    Under the old single-commit design all would be rolled back, causing
+    duplicate emails on the next scheduled run.
+    """
+    import smtplib
+
+    from app.services import scheduler as scheduler_module
+
+    db = TEST_SESSION_LOCAL()
+
+    try:
+        _make_sub(db, "a@example.com")
+        _make_sub(db, "b@example.com")
+        _make_sub(db, "c@example.com")
+
+        fake_stats = {
+            "email": "",
+            "total_analyses": 1,
+            "languages": ["Python"],
+            "avg_score": 80,
+            "prev_avg": 75,
+            "improvement": 6.7,
+            "trend": "up",
+            "top_bug": "ZeroDivisionError",
+            "total_issues": 1,
+            "week_start": "Jun 20",
+            "week_end": "Jun 27, 2026",
+        }
+
+        def fake_compute(session, email):
+            return {**fake_stats, "email": email}
+
+        call_order = []
+
+        def fake_send_digest(stats, token):
+            call_order.append(stats["email"])
+            if stats["email"] == "b@example.com":
+                raise smtplib.SMTPException("Connection refused")
+            return True
+
+        monkeypatch.setattr(scheduler_module, "SessionLocal", lambda: db)
+        monkeypatch.setattr(scheduler_module, "compute_subscriber_stats", fake_compute)
+        monkeypatch.setattr(scheduler_module, "send_digest", fake_send_digest)
+        monkeypatch.setattr(scheduler_module.settings, "digest_enabled", True)
+
+        scheduler_module._send_weekly_digests()
+
+        # Verify all 3 subscribers were attempted (order not guaranteed by SQLite)
+        assert set(call_order) == {"a@example.com", "b@example.com", "c@example.com"}
+        assert len(call_order) == 3
+
+        db.expire_all()
+        sub_a = db.query(DigestSubscription).filter_by(email="a@example.com").first()
+        sub_b = db.query(DigestSubscription).filter_by(email="b@example.com").first()
+        sub_c = db.query(DigestSubscription).filter_by(email="c@example.com").first()
+
+        assert sub_a.last_sent_at is not None, "a@ succeeded — must be committed"
+        assert sub_b.last_sent_at is None, "b@ raised — must NOT be committed"
+        assert sub_c.last_sent_at is not None, "c@ succeeded — must be committed"
+
+    finally:
+        db.close()
+
+
+def test_digest_stats_exception_does_not_abort_other_subscribers(monkeypatch):
+    """
+    Regression for #1118: if compute_subscriber_stats raises for one subscriber,
+    the remaining subscribers must still be sent and their last_sent_at committed.
+    """
+    from app.services import scheduler as scheduler_module
+
+    db = TEST_SESSION_LOCAL()
+
+    try:
+        _make_sub(db, "fail@example.com")
+        _make_sub(db, "ok@example.com")
+
+        fake_stats = {
+            "email": "ok@example.com",
+            "total_analyses": 2,
+            "languages": ["Python"],
+            "avg_score": 90,
+            "prev_avg": None,
+            "improvement": None,
+            "trend": "stable",
+            "top_bug": None,
+            "total_issues": 0,
+            "week_start": "Jun 20",
+            "week_end": "Jun 27, 2026",
+        }
+
+        def fake_compute(session, email):
+            if email == "fail@example.com":
+                raise RuntimeError("DB exploded")
+            return fake_stats
+
+        monkeypatch.setattr(scheduler_module, "SessionLocal", lambda: db)
+        monkeypatch.setattr(scheduler_module, "compute_subscriber_stats", fake_compute)
+        monkeypatch.setattr(scheduler_module, "send_digest", lambda stats, token: True)
+        monkeypatch.setattr(scheduler_module.settings, "digest_enabled", True)
+
+        scheduler_module._send_weekly_digests()
+
+        db.expire_all()
+        sub_fail = db.query(DigestSubscription).filter_by(email="fail@example.com").first()
+        sub_ok = db.query(DigestSubscription).filter_by(email="ok@example.com").first()
+
+        assert sub_fail.last_sent_at is None, "fail@ raised — must NOT be committed"
+        assert sub_ok.last_sent_at is not None, "ok@ succeeded — must be committed"
+
+    finally:
+        db.close()


### PR DESCRIPTION
## Description
This PR resolves the database transaction rollback and duplicate email risk in the weekly Sunday digest background job (`_send_weekly_digests()`).

Currently, the job executes the dispatch loop for all active subscribers and performs a single `db.commit()` at the very end. If a failure (such as an SMTP timeout, database error, or runtime exception during stats calculation) occurs mid-loop, the entire database transaction is rolled back. However, any emails already sent cannot be unsent. On the next scheduled run, those subscribers receive duplicate emails.

### Fixes:
- Moved `db.commit()` inside the loop to run immediately after each successfully sent email.
- Wrapped the per-subscriber loop iteration in its own `try/except` block with `db.rollback()` on failure.
- A failure on one subscriber now rolls back only that subscriber's dirty state, logs the exception, and safely continues to the next subscriber in the batch.
- Added a `failed` counter and improved the run summary log.

---

## Related Issue
Fixes #1118

---

## Type of change
- [x] Bug fix
- [ ] New feature / enhancement
- [ ] Documentation update
- [x] Test addition
- [ ] Refactor

---

## Checklist
- [x] I have read [CONTRIBUTING.md](../CONTRIBUTING.md)
- [x] My branch is up to date with `main`
- [x] I have run `pytest -v` and all tests pass
- [x] I have not introduced duplicate issues or features
- [x] My PR title follows the format: `feat/fix/docs/test: short description`
- [x] I have added tests for new features (Level 2 and 3 issues)
- [x] No hardcoded secrets or API keys in my code
- [x] This PR is linked to a GSSoC 2026 issue

---

## Screenshots (if frontend change)
N/A

---

## Test evidence
Executed the digest test suite using Python 3.12:
```bash
python -m pytest tests/test_digest.py -v

============================= test session starts =============================
platform win32 -- Python 3.12.10, pytest-9.1.1, pluggy-1.6.0 -- C:\Users\divya\AppData\Local\Programs\Python\Python312\python.exe
cachedir: .pytest_cache
rootdir: C:\Users\divya\Desktop\gssoc\AI-dev-assistant
configfile: pyproject.toml
plugins: anyio-4.14.1
collecting ... collected 15 items

tests/test_digest.py::test_subscribe_success PASSED                      [  6%]
tests/test_digest.py::test_subscribe_duplicate_returns_409 PASSED        [ 13%]
tests/test_digest.py::test_subscribe_re_activates_after_unsubscribe PASSED [ 20%]
tests/test_digest.py::test_unsubscribe_success PASSED                    [ 26%]
tests/test_digest.py::test_unsubscribe_wrong_token PASSED                [ 33%]
tests/test_digest.py::test_unsubscribe_nonexistent PASSED                [ 40%]
tests/test_digest.py::test_get_unsubscribe_link PASSED                   [ 46%]
tests/test_digest.py::test_invalid_email PASSED                          [ 53%]
tests/test_digest.py::test_subscribe_stores_token PASSED                 [ 60%]
tests/test_digest.py::test_digest_email_uses_mounted_unsubscribe_route PASSED [ 66%]
tests/test_digest.py::test_unsubscribe_url_handles_base_url_slashes[https://qyverixai.onrender.com-https://qyverixai.onrender.com/subscribe/unsubscribe] PASSED [ 73%]
tests/test_digest.py::test_unsubscribe_url_handles_base_url_slashes[https://qyverixai.onrender.com/-https://qyverixai.onrender.com/subscribe/unsubscribe] PASSED [ 80%]
tests/test_digest.py::test_unsubscribe_url_encodes_query_parameters PASSED [ 86%]
tests/test_digest.py::test_digest_partial_smtp_failure_commits_successful_subscribers PASSED [ 93%]
tests/test_digest.py::test_digest_stats_exception_does_not_abort_other_subscribers PASSED [100%]

====================== 15 passed, 105 warnings in 2.76s =======================
```