### PR TITLE
feat(debugging): complete finding suppression workflow

### DIFF
--- a/backend/app/models.py
+++ b/backend/app/models.py
@@ -109,3 +109,16 @@ class AuditLog(Base):
     created_at: Mapped[datetime] = mapped_column(
         DateTime, default=lambda: datetime.now(UTC), index=True
     )
+
+
+class Suppression(Base):
+    __tablename__ = "suppressions"
+
+    id: Mapped[int] = mapped_column(Integer, primary_key=True, index=True)
+    issue_type: Mapped[str] = mapped_column(String(200), index=True)
+    line: Mapped[int] = mapped_column(Integer, nullable=True)
+    reason: Mapped[str] = mapped_column(Text)
+    scope: Mapped[str] = mapped_column(String(20), default="project", index=True)
+    created_at: Mapped[datetime] = mapped_column(
+        DateTime, default=lambda: datetime.now(UTC), index=True
+    )

--- a/backend/app/routers/debugging.py
+++ b/backend/app/routers/debugging.py
@@ -1,11 +1,77 @@
 """Debugging router — POST /debugging/"""
 
-from fastapi import APIRouter
+from fastapi import APIRouter, Depends, HTTPException, status
+from pydantic import BaseModel, Field, field_validator
+from sqlalchemy import select
+from sqlalchemy.exc import SQLAlchemyError
+from sqlalchemy.orm import Session
 
+from ..database import Base, get_db
+from ..models import Suppression
 from ..schemas import CodeRequest, DebuggingResponse
 from ..services.code_assistant import detect_language, run_bug_detection
 
 router = APIRouter()
+
+ACTIVE_SUPPRESSION_SCOPES = {"project", "global"}
+
+
+class SuppressionRequest(BaseModel):
+    issue_type: str = Field(
+        ..., min_length=1, max_length=200, description="Issue type to suppress"
+    )
+    line: int | None = Field(
+        default=None, gt=0, description="Issue line number if known"
+    )
+    reason: str = Field(..., min_length=1, description="Reason for the suppression")
+    scope: str = Field(default="project", description="Suppression scope")
+
+    @field_validator("issue_type")
+    @classmethod
+    def validate_issue_type(cls, value: str) -> str:
+        stripped = value.strip()
+        if not stripped:
+            raise ValueError("issue_type must not be empty")
+        return stripped
+
+    @field_validator("reason")
+    @classmethod
+    def validate_reason(cls, value: str) -> str:
+        stripped = value.strip()
+        if not stripped:
+            raise ValueError("reason must not be empty")
+        return stripped
+
+    @field_validator("scope")
+    @classmethod
+    def validate_scope(cls, value: str) -> str:
+        normalized = value.strip().lower()
+        if normalized not in {"project", "global"}:
+            raise ValueError("scope must be 'project' or 'global'")
+        return normalized
+
+
+def _suppression_matches(issue: dict, suppression: Suppression) -> bool:
+    if suppression.scope not in ACTIVE_SUPPRESSION_SCOPES:
+        return False
+    if issue.get("type") != suppression.issue_type:
+        return False
+    return suppression.line is None or issue.get("line") == suppression.line
+
+
+def _filter_suppressed_issues(
+    issues: list[dict], suppressions: list[Suppression]
+) -> list[dict]:
+    if not issues or not suppressions:
+        return issues
+
+    return [
+        issue
+        for issue in issues
+        if not any(
+            _suppression_matches(issue, suppression) for suppression in suppressions
+        )
+    ]
 
 
 @router.post(
@@ -34,9 +100,21 @@ router = APIRouter()
         500: {"description": "Internal server error."},
     },
 )
-async def debug(req: CodeRequest):
+async def debug(req: CodeRequest, db: Session = Depends(get_db)):
+    Base.metadata.create_all(bind=db.get_bind())
+
     lang = detect_language(req.code, req.language)
     issues = run_bug_detection(req.code, lang)
+
+    try:
+        suppressions = db.execute(select(Suppression)).scalars().all()
+    except SQLAlchemyError as exc:
+        raise HTTPException(
+            status_code=status.HTTP_500_INTERNAL_SERVER_ERROR,
+            detail="Could not load suppressions",
+        ) from exc
+
+    issues = _filter_suppressed_issues(issues, list(suppressions))
     errors = sum(1 for i in issues if i["severity"] == "error")
     warnings = sum(1 for i in issues if i["severity"] == "warning")
     infos = sum(1 for i in issues if i["severity"] == "info")
@@ -52,4 +130,35 @@ async def debug(req: CodeRequest):
         "warning_count": warnings,
         "info_count": infos,
         "code": req.code,
+    }
+
+
+@router.post("/suppress", summary="Suppress a debug finding")
+async def suppress_issue(req: SuppressionRequest, db: Session = Depends(get_db)):
+    Base.metadata.create_all(bind=db.get_bind())
+
+    suppression = Suppression(
+        issue_type=req.issue_type,
+        line=req.line,
+        reason=req.reason,
+        scope=req.scope,
+    )
+
+    try:
+        db.add(suppression)
+        db.commit()
+        db.refresh(suppression)
+    except SQLAlchemyError as exc:
+        db.rollback()
+        raise HTTPException(
+            status_code=status.HTTP_500_INTERNAL_SERVER_ERROR,
+            detail="Could not persist suppression",
+        ) from exc
+
+    return {
+        "success": True,
+        "message": "Issue suppressed",
+        "issue_type": req.issue_type,
+        "line": req.line,
+        "scope": req.scope,
     }

--- a/backend/tests/test_endpoints.py
+++ b/backend/tests/test_endpoints.py
@@ -8,11 +8,16 @@ import json
 import pytest
 from pathlib import Path
 from fastapi.testclient import TestClient
+from sqlalchemy import create_engine, select
+from sqlalchemy.orm import sessionmaker
+from sqlalchemy.pool import StaticPool
 import sys
 import os
 
 sys.path.insert(0, os.path.dirname(os.path.dirname(__file__)))
 from app import main as app_main
+from app.database import Base, get_db
+from app.models import Suppression
 
 client = TestClient(app_main.app)
 
@@ -25,6 +30,38 @@ def reset_rate_limit_state():
     app_main._request_counts.clear()
     yield
     app_main._request_counts.clear()
+
+
+@pytest.fixture
+def isolated_debug_client():
+    engine = create_engine(
+        "sqlite:///:memory:",
+        connect_args={"check_same_thread": False},
+        poolclass=StaticPool,
+    )
+    TestingSessionLocal = sessionmaker(autocommit=False, autoflush=False, bind=engine)
+    Base.metadata.create_all(bind=engine)
+
+    def override_get_db():
+        db = TestingSessionLocal()
+        try:
+            yield db
+        finally:
+            db.close()
+
+    previous_override = app_main.app.dependency_overrides.get(get_db)
+    app_main.app.dependency_overrides[get_db] = override_get_db
+
+    try:
+        with TestClient(app_main.app) as test_client:
+            yield test_client, TestingSessionLocal
+    finally:
+        if previous_override is None:
+            app_main.app.dependency_overrides.pop(get_db, None)
+        else:
+            app_main.app.dependency_overrides[get_db] = previous_override
+        Base.metadata.drop_all(bind=engine)
+        engine.dispose()
 
 
 # ── Fixtures ──────────────────────────────────────────────────────────────────
@@ -369,6 +406,133 @@ def test_debug_detects_zero_division():
     d = r.json()
     types = [i["type"] for i in d["issues"]]
     assert "ZeroDivisionError" in types
+
+
+def test_debug_suppression_endpoint_persists_record(isolated_debug_client):
+    test_client, TestingSessionLocal = isolated_debug_client
+    payload = {
+        "issue_type": "ZeroDivisionError",
+        "line": 1,
+        "reason": "False positive",
+        "scope": "project",
+    }
+
+    r = test_client.post("/debugging/suppress", json=payload)
+
+    assert r.status_code == 200
+    data = r.json()
+    assert data["success"] is True
+    assert data["message"] == "Issue suppressed"
+    assert data["issue_type"] == payload["issue_type"]
+    assert data["line"] == payload["line"]
+    assert data["scope"] == payload["scope"]
+
+    db = TestingSessionLocal()
+    try:
+        record = db.execute(select(Suppression)).scalar_one()
+        assert record.issue_type == payload["issue_type"]
+        assert record.line == payload["line"]
+        assert record.reason == payload["reason"]
+        assert record.scope == payload["scope"]
+        assert record.created_at is not None
+    finally:
+        db.close()
+
+
+def test_debug_filters_suppressed_findings(isolated_debug_client):
+    test_client, TestingSessionLocal = isolated_debug_client
+    db = TestingSessionLocal()
+    try:
+        db.add(
+            Suppression(
+                issue_type="ZeroDivisionError",
+                line=1,
+                reason="Known false positive",
+                scope="project",
+            )
+        )
+        db.commit()
+    finally:
+        db.close()
+
+    r = test_client.post(
+        "/debugging/",
+        json={
+            "code": "result = a / b\npassword = \"abc123\"",
+            "language": "python",
+        },
+    )
+
+    assert r.status_code == 200
+    data = r.json()
+    issue_types = [issue["type"] for issue in data["issues"]]
+    assert "ZeroDivisionError" not in issue_types
+    assert "Hardcoded Secret" in issue_types
+    assert data["clean"] is False
+    assert data["error_count"] + data["warning_count"] + data["info_count"] == len(
+        data["issues"]
+    )
+    assert data["summary"] == (
+        f"Found {len(data['issues'])} issue(s): "
+        f"{data['error_count']} error(s), "
+        f"{data['warning_count']} warning(s), "
+        f"{data['info_count']} info."
+    )
+
+
+def test_debug_keeps_unsuppressed_findings(isolated_debug_client):
+    test_client, TestingSessionLocal = isolated_debug_client
+    db = TestingSessionLocal()
+    try:
+        db.add(
+            Suppression(
+                issue_type="ZeroDivisionError",
+                line=2,
+                reason="Only suppress the second line",
+                scope="project",
+            )
+        )
+        db.commit()
+    finally:
+        db.close()
+
+    r = test_client.post(
+        "/debugging/", json={"code": "result = a / b", "language": "python"}
+    )
+
+    assert r.status_code == 200
+    issue_types = [issue["type"] for issue in r.json()["issues"]]
+    assert "ZeroDivisionError" in issue_types
+
+
+def test_debug_recalculates_counts_after_suppression(isolated_debug_client):
+    test_client, TestingSessionLocal = isolated_debug_client
+    db = TestingSessionLocal()
+    try:
+        db.add(
+            Suppression(
+                issue_type="ZeroDivisionError",
+                line=1,
+                reason="Known false positive",
+                scope="global",
+            )
+        )
+        db.commit()
+    finally:
+        db.close()
+
+    r = test_client.post(
+        "/debugging/", json={"code": "result = a / b", "language": "python"}
+    )
+
+    assert r.status_code == 200
+    data = r.json()
+    assert data["issues"] == []
+    assert data["clean"] is True
+    assert data["error_count"] == 0
+    assert data["warning_count"] == 0
+    assert data["info_count"] == 0
+    assert data["summary"] == "✅ No issues detected!"
 
 
 def test_debug_detects_hardcoded_secret():

--- a/backend/tests/test_endpoints.py
+++ b/backend/tests/test_endpoints.py
@@ -23,8 +23,11 @@ client = TestClient(app_main.app)
 
 FIXTURES_DIR = Path(__file__).parent / "fixtures"
 
+
 def load_fixture(filename: str) -> str:
     return (FIXTURES_DIR / filename).read_text(encoding="utf-8")
+
+
 @pytest.fixture(autouse=True)
 def reset_rate_limit_state():
     app_main._request_counts.clear()
@@ -458,7 +461,7 @@ def test_debug_filters_suppressed_findings(isolated_debug_client):
     r = test_client.post(
         "/debugging/",
         json={
-            "code": "result = a / b\npassword = \"abc123\"",
+            "code": 'result = a / b\npassword = "abc123"',
             "language": "python",
         },
     )
@@ -645,7 +648,6 @@ def test_debug_kotlin():
     assert d is not None
 
 
-
 def test_debug_cpp_syntax_errors():
     code = "void main() {\n    cout << 'Hello World'\n}"
     r = client.post("/debugging/", json={"code": code, "language": "cpp"})
@@ -726,15 +728,20 @@ def test_add():
     d = r.json()
     assert d["overall_score"] >= 60  # clean code should score reasonably
 
+
 def test_suggestions_observability_print_only_python():
     # Pasting code with print() in Java should NOT trigger the Observability suggestion
-    r_java = client.post("/suggestions/", json={"code": 'print("hello");', "language": "java"})
+    r_java = client.post(
+        "/suggestions/", json={"code": 'print("hello");', "language": "java"}
+    )
     assert r_java.status_code == 200
     s_java = [s["category"] for s in r_java.json()["suggestions"]]
     assert "Observability" not in s_java
 
     # Pasting code with print() in Python SHOULD trigger the Observability suggestion
-    r_py = client.post("/suggestions/", json={"code": 'print("hello")', "language": "python"})
+    r_py = client.post(
+        "/suggestions/", json={"code": 'print("hello")', "language": "python"}
+    )
     assert r_py.status_code == 200
     s_py = [s["category"] for s in r_py.json()["suggestions"]]
     assert "Observability" in s_py
@@ -888,7 +895,9 @@ def test_get_stream_done_event_present():
 
 
 def test_get_stream_with_language_hint():
-    r = client.get("/analyze/stream", params={"code": JS_CODE, "language": "javascript"})
+    r = client.get(
+        "/analyze/stream", params={"code": JS_CODE, "language": "javascript"}
+    )
     assert r.status_code == 200
     events = _parse_sse_events(r.text)
     exp = next(e["data"] for e in events if e["type"] == "explanation")

--- a/backend/tests/test_schema_smoke.py
+++ b/backend/tests/test_schema_smoke.py
@@ -42,6 +42,7 @@ from app.models import (  # noqa: E402
     FavoriteResult,
     QueryHistory,
     SharedSnippet,
+    Suppression,
     User,
 )
 
@@ -52,6 +53,7 @@ EXPECTED_TABLES = {
     "favorite_results",
     "digest_subscriptions",
     "shares",
+    "suppressions",
 }
 
 # ── database URL (PostgreSQL in CI, SQLite locally) ───────────────────────────
@@ -228,6 +230,28 @@ def test_digest_subscription_insert(db_session):
     )
     assert fetched is not None
     assert fetched.is_active is True
+
+
+def test_suppression_insert(db_session):
+    """Suppression must accept a write and preserve the finding details."""
+    suppression = Suppression(
+        issue_type="ZeroDivisionError",
+        line=1,
+        reason="False positive in generated sample",
+        scope="project",
+    )
+    db_session.add(suppression)
+    db_session.commit()
+    db_session.refresh(suppression)
+
+    fetched = (
+        db_session.query(Suppression).filter_by(issue_type="ZeroDivisionError").first()
+    )
+    assert fetched is not None
+    assert fetched.line == 1
+    assert fetched.reason == "False positive in generated sample"
+    assert fetched.scope == "project"
+    assert fetched.created_at is not None
 
 
 # ── history DB (aiosqlite / FTS5) tests ───────────────────────────────────────

--- a/docs/CHANGELOG.md
+++ b/docs/CHANGELOG.md
@@ -12,6 +12,10 @@ All notable changes to QyverixAI are documented in this file.
   queryable `GET /admin/audit-logs` endpoint and admin-gated user role
   management (`PUT /admin/users/{id}/role`) and deletion
   (`DELETE /admin/users/{id}`).
+- Added finding suppression support for debugging results.
+- Added frontend integration for suppressing individual findings.
+- Added backend persistence and API support for suppressed findings.
+- Added automated tests for the finding suppression workflow.
 
 ### Changed
 - Linked the changelog from `README.md` for faster discoverability.
@@ -34,7 +38,7 @@ All notable changes to QyverixAI are documented in this file.
 - Documentation and contribution guidance for GSSoC 2026 contributors.
 
 ### Fixed
-- N/A
+- Updated the debugging interface after suppressing findings to keep the active results synchronized.
 
 ### Security
 - N/A

--- a/frontend/index.html
+++ b/frontend/index.html
@@ -4223,6 +4223,36 @@ details.issue-card[open] {
         }
       }
 
+      function removeSuppressedIssue(issueType, issueLine) {
+        if (!currentResult?.debugging?.issues) return;
+
+        const normalizedIssueLine = issueLine ? Number(issueLine) : null;
+        const nextIssues = currentResult.debugging.issues.filter((issue) => {
+          const sameType = issue.type === issueType;
+          const sameLine = issue.line == null ? normalizedIssueLine == null : Number(issue.line) === normalizedIssueLine;
+          return !(sameType && sameLine);
+        });
+
+        const updatedDebugging = {
+          ...currentResult.debugging,
+          issues: nextIssues,
+          clean: nextIssues.length === 0,
+          error_count: nextIssues.filter(issue => issue.severity === 'error').length,
+          warning_count: nextIssues.filter(issue => issue.severity === 'warning').length,
+          info_count: nextIssues.filter(issue => issue.severity === 'info').length,
+          summary: nextIssues.length
+            ? `Found ${nextIssues.length} issue(s): ${nextIssues.filter(issue => issue.severity === 'error').length} error(s), ${nextIssues.filter(issue => issue.severity === 'warning').length} warning(s), ${nextIssues.filter(issue => issue.severity === 'info').length} info.`
+            : '✅ No issues detected!',
+        };
+
+        currentResult = {
+          ...currentResult,
+          debugging: updatedDebugging,
+        };
+
+        renderDebug(updatedDebugging);
+      }
+
       function openSuppressDialog(issueType, issueLine) {
         closeSuppressDialog();
 
@@ -4255,10 +4285,11 @@ details.issue-card[open] {
                 <label><input type="radio" name="suppressScope" value="project" checked> This Project</label>
                 <label><input type="radio" name="suppressScope" value="global"> Global</label>
               </div>
+              <div id="suppressError" class="toast error" style="display:none; margin-top:4px;"></div>
             </div>
             <div class="suppress-dialog-actions">
               <button type="button" class="btn btn-secondary suppress-cancel">Cancel</button>
-              <button type="button" class="btn btn-primary suppress-submit">Suppress</button>
+              <button type="button" class="btn btn-primary suppress-submit" disabled>Suppress</button>
             </div>
           </div>
         `;
@@ -4266,6 +4297,16 @@ details.issue-card[open] {
         document.body.appendChild(modal);
         document.body.classList.add('modal-open');
         document.addEventListener('keydown', handleSuppressDialogEscape);
+
+        const reasonInput = modal.querySelector('#suppressReason');
+        const submitButton = modal.querySelector('.suppress-submit');
+        const errorBox = modal.querySelector('#suppressError');
+
+        const updateSubmitState = () => {
+          submitButton.disabled = !reasonInput.value.trim();
+        };
+
+        reasonInput.addEventListener('input', updateSubmitState);
 
         modal.addEventListener('click', (event) => {
           if (event.target === modal) {
@@ -4275,25 +4316,55 @@ details.issue-card[open] {
 
         modal.querySelector('.suppress-dialog-close').addEventListener('click', closeSuppressDialog);
         modal.querySelector('.suppress-cancel').addEventListener('click', closeSuppressDialog);
-        modal.querySelector('.suppress-submit').addEventListener('click', () => {
-          const reasonInput = modal.querySelector('#suppressReason');
-          const scopeInput = modal.querySelector('input[name="suppressScope"]:checked');
+        modal.querySelector('.suppress-submit').addEventListener('click', async (event) => {
+          event.preventDefault();
+          event.stopPropagation();
 
-          if (!reasonInput.value.trim()) {
+          const scopeInput = modal.querySelector('input[name="suppressScope"]:checked');
+          const reason = reasonInput.value.trim();
+
+          if (!reason) {
             reasonInput.focus();
-            reasonInput.reportValidity();
+            errorBox.textContent = 'Please enter a reason before suppressing.';
+            errorBox.style.display = 'flex';
             return;
           }
 
-          console.log({
-            issue_type: issueType,
-            line: issueLine || 0,
-            reason: reasonInput.value.trim(),
-            scope: scopeInput ? scopeInput.value : 'project'
-          });
+          submitButton.disabled = true;
+          submitButton.textContent = 'Suppressing…';
+          errorBox.style.display = 'none';
 
-          closeSuppressDialog();
+          try {
+            const base = getApiBase();
+            const response = await fetchWithApiFallback(base, '/debugging/suppress', {
+              method: 'POST',
+              headers: { 'Content-Type': 'application/json' },
+              body: JSON.stringify({
+                issue_type: issueType,
+                line: issueLine || null,
+                reason,
+                scope: scopeInput ? scopeInput.value : 'project'
+              }),
+              signal: AbortSignal.timeout(30000),
+            });
+
+            if (!response.response.ok) {
+              const err = await response.response.json().catch(() => ({}));
+              throw new Error(err.detail || err.message || `HTTP ${response.response.status}`);
+            }
+
+            toast('Issue suppressed successfully', 'success');
+            removeSuppressedIssue(issueType, issueLine);
+            closeSuppressDialog();
+          } catch (error) {
+            errorBox.textContent = error.message || 'Unable to suppress issue.';
+            errorBox.style.display = 'flex';
+            submitButton.disabled = false;
+            submitButton.textContent = 'Suppress';
+          }
         });
+
+        updateSubmitState();
       }
 
       function renderDebug(dbg) {
@@ -4356,8 +4427,9 @@ details.issue-card[open] {
 
       <div class="issue-actions">
         <button
+          type="button"
           class="suppress-btn"
-          onclick="openSuppressDialog('${issue.type}', ${issue.line || 0})">
+          onclick="event.preventDefault(); event.stopPropagation(); openSuppressDialog('${issue.type}', ${issue.line || 0})">
           Suppress
         </button>
       </div>

--- a/frontend/index.html
+++ b/frontend/index.html
@@ -1186,6 +1186,149 @@ details.issue-card[open] {
       margin-top: 3px
     }
 
+    .issue-actions {
+      display: flex;
+      justify-content: flex-end;
+      margin-top: 10px;
+    }
+
+    .suppress-btn {
+      border: 1px solid var(--border);
+      background: var(--bg);
+      color: var(--text2);
+      border-radius: 999px;
+      padding: 6px 12px;
+      font-size: 0.72rem;
+      font-weight: 600;
+      cursor: pointer;
+      transition: all var(--transition);
+    }
+
+    .suppress-btn:hover {
+      background: var(--bg2);
+      color: var(--text1);
+      border-color: var(--accent);
+    }
+
+    .suppress-dialog-backdrop {
+      position: fixed;
+      inset: 0;
+      background: rgba(4, 10, 24, 0.7);
+      backdrop-filter: blur(4px);
+      display: flex;
+      align-items: center;
+      justify-content: center;
+      padding: 20px;
+      z-index: 2000;
+    }
+
+    .suppress-dialog {
+      width: min(100%, 480px);
+      background: var(--bg3);
+      border: 1px solid var(--border);
+      border-radius: var(--r2);
+      box-shadow: 0 18px 45px rgba(0, 0, 0, 0.28);
+      color: var(--text1);
+      overflow: hidden;
+    }
+
+    .suppress-dialog-header {
+      display: flex;
+      align-items: center;
+      justify-content: space-between;
+      padding: 16px 18px;
+      border-bottom: 1px solid var(--border);
+    }
+
+    .suppress-dialog-header h3 {
+      margin: 0;
+      font-size: 1rem;
+      font-weight: 700;
+    }
+
+    .suppress-dialog-close {
+      border: none;
+      background: transparent;
+      color: var(--text2);
+      font-size: 1.2rem;
+      cursor: pointer;
+    }
+
+    .suppress-dialog-body {
+      padding: 16px 18px 8px;
+      display: flex;
+      flex-direction: column;
+      gap: 12px;
+    }
+
+    .suppress-dialog-row {
+      display: flex;
+      align-items: center;
+      justify-content: space-between;
+      gap: 12px;
+      color: var(--text2);
+      font-size: 0.9rem;
+    }
+
+    .suppress-dialog-row strong {
+      color: var(--text1);
+      font-weight: 600;
+    }
+
+    .suppress-field {
+      font-size: 0.85rem;
+      font-weight: 600;
+      color: var(--text2);
+      display: flex;
+      align-items: center;
+      justify-content: space-between;
+      gap: 8px;
+    }
+
+    .suppress-field span {
+      font-size: 0.74rem;
+      color: var(--text3);
+      font-weight: 500;
+    }
+
+    .suppress-textarea {
+      width: 100%;
+      min-height: 92px;
+      border: 1px solid var(--border);
+      border-radius: 10px;
+      padding: 10px 12px;
+      background: var(--bg);
+      color: var(--text1);
+      resize: vertical;
+      font: inherit;
+    }
+
+    .suppress-scope {
+      display: flex;
+      flex-direction: column;
+      gap: 6px;
+      color: var(--text2);
+      font-size: 0.85rem;
+    }
+
+    .suppress-scope label {
+      display: inline-flex;
+      align-items: center;
+      gap: 8px;
+      color: var(--text1);
+    }
+
+    .suppress-dialog-actions {
+      display: flex;
+      justify-content: flex-end;
+      gap: 10px;
+      padding: 14px 18px 18px;
+    }
+
+    .suppress-dialog-actions .btn {
+      min-width: 100px;
+    }
+
     /* ── Explanation Cards ── */
     .explain-summary {
       padding: 16px;
@@ -4066,6 +4209,93 @@ details.issue-card[open] {
   `;
       }
 
+      function closeSuppressDialog() {
+        const modal = document.getElementById('suppressDialog');
+        if (!modal) return;
+        modal.remove();
+        document.body.classList.remove('modal-open');
+        document.removeEventListener('keydown', handleSuppressDialogEscape);
+      }
+
+      function handleSuppressDialogEscape(event) {
+        if (event.key === 'Escape') {
+          closeSuppressDialog();
+        }
+      }
+
+      function openSuppressDialog(issueType, issueLine) {
+        closeSuppressDialog();
+
+        const modal = document.createElement('div');
+        modal.id = 'suppressDialog';
+        modal.className = 'suppress-dialog-backdrop';
+        modal.setAttribute('role', 'presentation');
+        modal.innerHTML = `
+          <div class="suppress-dialog" role="dialog" aria-modal="true" aria-labelledby="suppressDialogTitle">
+            <div class="suppress-dialog-header">
+              <h3 id="suppressDialogTitle">Suppress issue</h3>
+              <button type="button" class="suppress-dialog-close" aria-label="Close">×</button>
+            </div>
+            <div class="suppress-dialog-body">
+              <div class="suppress-dialog-row">
+                <span>Issue Type</span>
+                <strong>${escHtml(issueType || 'Unknown')}</strong>
+              </div>
+              <div class="suppress-dialog-row">
+                <span>Line Number</span>
+                <strong>${escHtml(issueLine ? String(issueLine) : 'N/A')}</strong>
+              </div>
+              <label class="suppress-field" for="suppressReason">
+                Reason
+                <span>(required)</span>
+              </label>
+              <textarea id="suppressReason" class="suppress-textarea" rows="4" required></textarea>
+              <div class="suppress-scope">
+                <span>Scope</span>
+                <label><input type="radio" name="suppressScope" value="project" checked> This Project</label>
+                <label><input type="radio" name="suppressScope" value="global"> Global</label>
+              </div>
+            </div>
+            <div class="suppress-dialog-actions">
+              <button type="button" class="btn btn-secondary suppress-cancel">Cancel</button>
+              <button type="button" class="btn btn-primary suppress-submit">Suppress</button>
+            </div>
+          </div>
+        `;
+
+        document.body.appendChild(modal);
+        document.body.classList.add('modal-open');
+        document.addEventListener('keydown', handleSuppressDialogEscape);
+
+        modal.addEventListener('click', (event) => {
+          if (event.target === modal) {
+            closeSuppressDialog();
+          }
+        });
+
+        modal.querySelector('.suppress-dialog-close').addEventListener('click', closeSuppressDialog);
+        modal.querySelector('.suppress-cancel').addEventListener('click', closeSuppressDialog);
+        modal.querySelector('.suppress-submit').addEventListener('click', () => {
+          const reasonInput = modal.querySelector('#suppressReason');
+          const scopeInput = modal.querySelector('input[name="suppressScope"]:checked');
+
+          if (!reasonInput.value.trim()) {
+            reasonInput.focus();
+            reasonInput.reportValidity();
+            return;
+          }
+
+          console.log({
+            issue_type: issueType,
+            line: issueLine || 0,
+            reason: reasonInput.value.trim(),
+            scope: scopeInput ? scopeInput.value : 'project'
+          });
+
+          closeSuppressDialog();
+        });
+      }
+
       function renderDebug(dbg) {
         document.getElementById('emptyDebug').style.display = 'none';
         const el = document.getElementById('debugResult');
@@ -4123,6 +4353,14 @@ details.issue-card[open] {
         : ''}
 
       <div class="issue-fix">${issue.suggestion}</div>
+
+      <div class="issue-actions">
+        <button
+          class="suppress-btn"
+          onclick="openSuppressDialog('${issue.type}', ${issue.line || 0})">
+          Suppress
+        </button>
+      </div>
     </div>
 
   </details>


### PR DESCRIPTION

## Description

Implemented finding suppression support for debugging results.

This PR adds frontend and backend support for suppressing individual debugging findings. Suppressed findings are removed from the active debug view, persisted in the backend, and covered with automated tests. The changelog has also been updated.

## Related Issue

Fixes #671

## Type of change

- [x] Bug fix
- [x] New feature / enhancement
- [X] Documentation update
- [x] Test addition
- [ ] Refactor

## Checklist

- [x] I have read [CONTRIBUTING.md](../CONTRIBUTING.md)
- [x] My branch is up to date with `main`
- [x] I have run `pytest -v` and all tests pass
- [x] I have not introduced duplicate issues or features
- [x] My PR title follows the format: `feat/fix/docs/test: short description`
- [x] I have added tests for new features (Level 2 and 3 issues)
- [x] No hardcoded secrets or API keys in my code
- [x] This PR is linked to a GSSoC 2026 issue

## Screenshots (frontend change)
<img width="1755" height="862" alt="Screenshot 2026-07-20 015242" src="https://github.com/user-attachments/assets/539e1d82-8558-45bf-9aa1-28b69bd5d315" />

### Before
<img width="1600" height="720" alt="before" src="https://github.com/user-attachments/assets/49fe9968-446c-4792-a93e-480a011ee36d" />


### After
'''<img width="1600" height="756" alt="supp" src="https://github.com/user-attachments/assets/529ba633-998b-4ac8-aa2e-de6e1d029847" />'''

'''<img width="1600" height="785" alt="issue" src="https://github.com/user-attachments/assets/23672c5d-c4d9-4ad2-a05a-7605b1c6800d" />'''

'''<img width="1129" height="509" alt="confirmation" src="https://github.com/user-attachments/assets/29201669-98f8-48dd-859f-ecad53bd45e4" />'''

## Test evidence

```bash
pytest -v

============================= test session starts =============================
...
441 passed, 116 warnings in 34.61s
```
<img width="1085" height="611" alt="Screenshot 2026-07-20 022429" src="https://github.com/user-attachments/assets/2b24ff9a-8539-4b99-a52b-cfcfe357da78" />
