### PR TITLE
fix: delay Blob URL revocation to prevent export download failures

### DIFF
--- a/frontend/index.html
+++ b/frontend/index.html
@@ -5321,10 +5321,14 @@ document.getElementById('clearFavsBtn').addEventListener('click', () => {
         const text = buildReport(currentResult, editor.value);
         const blob = new Blob([text], { type: 'text/plain' });
         const a = document.createElement('a');
-        a.href = URL.createObjectURL(blob);
+        const url = URL.createObjectURL(blob);
+        a.href = url;
         a.download = `qyverixai-report-${Date.now()}.txt`;
         a.click();
-        URL.revokeObjectURL(a.href);
+        // Delay Blob URL revocation to allow browser download stream initialization
+        setTimeout(() => {
+          URL.revokeObjectURL(url);
+        }, 1000);
         toast(getTranslation('toast_report_downloaded'), 'success');
       });
 
@@ -5339,10 +5343,14 @@ document.getElementById('clearFavsBtn').addEventListener('click', () => {
             
             const blob = new Blob([mdText], { type: 'text/markdown' });
             const a = document.createElement('a');
-            a.href = URL.createObjectURL(blob);
+            const url = URL.createObjectURL(blob);
+            a.href = url;
             a.download = `qyverixai-report-${Date.now()}.md`;
             a.click();
-            URL.revokeObjectURL(a.href);
+            // Delay Blob URL revocation to allow browser download stream initialization
+            setTimeout(() => {
+                URL.revokeObjectURL(url);
+            }, 1000);
             
             if (typeof toast === 'function') toast('Downloaded as Markdown', 'success');
         } catch (error) {

--- a/frontend/script.js
+++ b/frontend/script.js
@@ -132,9 +132,14 @@ document.getElementById('downloadBtn').addEventListener('click', () => {
   if (!lastResult) return;
   const blob = new Blob([lastResult], { type: 'text/plain' });
   const a = document.createElement('a');
-  a.href = URL.createObjectURL(blob);
+  const url = URL.createObjectURL(blob);
+  a.href = url;
   a.download = `qyverix-analysis-${Date.now()}.txt`;
   a.click();
+  // Delay Blob URL revocation to allow browser download stream initialization
+  setTimeout(() => {
+    URL.revokeObjectURL(url);
+  }, 1000);
 });
 
 // ── Save favorite ──
@@ -175,10 +180,15 @@ document.getElementById('downloadJsonBtn').addEventListener('click', () => {
   );
 
   const a = document.createElement('a');
-  a.href = URL.createObjectURL(blob);
+  const url = URL.createObjectURL(blob);
+  a.href = url;
   a.download = 'analysis-history.json';
   a.click();
-  URL.revokeObjectURL(a.href);
+
+  // Delay Blob URL revocation to allow browser download stream initialization
+  setTimeout(() => {
+    URL.revokeObjectURL(url);
+  }, 1000);
 
 });
 // ── Download History CSV ──
@@ -211,10 +221,15 @@ document.getElementById('downloadCsvBtn').addEventListener('click', () => {
   );
 
   const a = document.createElement('a');
-  a.href = URL.createObjectURL(blob);
+  const url = URL.createObjectURL(blob);
+  a.href = url;
   a.download = 'analysis-history.csv';
   a.click();
-URL.revokeObjectURL(a.href);
+
+  // Delay Blob URL revocation to allow browser download stream initialization
+  setTimeout(() => {
+    URL.revokeObjectURL(url);
+  }, 1000);
 });
 
 // ── Run Button ──


### PR DESCRIPTION


## Description
This PR fixes an issue where clicking "Download JSON", "Download CSV", or exporting reports caused download failures or 0-byte files across Chrome, Firefox, and Safari. Synchronously calling `URL.revokeObjectURL(a.href)` immediately after `a.click()` invalidates the Blob URL before browser engines complete opening the asynchronous download stream. This change replaces synchronous revocation with a 1-second delayed `setTimeout` cleanup, allowing browser download streams sufficient time to initialize while preventing memory leaks.

## Related Issue
Fixes #1652

## Type of change
- [x] Bug fix
- [ ] New feature / enhancement
- [ ] Documentation update
- [ ] Test addition
- [ ] Refactor

## Checklist
- [x] I have read [CONTRIBUTING.md](../CONTRIBUTING.md)
- [x] My branch is up to date with `main`
- [x] I have run `pytest -v` and all tests pass
- [x] I have not introduced duplicate issues or features
- [x] My PR title follows the format: `feat/fix/docs/test: short description`
- [ ] I have added tests for new features (Level 2 and 3 issues)
- [x] No hardcoded secrets or API keys in my code
- [x] This PR is linked to a GSSoC 2026 issue

## Screenshots (if frontend change)
*No layout changes; functional download fix.*

## Test evidence
```bash
# Manual verification across Chrome, Firefox, and Safari for JSON, CSV, TXT, and MD exports
```

