### PR TITLE
fix(auth): remove password min_length validation from LoginRequest

### DIFF
--- a/backend/app/schemas.py
+++ b/backend/app/schemas.py
@@ -381,7 +381,6 @@ class LoginRequest(BaseModel):
     )
     password: str = Field(
         ...,
-        min_length=8,
         max_length=128,
         description="The account password.",
         example="supersecret123",

--- a/backend/tests/test_auth_endpoints.py
+++ b/backend/tests/test_auth_endpoints.py
@@ -99,7 +99,17 @@ def test_signup_login_and_me_happy_path(client):
         "user_id": signup_data["user_id"],
         "email": "new.user@example.com",
     }
+    
+def test_login_short_password_not_rejected_by_schema(client):
+    response = client.post(
+        "/auth/login",
+        json={
+            "email": "user@example.com",
+            "password": "short",
+        },
+    )
 
+    assert response.status_code != 422
 
 def test_signup_duplicate_email_returns_409(client):
     payload = {"email": "dup@example.com", "password": "StrongPass123!"}

--- a/backend/tests/test_auth_endpoints.py
+++ b/backend/tests/test_auth_endpoints.py
@@ -99,7 +99,8 @@ def test_signup_login_and_me_happy_path(client):
         "user_id": signup_data["user_id"],
         "email": "new.user@example.com",
     }
-    
+
+
 def test_login_short_password_not_rejected_by_schema(client):
     response = client.post(
         "/auth/login",
@@ -110,6 +111,7 @@ def test_login_short_password_not_rejected_by_schema(client):
     )
 
     assert response.status_code != 422
+
 
 def test_signup_duplicate_email_returns_409(client):
     payload = {"email": "dup@example.com", "password": "StrongPass123!"}


### PR DESCRIPTION
## Description

This PR fixes the login request validation by removing the `min_length=8` constraint from the `LoginRequest` schema.

Previously, login requests with passwords shorter than 8 characters were rejected with a **422 Unprocessable Entity** response before reaching the authentication logic. Password complexity rules should only be enforced during account creation, not during login.

### Changes Made
- Removed `min_length=8` from `LoginRequest.password`.
- Retained `max_length=128` to guard against excessively large inputs.
- Added a regression test to ensure login requests are not rejected by schema validation due to password length.

## Related Issue

Fixes #1679

## Type of change

- [x] Bug fix
- [ ] New feature / enhancement
- [ ] Documentation update
- [x] Test addition
- [ ] Refactor

## Checklist

- [x] I have read [CONTRIBUTING.md](../CONTRIBUTING.md)
- [x] My branch is up to date with `main`
- [x] I have run `pytest -v` (relevant authentication tests) and all tests pass
- [x] I have not introduced duplicate issues or features
- [x] My PR title follows the format: `feat/fix/docs/test: short description`
- [x] I have added tests for new features (Level 2 and 3 issues)
- [x] No hardcoded secrets or API keys in my code
- [x] This PR is linked to a GSSoC 2026 issue

## Test evidence

```bash
pytest backend/tests/test_auth_endpoints.py

============================= test session starts =============================
...
============================= 9 passed in 5.05s =============================
