### PR TITLE
feat: add mode keyboard shortcuts

### DIFF
--- a/frontend/index.html
+++ b/frontend/index.html
@@ -2680,7 +2680,7 @@ details.issue-card[open] {
               <button class="mode-btn" data-mode="debug" aria-pressed="false" aria-keyshortcuts="Control+Alt+3" data-i18n="mode_debug">Debug</button>
               <button class="mode-btn" data-mode="suggest" aria-pressed="false" aria-keyshortcuts="Control+Alt+4" data-i18n="tab_improve">Improve</button>
             </div>
-            <span class="shortcut-hint" aria-label="Use Control Alt 1 through 4 to switch analysis modes">Ctrl+Alt+1-4 modes</span>
+            <span class="shortcut-hint" title="Use Control Alt 1 through 4 to switch analysis modes">Ctrl+Alt+1-4 modes</span>
           </div>
         </div>
 

--- a/frontend/index.html
+++ b/frontend/index.html
@@ -774,6 +774,16 @@
       color: var(--text3)
     }
 
+    .shortcut-hint {
+      align-self: center;
+      padding: 5px 8px;
+      border: 1px solid var(--border);
+      border-radius: 999px;
+      color: var(--text3);
+      background: rgba(255,255,255,0.03);
+      white-space: nowrap;
+    }
+
     /* ── Mode Selector ── */
     .mode-row {
       display: flex;
@@ -2665,11 +2675,12 @@ details.issue-card[open] {
           <div id="charCount">0 chars · 0 lines</div>
           <div style="display:flex;gap:8px">
             <div class="mode-row" role="tablist" aria-label="Mode selector">
-              <button class="mode-btn active" data-mode="analyze" aria-pressed="true" data-i18n="mode_full">Full</button>
-              <button class="mode-btn" data-mode="explain" aria-pressed="false" data-i18n="tab_explain">Explain</button>
-              <button class="mode-btn" data-mode="debug" aria-pressed="false" data-i18n="mode_debug">Debug</button>
-              <button class="mode-btn" data-mode="suggest" aria-pressed="false" data-i18n="tab_improve">Improve</button>
+              <button class="mode-btn active" data-mode="analyze" aria-pressed="true" aria-keyshortcuts="Control+Alt+1" data-i18n="mode_full">Full</button>
+              <button class="mode-btn" data-mode="explain" aria-pressed="false" aria-keyshortcuts="Control+Alt+2" data-i18n="tab_explain">Explain</button>
+              <button class="mode-btn" data-mode="debug" aria-pressed="false" aria-keyshortcuts="Control+Alt+3" data-i18n="mode_debug">Debug</button>
+              <button class="mode-btn" data-mode="suggest" aria-pressed="false" aria-keyshortcuts="Control+Alt+4" data-i18n="tab_improve">Improve</button>
             </div>
+            <span class="shortcut-hint" aria-label="Use Control Alt 1 through 4 to switch analysis modes">Ctrl+Alt+1-4 modes</span>
           </div>
         </div>
 
@@ -3719,16 +3730,37 @@ details.issue-card[open] {
       /* ═══════════════════════════════════════════════════════════════
          MODE BUTTONS
       ═══════════════════════════════════════════════════════════════ */
-      document.querySelectorAll('.mode-btn').forEach(b => {
-        b.addEventListener('click', () => {
-          selectedMode = b.dataset.mode;
-          document.querySelectorAll('.mode-btn').forEach(x => {
-            x.classList.remove('active');
-            x.setAttribute('aria-pressed', 'false');
-          });
-          b.classList.add('active');
-          b.setAttribute('aria-pressed', 'true');
+      function setMode(mode) {
+        const button = document.querySelector(`.mode-btn[data-mode="${mode}"]`);
+        if (!button) return;
+
+        selectedMode = mode;
+        document.querySelectorAll('.mode-btn').forEach(x => {
+          x.classList.remove('active');
+          x.setAttribute('aria-pressed', 'false');
         });
+        button.classList.add('active');
+        button.setAttribute('aria-pressed', 'true');
+      }
+
+      document.querySelectorAll('.mode-btn').forEach(b => {
+        b.addEventListener('click', () => setMode(b.dataset.mode));
+      });
+
+      document.addEventListener('keydown', e => {
+        if (!(e.ctrlKey || e.metaKey) || !e.altKey) return;
+
+        const shortcutModes = {
+          '1': 'analyze',
+          '2': 'explain',
+          '3': 'debug',
+          '4': 'suggest'
+        };
+        const mode = shortcutModes[e.key];
+        if (!mode) return;
+
+        e.preventDefault();
+        setMode(mode);
       });
 
       /* ═══════════════════════════════════════════════════════════════


### PR DESCRIPTION
## Summary
- add Ctrl+Alt+1 through Ctrl+Alt+4 shortcuts for switching analysis modes
- expose the shortcuts through `aria-keyshortcuts` on the mode buttons
- add a compact footer hint so keyboard users can discover the mode shortcuts

Fixes #1598

## Validation
- Parsed `frontend/index.html` with Python `html.parser`
- Extracted inline scripts and ran `node --check`
- Ran `git diff --check -- frontend/index.html`

## Checklist
- [x] I have read the contributing guidelines
- [x] My PR is small and focused
- [x] No hardcoded secrets or API keys in my code
- [x] This PR is linked to a GSSoC 2026 issue