### PR TITLE
feat(analyzer): add C# language detection

### DIFF
--- a/backend/app/services/code_assistant.py
+++ b/backend/app/services/code_assistant.py
@@ -47,6 +47,13 @@ LANG_SIGNATURES: dict[str, list[str]] = {
         r"@Override",
         r"\bnew\s+\w+\s*\(",
     ],
+    "C#": [
+        r"\busing\s+System",
+        r"\bnamespace\s+\w+",
+        r"\bpublic\s+(class|void|static)\b",
+        r"\bConsole\.Write",
+        r"\bnew\s+\w+\s*\(",
+    ],
     "C++": [
         r"#include\s*<",
         r"\bstd::\w+",
@@ -105,6 +112,9 @@ def detect_language(code: str, hint: str | None = None) -> str:
         "typescript": "TypeScript",
         "ts": "TypeScript",
         "java": "Java",
+        "csharp": "C#",
+        "c#": "C#",
+        "cs": "C#",
         "cpp": "C++",
         "c++": "C++",
         "cxx": "C++",
@@ -276,6 +286,7 @@ class BugPattern:
             "JavaScript",
             "TypeScript",
             "Java",
+            "C#",
             "C++",
             "PHP",
             "Rust",
@@ -549,6 +560,31 @@ BUG_PATTERNS: list[BugPattern] = [
         "Throw an exception instead and let the caller decide.",
         "error",
         ["Java"],
+    ),
+    # C#
+    BugPattern(
+        "C# Empty Catch Block",
+        r"catch\s*\([^)]*\)\s*\{\s*\}",
+        "Empty catch block swallows exceptions and hides failures.",
+        "Log the exception or handle the specific recovery path explicitly.",
+        "error",
+        ["C#"],
+    ),
+    BugPattern(
+        "C# Hardcoded Connection String",
+        r"\bconnectionString\s*=\s*\"",
+        "Hardcoded connection string found in source code.",
+        "Move connection strings to environment variables or a secure configuration provider.",
+        "error",
+        ["C#"],
+    ),
+    BugPattern(
+        "C# Thread.Sleep in Async Method",
+        r"Thread\.Sleep\s*\(",
+        "`Thread.Sleep()` blocks the thread and is unsafe inside async workflows.",
+        "Use `await Task.Delay(...)` in async methods.",
+        "warning",
+        ["C#"],
     ),
     # ── C++ ──
     BugPattern(

--- a/backend/tests/test_endpoints.py
+++ b/backend/tests/test_endpoints.py
@@ -93,6 +93,35 @@ int main() {
 }
 """
 
+CSHARP_CODE = """
+using System;
+
+namespace DemoApp {
+    public class Worker {
+        public static void Main() {
+            var service = new Worker();
+            Console.WriteLine("Ready");
+        }
+    }
+}
+"""
+
+CSHARP_BUGGY = """
+using System;
+using System.Threading;
+
+namespace DemoApp {
+    public class Worker {
+        public async void Run() {
+            string connectionString = "Server=localhost;Database=prod;";
+            try {
+                Thread.Sleep(1000);
+            } catch (Exception ex) {}
+        }
+    }
+}
+"""
+
 RUST_CODE = """
 use std::collections::HashMap;
 
@@ -240,6 +269,20 @@ def test_explanation_cpp():
     assert r.status_code == 200
     d = r.json()
     assert d["language"] == "C++"
+
+
+def test_explanation_detects_csharp_without_hint():
+    r = client.post("/explanation/", json={"code": CSHARP_CODE})
+    assert r.status_code == 200
+    assert r.json()["language"] == "C#"
+
+
+def test_explanation_accepts_csharp_hint_alias():
+    r = client.post(
+        "/explanation/", json={"code": 'Console.WriteLine("Hi");', "language": "cs"}
+    )
+    assert r.status_code == 200
+    assert r.json()["language"] == "C#"
 
 
 # ── Cyclomatic Complexity ─────────────────────────────────────────────────────
@@ -425,6 +468,15 @@ def test_debug_cpp():
     assert r.status_code == 200
     d = r.json()
     assert len(d["issues"]) > 0
+
+
+def test_debug_csharp_buggy_patterns():
+    r = client.post("/debugging/", json={"code": CSHARP_BUGGY, "language": "csharp"})
+    assert r.status_code == 200
+    types = [i["type"] for i in r.json()["issues"]]
+    assert "C# Empty Catch Block" in types
+    assert "C# Hardcoded Connection String" in types
+    assert "C# Thread.Sleep in Async Method" in types
 
 
 def test_explanation_php():
@@ -650,6 +702,7 @@ def test_full_analyze_all_languages():
         (JS_CODE, "javascript"),
         (TS_CODE, "typescript"),
         (JAVA_CODE, "java"),
+        (CSHARP_CODE, "csharp"),
         (CPP_CODE, "cpp"),
         (PHP_CODE, "php"),
         (RUST_CODE, "rust"),


### PR DESCRIPTION
Closes #118

## Summary
- Adds C# language signatures and hint aliases (`csharp`, `c#`, `cs`)
- Adds C# bug patterns for empty catch blocks, hardcoded connection strings, and `Thread.Sleep`
- Adds endpoint tests for C# detection and debugging output

## Validation
- python -m py_compile backend/app/services/code_assistant.py backend/tests/test_endpoints.py
- Focused analyzer smoke test for C# detection and bug patterns

Note: Full endpoint pytest collection could not run locally because `prometheus_client` is missing in this Python environment.