### PR TITLE
test: add accessible labels to frontend controls

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -48,3 +48,6 @@ vscode-extension/extension.js
 *.db
 assistant.db
 backend/assistant.db
+
+frontend/test-results/
+frontend/tests/test-results/

--- a/docs/CHANGELOG.md
+++ b/docs/CHANGELOG.md
@@ -12,6 +12,7 @@ All notable changes to QyverixAI are documented in this file.
   queryable `GET /admin/audit-logs` endpoint and admin-gated user role
   management (`PUT /admin/users/{id}/role`) and deletion
   (`DELETE /admin/users/{id}`).
+- Added accessible labels (`aria-label`) to result action buttons, history sort/order selects, collaboration panel inputs, and the digest subscription email field, along with Playwright e2e coverage in `frontend/tests/e2e/accessible-labels.spec.js`.
 
 ### Changed
 - Linked the changelog from `README.md` for faster discoverability.

--- a/frontend/index.html
+++ b/frontend/index.html
@@ -2682,10 +2682,10 @@ details.issue-card[open] {
 
         <!-- Result action buttons (hidden until results) -->
         <div id="resultActions" class="result-actions" style="display:none">
-          <button class="icon-btn" id="favBtn" title="Save to favorites">★</button>
-          <button class="icon-btn" id="downloadBtn" title="Download results">⬇</button>
-          <button class="icon-btn" id="export-pdf-btn" title="Export as PDF">📄</button>
-          <button class="icon-btn" id="export-md-btn" title="Export as Markdown">📝</button>
+          <button class="icon-btn" id="favBtn" title="Save to favorites" aria-label="Save to favorites">★</button>
+          <button class="icon-btn" id="downloadBtn" title="Download results" aria-label="Download results">⬇</button>
+          <button class="icon-btn" id="export-pdf-btn" title="Export as PDF" aria-label="Export results as PDF">📄</button>
+          <button class="icon-btn" id="export-md-btn" title="Export as Markdown" aria-label="Export results as Markdown">📝</button>
         </div>
 
       </div>
@@ -2782,13 +2782,13 @@ details.issue-card[open] {
         </div>
         <div class="history-controls-row" style="display:flex; gap: 8px; padding: 8px 16px; border-bottom: 1px solid var(--border); font-size: 0.72rem; align-items:center; flex-wrap:wrap;">
           <span style="color:var(--text3);" data-i18n="history_sort_label">Sort:</span>
-          <select id="historySortSelect" style="background:var(--bg); border:1px solid var(--border); color:var(--text); border-radius:4px; padding:2px 6px; font-size:0.72rem; cursor:pointer;">
+          <select id="historySortSelect" aria-label="Sort history by" style="background:var(--bg); border:1px solid var(--border); color:var(--text); border-radius:4px; padding:2px 6px; font-size:0.72rem; cursor:pointer;">
             <option value="timestamp" data-i18n="history_sort_date">Date</option>
             <option value="score" data-i18n="history_sort_score">Quality Score</option>
             <option value="issue_count" data-i18n="history_sort_bugs">Bugs Scanned</option>
           </select>
           <span style="color:var(--text3); margin-left: 8px;" data-i18n="history_order_label">Order:</span>
-          <select id="historyOrderSelect" style="background:var(--bg); border:1px solid var(--border); color:var(--text); border-radius:4px; padding:2px 6px; font-size:0.72rem; cursor:pointer;">
+          <select id="historyOrderSelect" aria-label="History sort order" style="background:var(--bg); border:1px solid var(--border); color:var(--text); border-radius:4px; padding:2px 6px; font-size:0.72rem; cursor:pointer;">
             <option value="desc" data-i18n="history_order_desc">Desc</option>
             <option value="asc" data-i18n="history_order_asc">Asc</option>
           </select>
@@ -2832,7 +2832,7 @@ details.issue-card[open] {
         <div style="max-width:360px;">
           <p style="margin:0 0 6px;font-size:0.8rem;font-weight:600;color:var(--accent);">Weekly Digest</p>
           <form id="digestForm" style="display:flex;gap:6px;">
-            <input type="email" id="digestEmail" placeholder="your@email.com" required
+            <input type="email" id="digestEmail" placeholder="your@email.com" aria-label="Email address for digest subscription" required
                    style="flex:1;min-width:180px;padding:7px 10px;font-size:0.8rem;border:1px solid var(--border);border-radius:6px;background:var(--bg);color:var(--fg);">
             <button type="submit" id="digestBtn" style="padding:7px 14px;font-size:0.8rem;font-weight:600;background:var(--accent);color:#fff;border:none;border-radius:6px;cursor:pointer;">Subscribe</button>
           </form>
@@ -5352,8 +5352,8 @@ int main() {
         <span>Session</span>
       </div>
       <div class="collab-panel-top">
-        <input id="collabName" placeholder="Your name" value="Your name" />
-        <input id="collabSession" placeholder="Session ID e.g. review-676" />
+        <input id="collabName" placeholder="Your name" value="Your name" aria-label="Your name" />
+        <input id="collabSession" placeholder="Session ID e.g. review-676" aria-label="Session ID" />
         <button id="collabJoinBtn" type="button">Join Live</button>
         <button id="collabLeaveBtn" type="button" disabled>Leave</button>
       </div>
@@ -5373,8 +5373,8 @@ int main() {
         <span>Review comments</span>
       </div>
       <div class="collab-comment-row">
-        <input id="collabLine" class="collab-line-input" type="number" min="1" value="1" />
-        <input id="collabCommentText" placeholder="Add a live review comment..." />
+        <input id="collabLine" class="collab-line-input" type="number" min="1" value="1" aria-label="Line number for comment" />
+        <input id="collabCommentText" placeholder="Add a live review comment..." aria-label="Live review comment text" />
         <button id="collabCommentBtn" type="button" disabled>Comment</button>
       </div>
       <div id="collabComments" class="collab-comments"></div>

--- a/frontend/package-lock.json
+++ b/frontend/package-lock.json
@@ -8,17 +8,17 @@
       "name": "qyverixai-frontend-e2e",
       "version": "0.0.0",
       "devDependencies": {
-        "@playwright/test": "^1.53.0"
+        "@playwright/test": "^1.61.1"
       }
     },
     "node_modules/@playwright/test": {
-      "version": "1.60.0",
-      "resolved": "https://registry.npmjs.org/@playwright/test/-/test-1.60.0.tgz",
-      "integrity": "sha512-O71yZIbAh/PxDMNGns37GHBIfrVkEVyn+AXyIa5dOTfb4/xNvRWV+Vv/NMbNCtODB/pO7vLlF2OTmMVLhmr7Ag==",
+      "version": "1.61.1",
+      "resolved": "https://registry.npmjs.org/@playwright/test/-/test-1.61.1.tgz",
+      "integrity": "sha512-8nKv6+0RJSL9FE4jYOEGXnPeM/Hg12qZpmqzZjRh3qM0Y7c3z1mrOTfFLids72RDQYVh9WpLEfR5WdpNX4fkig==",
       "dev": true,
       "license": "Apache-2.0",
       "dependencies": {
-        "playwright": "1.60.0"
+        "playwright": "1.61.1"
       },
       "bin": {
         "playwright": "cli.js"
@@ -43,13 +43,13 @@
       }
     },
     "node_modules/playwright": {
-      "version": "1.60.0",
-      "resolved": "https://registry.npmjs.org/playwright/-/playwright-1.60.0.tgz",
-      "integrity": "sha512-hheHdokM8cdqCb0lcE3s+zT4t4W+vvjpGxsZlDnikarzx8tSzMebh3UiFtgqwFwnTnjYQcsyMF8ei2mCO/tpeA==",
+      "version": "1.61.1",
+      "resolved": "https://registry.npmjs.org/playwright/-/playwright-1.61.1.tgz",
+      "integrity": "sha512-DWnY5o3YbLWK4GovuAVwpqL+1VwGNdUGrRr++8j8PtQQzvAVZUIMjKQ90fY689sEJZJBbZVw1rXaOKSTitkzPQ==",
       "dev": true,
       "license": "Apache-2.0",
       "dependencies": {
-        "playwright-core": "1.60.0"
+        "playwright-core": "1.61.1"
       },
       "bin": {
         "playwright": "cli.js"
@@ -62,9 +62,9 @@
       }
     },
     "node_modules/playwright-core": {
-      "version": "1.60.0",
-      "resolved": "https://registry.npmjs.org/playwright-core/-/playwright-core-1.60.0.tgz",
-      "integrity": "sha512-9bW6zvX/m0lEbgTKJ6YppOKx8H3VOPBMOCFh2irXFOT4BbHgrx5hPjwJYLT40Lu+4qtD36qKc/Hn56StUW57IA==",
+      "version": "1.61.1",
+      "resolved": "https://registry.npmjs.org/playwright-core/-/playwright-core-1.61.1.tgz",
+      "integrity": "sha512-h7Qlt6m4REp25qvIdvbDtVmD4LqVXfpRxhORv9L0jzETM05p4fuPJ3dKyuSXQxDSbXnmS79HAgi9589lGSpLkg==",
       "dev": true,
       "license": "Apache-2.0",
       "bin": {

--- a/frontend/package.json
+++ b/frontend/package.json
@@ -10,6 +10,6 @@
     "test:e2e:headed": "playwright test --headed"
   },
   "devDependencies": {
-    "@playwright/test": "^1.53.0"
+    "@playwright/test": "^1.61.1"
   }
 }

--- a/frontend/tests/e2e/accessible-labels.spec.js
+++ b/frontend/tests/e2e/accessible-labels.spec.js
@@ -1,0 +1,33 @@
+import { test, expect } from '@playwright/test';
+
+test.describe('Accessible labels on frontend controls', () => {
+  test.beforeEach(async ({ page }) => {
+    await page.goto('/app/');
+  });
+
+  test('result action icon buttons have accessible labels', async ({ page }) => {
+    await expect(page.locator('#favBtn')).toHaveAttribute('aria-label', 'Save to favorites');
+    await expect(page.locator('#downloadBtn')).toHaveAttribute('aria-label', 'Download results');
+    await expect(page.locator('#export-pdf-btn')).toHaveAttribute('aria-label', 'Export results as PDF');
+    await expect(page.locator('#export-md-btn')).toHaveAttribute('aria-label', 'Export results as Markdown');
+  });
+
+  test('history sort and order selects have accessible labels', async ({ page }) => {
+    await expect(page.locator('#historySortSelect')).toHaveAttribute('aria-label', 'Sort history by');
+    await expect(page.locator('#historyOrderSelect')).toHaveAttribute('aria-label', 'History sort order');
+  });
+
+  test('collaboration panel inputs have accessible labels', async ({ page }) => {
+    await expect(page.locator('#collabName')).toHaveAttribute('aria-label', 'Your name');
+    await expect(page.locator('#collabSession')).toHaveAttribute('aria-label', 'Session ID');
+    await expect(page.locator('#collabLine')).toHaveAttribute('aria-label', 'Line number for comment');
+    await expect(page.locator('#collabCommentText')).toHaveAttribute('aria-label', 'Live review comment text');
+  });
+
+  test('digest subscription email input has an accessible label', async ({ page }) => {
+    await expect(page.locator('#digestEmail')).toHaveAttribute(
+      'aria-label',
+      'Email address for digest subscription'
+    );
+  });
+});


### PR DESCRIPTION
## Description
Adds `aria-label` attributes to previously unlabeled frontend controls (result action icon buttons, history sort/order selects, collaboration panel inputs, digest email field) so they're properly announced by screen readers. Adds a new Playwright e2e spec covering these labels.

## Related Issue
Fixes #1606

## Type of change
- [x] Test addition

## Checklist
- [x] I have read CONTRIBUTING.md
- [x] My branch is up to date with `main`
- [x] I have run `pytest -v` and all tests pass
- [x] I have not introduced duplicate issues or features
- [x] My PR title follows the format
- [x] I have added tests for new features
- [x] I have updated `docs/CHANGELOG.md`
- [x] No hardcoded secrets or API keys
- [x] This PR is linked to a GSSoC 2026 issue

## Test evidence
```bash
npx playwright test
# 7 passed
```