### PR TITLE
fix: add periodic purge job for empty collaboration rooms

### DIFF
--- a/backend/app/services/scheduler.py
+++ b/backend/app/services/scheduler.py
@@ -1,6 +1,7 @@
 """APScheduler integration — weekly Sunday digest dispatch."""
 
 from __future__ import annotations
+
 import logging
 from datetime import UTC, datetime
 
@@ -9,11 +10,13 @@ from apscheduler.schedulers.background import BackgroundScheduler
 from ..config import settings
 from ..database import SessionLocal
 from ..models import DigestSubscription
+from ..routers.collaboration import manager as collaboration_manager
 from .email_service import compute_subscriber_stats, send_digest
 
 log = logging.getLogger(__name__)
 scheduler = BackgroundScheduler(daemon=True)
 JOB_ID = "weekly_digest"
+PURGE_ROOMS_JOB_ID = "purge_empty_collab_rooms"
 
 
 def _send_weekly_digests() -> None:
@@ -54,6 +57,18 @@ def _send_weekly_digests() -> None:
         db.close()
 
 
+def _purge_empty_collab_rooms() -> None:
+    """Remove collaboration rooms left with no active sockets."""
+    empty = [
+        sid for sid, room in list(collaboration_manager.rooms.items())
+        if not room.sockets
+    ]
+    for sid in empty:
+        collaboration_manager.rooms.pop(sid, None)
+    if empty:
+        log.info("Purged %d empty collaboration room(s)", len(empty))
+
+
 def start_scheduler() -> None:
     """Start the background scheduler with the weekly digest job."""
     if scheduler.get_job(JOB_ID):
@@ -69,6 +84,16 @@ def start_scheduler() -> None:
         id=JOB_ID,
         replace_existing=True,
     )
+
+    log.info("Starting empty collaboration room purge job (every 30 min)")
+    scheduler.add_job(
+        _purge_empty_collab_rooms,
+        trigger="interval",
+        minutes=30,
+        id=PURGE_ROOMS_JOB_ID,
+        replace_existing=True,
+    )
+
     scheduler.start()
 
 


### PR DESCRIPTION
Fixes #1129 - rooms where all clients drop abruptly (tab close, network failure) are never cleaned up because stale_clients in broadcast() is only processed when a broadcast fires. Adds a 30-minute APScheduler interval job that sweeps manager.rooms and removes any room with no active sockets, preventing unbounded memory growth over the server lifetime.

## Description
<!-- What does this PR do? Be specific. -->
Collaboration rooms where all clients disconnect abruptly (tab close,
browser crash, network failure) were never removed from
`CollaborationManager.rooms`. The existing stale socket cleanup in
`broadcast()` only runs when a message is sent — if no broadcast fires
after all clients drop, the room leaks in memory indefinitely with
empty sockets/users but full code and comments state retained.

Added a `_purge_empty_collab_rooms()` job in
`backend/app/services/scheduler.py` that runs every 30 minutes via
APScheduler and removes any room where `len(room.sockets) == 0`.
No changes to `collaboration.py` — fix is entirely in the scheduler.

## Related Issue
<!-- Required — link the issue this PR fixes -->
Fixes #1129 

## Type of change
- [x] Bug fix


## Checklist
<!-- All boxes must be checked before requesting review -->
- [x] I have read [CONTRIBUTING.md](../CONTRIBUTING.md)
- [x] My branch is up to date with `main`
- [ ] I have run `pytest -v` and all tests pass
- [x] I have not introduced duplicate issues or features
- [x] My PR title follows the format: `feat/fix/docs/test: short description`
- [ ] I have added tests for new features (Level 2 and 3 issues)
- [x] No hardcoded secrets or API keys in my code
- [x] This PR is linked to a GSSoC 2026 issue

## Screenshots (if frontend change)
<!-- Add before/after screenshots -->
N/A — backend-only change, no UI affected.

## Test evidence
<!-- Paste pytest output here -->
Local environment does not have all backend dependencies configured
for a full pytest run. The fix is verified by code inspection:

- `_purge_empty_collab_rooms()` iterates `manager.rooms` safely via
  `list()` copy to avoid mutation during iteration
- Only removes rooms where `room.sockets` is empty (falsy dict)
- Logs the count of purged rooms for observability
- Registered with `replace_existing=True` so restarts don't duplicate
  the job

```bash
python -c "from apscheduler.schedulers.background import BackgroundScheduler; print('OK')"
# OK
python -c "from app.services.scheduler import start_scheduler; print('OK')"
# OK
```
```
