### PR TITLE
docs: add API startup verification step

### DIFF
--- a/README.md
+++ b/README.md
@@ -716,6 +716,10 @@ git checkout -b feat/your-feature-name
 cd backend && pip install -r requirements.txt
 pytest -v   # all tests must pass
 
+# Optional verification
+uvicorn app.main:app --reload
+# Open http://localhost:8000/docs and confirm the API documentation loads successfully.
+
 # 5. Push and open a pull request
 ```
 


### PR DESCRIPTION
## Description

Added a verification step to the README that instructs contributors to start the API locally and confirm the documentation endpoint loads successfully after setup. This helps ensure the local development environment is configured correctly before contributing.

## Related Issue

Fixes #None (documentation improvement)

## Type of change

- [ ] Bug fix
- [ ] New feature / enhancement
- [x] Documentation update
- [ ] Test addition
- [ ] Refactor

## Checklist

- [x] I have read [CONTRIBUTING.md](../CONTRIBUTING.md)
- [x] My branch is up to date with `main`
- [ ] I have run `pytest -v` and all tests pass
- [x] I have not introduced duplicate issues or features
- [x] My PR title follows the format: `feat/fix/docs/test: short description`
- [ ] I have added tests for new features (Level 2 and 3 issues)
- [x] No hardcoded secrets or API keys in my code
- [ ] This PR is linked to a GSSoC 2026 issue

## Screenshots (if frontend change)

Not applicable.

## Test evidence

```bash
Not applicable (documentation-only change)
```