### PR TITLE
feat(observability): expose email service observability and fix NoneT…

### DIFF
--- a/backend/app/observability.py
+++ b/backend/app/observability.py
@@ -106,6 +106,19 @@ APP_INFO = Gauge(
     labelnames=("version", "ai_provider"),
 )
 
+EMAIL_SENT_TOTAL = Counter(
+    "qyverixai_email_sent_total",
+    "Total number of emails sent, labelled by type and status.",
+    labelnames=("type", "status"),
+)
+
+EMAIL_SEND_DURATION_SECONDS = Histogram(
+    "qyverixai_email_send_duration_seconds",
+    "Latency of email delivery in seconds, labelled by type.",
+    labelnames=("type",),
+)
+
+
 
 def initialise_app_info(version: str, ai_provider: str) -> None:
     """Set the app_info gauge once at startup so dashboards can display it."""

--- a/backend/app/observability.py
+++ b/backend/app/observability.py
@@ -36,7 +36,6 @@ from prometheus_client import (
     multiprocess,
 )
 
-
 # ── Configuration ─────────────────────────────────────────────────────────────
 # Both flags are intentionally read at **request time** (not import time) so
 # tests, hot-reloads, and operators can flip them without having to recreate

--- a/backend/app/observability.py
+++ b/backend/app/observability.py
@@ -44,6 +44,7 @@ from prometheus_client import (
 # ``Duplicated timeseries in CollectorRegistry`` because they live on the
 # module-global ``prometheus_client.REGISTRY``.
 
+
 def _bool_env(name: str, default: bool) -> bool:
     raw = os.getenv(name)
     if raw is None:
@@ -57,6 +58,7 @@ def metrics_enabled() -> bool:
 
 def metrics_auth_token() -> str | None:
     return os.getenv("METRICS_AUTH_TOKEN") or None
+
 
 # Paths the middleware ignores entirely (the /metrics endpoint must not record
 # itself; static files under /app are noisy and high-cardinality if used as
@@ -72,7 +74,18 @@ _EXCLUDED_PATH_PREFIXES: tuple[str, ...] = (
 # Buckets are chosen for a typical HTTP API: sub-millisecond up to ~30s. The
 # upper bucket of +Inf is added automatically by prometheus_client.
 _LATENCY_BUCKETS_SECONDS: tuple[float, ...] = (
-    0.005, 0.01, 0.025, 0.05, 0.1, 0.25, 0.5, 1.0, 2.5, 5.0, 10.0, 30.0,
+    0.005,
+    0.01,
+    0.025,
+    0.05,
+    0.1,
+    0.25,
+    0.5,
+    1.0,
+    2.5,
+    5.0,
+    10.0,
+    30.0,
 )
 
 REQUESTS_TOTAL = Counter(
@@ -119,7 +132,6 @@ EMAIL_SEND_DURATION_SECONDS = Histogram(
 )
 
 
-
 def initialise_app_info(version: str, ai_provider: str) -> None:
     """Set the app_info gauge once at startup so dashboards can display it."""
     APP_INFO.labels(version=version, ai_provider=ai_provider).set(1)
@@ -143,7 +155,10 @@ def _endpoint_label(request: Request) -> str:
 
 
 def _should_skip(path: str) -> bool:
-    return any(path == prefix or path.startswith(prefix + "/") for prefix in _EXCLUDED_PATH_PREFIXES)
+    return any(
+        path == prefix or path.startswith(prefix + "/")
+        for prefix in _EXCLUDED_PATH_PREFIXES
+    )
 
 
 # ── Middleware ────────────────────────────────────────────────────────────────

--- a/backend/app/services/email_service.py
+++ b/backend/app/services/email_service.py
@@ -10,9 +10,16 @@ import smtplib
 from urllib.parse import urlencode
 
 from sqlalchemy.orm import Session
+import time
 
 from ..config import settings
 from ..models import QueryHistory, User
+from ..observability import (
+    EMAIL_SEND_DURATION_SECONDS,
+    EMAIL_SENT_TOTAL,
+    metrics_enabled,
+)
+
 
 # ── Helpers ──────────────────────────────────────────────────────────────────
 
@@ -262,6 +269,7 @@ def send_digest(stats: dict, unsubscribe_token: str) -> bool:
     msg.attach(MIMEText(_build_text(stats, unsubscribe_url), "plain"))
     msg.attach(MIMEText(_build_html(stats, unsubscribe_url), "html"))
 
+    start_time = time.perf_counter()
     try:
         with smtplib.SMTP(settings.smtp_host, settings.smtp_port, timeout=30) as server:
             if settings.smtp_port == 587:
@@ -269,11 +277,22 @@ def send_digest(stats: dict, unsubscribe_token: str) -> bool:
             if settings.smtp_user:
                 server.login(settings.smtp_user, settings.smtp_pass)
             server.send_message(msg)
+        
+        if metrics_enabled():
+            duration = time.perf_counter() - start_time
+            EMAIL_SEND_DURATION_SECONDS.labels(type="digest").observe(duration)
+            EMAIL_SENT_TOTAL.labels(type="digest", status="success").inc()
         return True
     except Exception as exc:
+        if metrics_enabled():
+            duration = time.perf_counter() - start_time
+            EMAIL_SEND_DURATION_SECONDS.labels(type="digest").observe(duration)
+            EMAIL_SENT_TOTAL.labels(type="digest", status="failed").inc()
+
         import logging
 
         logging.getLogger(__name__).warning(
             "Failed to send digest to %s: %s", stats["email"], exc
         )
         return False
+

--- a/backend/app/services/email_service.py
+++ b/backend/app/services/email_service.py
@@ -277,7 +277,7 @@ def send_digest(stats: dict, unsubscribe_token: str) -> bool:
             if settings.smtp_user:
                 server.login(settings.smtp_user, settings.smtp_pass)
             server.send_message(msg)
-        
+
         if metrics_enabled():
             duration = time.perf_counter() - start_time
             EMAIL_SEND_DURATION_SECONDS.labels(type="digest").observe(duration)
@@ -295,4 +295,3 @@ def send_digest(stats: dict, unsubscribe_token: str) -> bool:
             "Failed to send digest to %s: %s", stats["email"], exc
         )
         return False
-

--- a/backend/app/services/email_service.py
+++ b/backend/app/services/email_service.py
@@ -1,16 +1,17 @@
 """Weekly digest email — SMTP sending and HTML template."""
 
 from __future__ import annotations
+
+import json
 import secrets
+import smtplib
+import time
 from datetime import UTC, datetime, timedelta
 from email.mime.multipart import MIMEMultipart
 from email.mime.text import MIMEText
-import json
-import smtplib
 from urllib.parse import urlencode
 
 from sqlalchemy.orm import Session
-import time
 
 from ..config import settings
 from ..models import QueryHistory, User
@@ -19,7 +20,6 @@ from ..observability import (
     EMAIL_SENT_TOTAL,
     metrics_enabled,
 )
-
 
 # ── Helpers ──────────────────────────────────────────────────────────────────
 

--- a/backend/tests/test_digest.py
+++ b/backend/tests/test_digest.py
@@ -266,3 +266,120 @@ def test_unsubscribe_url_encodes_query_parameters(monkeypatch):
     assert parsed.path == "/subscribe/unsubscribe"
     assert query["email"] == ["digest.user+weekly@example.com"]
     assert query["token"] == ["token/value+with symbols"]
+
+
+def test_email_observability_metrics_on_success(monkeypatch):
+    from prometheus_client import REGISTRY
+
+    # 1. Capture baseline metrics values
+    baseline_success = REGISTRY.get_sample_value(
+        "qyverixai_email_sent_total", {"type": "digest", "status": "success"}
+    ) or 0.0
+    baseline_duration_count = REGISTRY.get_sample_value(
+        "qyverixai_email_send_duration_seconds_count", {"type": "digest"}
+    ) or 0.0
+
+    class FakeSMTP:
+        def __init__(self, host, port, timeout):
+            pass
+        def __enter__(self):
+            return self
+        def __exit__(self, exc_type, exc, traceback):
+            return False
+        def starttls(self):
+            pass
+        def login(self, user, password):
+            pass
+        def send_message(self, message):
+            pass
+
+    monkeypatch.setattr(email_service.settings, "digest_enabled", True)
+    monkeypatch.setattr(email_service.settings, "smtp_host", "smtp.example.com")
+    monkeypatch.setattr(email_service.settings, "smtp_port", 2525)
+    monkeypatch.setattr(email_service.smtplib, "SMTP", FakeSMTP)
+
+    stats = {
+        "email": "metrics.success@example.com",
+        "total_analyses": 1,
+        "languages": ["Python"],
+        "avg_score": 90,
+        "prev_avg": None,
+        "improvement": None,
+        "trend": "stable",
+        "top_bug": None,
+        "total_issues": 0,
+        "week_start": "May 19",
+        "week_end": "May 26, 2026",
+    }
+
+    assert email_service.send_digest(stats, "token-value") is True
+
+    # 2. Check metrics are incremented
+    new_success = REGISTRY.get_sample_value(
+        "qyverixai_email_sent_total", {"type": "digest", "status": "success"}
+    ) or 0.0
+    new_duration_count = REGISTRY.get_sample_value(
+        "qyverixai_email_send_duration_seconds_count", {"type": "digest"}
+    ) or 0.0
+
+    assert new_success == baseline_success + 1.0
+    assert new_duration_count == baseline_duration_count + 1.0
+
+
+def test_email_observability_metrics_on_failure(monkeypatch):
+    from prometheus_client import REGISTRY
+
+    # 1. Capture baseline metrics values
+    baseline_failed = REGISTRY.get_sample_value(
+        "qyverixai_email_sent_total", {"type": "digest", "status": "failed"}
+    ) or 0.0
+    baseline_duration_count = REGISTRY.get_sample_value(
+        "qyverixai_email_send_duration_seconds_count", {"type": "digest"}
+    ) or 0.0
+
+    class BrokenSMTP:
+        def __init__(self, host, port, timeout):
+            pass
+        def __enter__(self):
+            return self
+        def __exit__(self, exc_type, exc, traceback):
+            return False
+        def starttls(self):
+            pass
+        def login(self, user, password):
+            pass
+        def send_message(self, message):
+            raise Exception("SMTP Connection Failed")
+
+    monkeypatch.setattr(email_service.settings, "digest_enabled", True)
+    monkeypatch.setattr(email_service.settings, "smtp_host", "smtp.example.com")
+    monkeypatch.setattr(email_service.settings, "smtp_port", 2525)
+    monkeypatch.setattr(email_service.smtplib, "SMTP", BrokenSMTP)
+
+    stats = {
+        "email": "metrics.fail@example.com",
+        "total_analyses": 1,
+        "languages": ["Python"],
+        "avg_score": 90,
+        "prev_avg": None,
+        "improvement": None,
+        "trend": "stable",
+        "top_bug": None,
+        "total_issues": 0,
+        "week_start": "May 19",
+        "week_end": "May 26, 2026",
+    }
+
+    assert email_service.send_digest(stats, "token-value") is False
+
+    # 2. Check metrics are incremented
+    new_failed = REGISTRY.get_sample_value(
+        "qyverixai_email_sent_total", {"type": "digest", "status": "failed"}
+    ) or 0.0
+    new_duration_count = REGISTRY.get_sample_value(
+        "qyverixai_email_send_duration_seconds_count", {"type": "digest"}
+    ) or 0.0
+
+    assert new_failed == baseline_failed + 1.0
+    assert new_duration_count == baseline_duration_count + 1.0
+

--- a/backend/tests/test_digest.py
+++ b/backend/tests/test_digest.py
@@ -272,24 +272,35 @@ def test_email_observability_metrics_on_success(monkeypatch):
     from prometheus_client import REGISTRY
 
     # 1. Capture baseline metrics values
-    baseline_success = REGISTRY.get_sample_value(
-        "qyverixai_email_sent_total", {"type": "digest", "status": "success"}
-    ) or 0.0
-    baseline_duration_count = REGISTRY.get_sample_value(
-        "qyverixai_email_send_duration_seconds_count", {"type": "digest"}
-    ) or 0.0
+    baseline_success = (
+        REGISTRY.get_sample_value(
+            "qyverixai_email_sent_total", {"type": "digest", "status": "success"}
+        )
+        or 0.0
+    )
+    baseline_duration_count = (
+        REGISTRY.get_sample_value(
+            "qyverixai_email_send_duration_seconds_count", {"type": "digest"}
+        )
+        or 0.0
+    )
 
     class FakeSMTP:
         def __init__(self, host, port, timeout):
             pass
+
         def __enter__(self):
             return self
+
         def __exit__(self, exc_type, exc, traceback):
             return False
+
         def starttls(self):
             pass
+
         def login(self, user, password):
             pass
+
         def send_message(self, message):
             pass
 
@@ -315,12 +326,18 @@ def test_email_observability_metrics_on_success(monkeypatch):
     assert email_service.send_digest(stats, "token-value") is True
 
     # 2. Check metrics are incremented
-    new_success = REGISTRY.get_sample_value(
-        "qyverixai_email_sent_total", {"type": "digest", "status": "success"}
-    ) or 0.0
-    new_duration_count = REGISTRY.get_sample_value(
-        "qyverixai_email_send_duration_seconds_count", {"type": "digest"}
-    ) or 0.0
+    new_success = (
+        REGISTRY.get_sample_value(
+            "qyverixai_email_sent_total", {"type": "digest", "status": "success"}
+        )
+        or 0.0
+    )
+    new_duration_count = (
+        REGISTRY.get_sample_value(
+            "qyverixai_email_send_duration_seconds_count", {"type": "digest"}
+        )
+        or 0.0
+    )
 
     assert new_success == baseline_success + 1.0
     assert new_duration_count == baseline_duration_count + 1.0
@@ -330,24 +347,35 @@ def test_email_observability_metrics_on_failure(monkeypatch):
     from prometheus_client import REGISTRY
 
     # 1. Capture baseline metrics values
-    baseline_failed = REGISTRY.get_sample_value(
-        "qyverixai_email_sent_total", {"type": "digest", "status": "failed"}
-    ) or 0.0
-    baseline_duration_count = REGISTRY.get_sample_value(
-        "qyverixai_email_send_duration_seconds_count", {"type": "digest"}
-    ) or 0.0
+    baseline_failed = (
+        REGISTRY.get_sample_value(
+            "qyverixai_email_sent_total", {"type": "digest", "status": "failed"}
+        )
+        or 0.0
+    )
+    baseline_duration_count = (
+        REGISTRY.get_sample_value(
+            "qyverixai_email_send_duration_seconds_count", {"type": "digest"}
+        )
+        or 0.0
+    )
 
     class BrokenSMTP:
         def __init__(self, host, port, timeout):
             pass
+
         def __enter__(self):
             return self
+
         def __exit__(self, exc_type, exc, traceback):
             return False
+
         def starttls(self):
             pass
+
         def login(self, user, password):
             pass
+
         def send_message(self, message):
             raise Exception("SMTP Connection Failed")
 
@@ -373,13 +401,18 @@ def test_email_observability_metrics_on_failure(monkeypatch):
     assert email_service.send_digest(stats, "token-value") is False
 
     # 2. Check metrics are incremented
-    new_failed = REGISTRY.get_sample_value(
-        "qyverixai_email_sent_total", {"type": "digest", "status": "failed"}
-    ) or 0.0
-    new_duration_count = REGISTRY.get_sample_value(
-        "qyverixai_email_send_duration_seconds_count", {"type": "digest"}
-    ) or 0.0
+    new_failed = (
+        REGISTRY.get_sample_value(
+            "qyverixai_email_sent_total", {"type": "digest", "status": "failed"}
+        )
+        or 0.0
+    )
+    new_duration_count = (
+        REGISTRY.get_sample_value(
+            "qyverixai_email_send_duration_seconds_count", {"type": "digest"}
+        )
+        or 0.0
+    )
 
     assert new_failed == baseline_failed + 1.0
     assert new_duration_count == baseline_duration_count + 1.0
-

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -5,3 +5,11 @@ target-version = ["py312"]
 [tool.isort] 
 profile = "black" 
 line_length = 88 
+
+[tool.pyright]
+extraPaths = ["backend"]
+
+[tool.pytest.ini_options]
+pythonpath = ["backend"]
+
+


### PR DESCRIPTION
# feat(observability): expose email service observability metrics

## Description
This PR exposes observability metrics and logging in the email service to improve monitoring and reliability:
* **Observability Setup**: Defines `EMAIL_SENT_TOTAL` (Counter) and `EMAIL_SEND_DURATION_SECONDS` (Histogram) in `observability.py`.
* **Metrics Instrumentation**: Tracks latency and success/failure counters during SMTP email dispatch in `send_digest()`.
* **Testing**: Adds unit tests (`test_email_observability_metrics_on_success` and `test_email_observability_metrics_on_failure`) in `test_digest.py` to verify the prometheus metrics increment correctly upon successful and failed email delivery.

## Related Issue
Fixes #1547

## Type of change
- [ ] Bug fix
- [x] New feature / enhancement
- [ ] Documentation update
- [x] Test addition
- [ ] Refactor

## Checklist
- [x] I have read [CONTRIBUTING.md](../CONTRIBUTING.md)
- [x] My branch is up to date with `main`
- [x] I have run `pytest -v` and all tests pass
- [x] I have not introduced duplicate issues or features
- [x] My PR title follows the format: `feat/fix/docs/test: short description`
- [x] I have added tests for new features (Level 2 and 3 issues)
- [x] No hardcoded secrets or API keys in my code
- [x] This PR is linked to a GSSoC 2026 issue

## Screenshots (if frontend change)
N/A (Backend-only changes)

## Test evidence
```bash
pytest backend/tests/test_digest.py -v
