### PR TITLE
fix(frontend): toggle results tabs visibility based on analysis data

### DIFF
--- a/backend/tests/test_frontend_results_tabs_visibility.py
+++ b/backend/tests/test_frontend_results_tabs_visibility.py
@@ -1,0 +1,44 @@
+from pathlib import Path
+
+
+FRONTEND_HTML = (
+    Path(__file__).resolve().parents[2] / "frontend" / "index.html"
+).read_text(encoding="utf-8")
+
+
+def test_render_results_toggles_tab_buttons_visibility():
+    """Test that renderResults hides tab buttons if their corresponding data is missing."""
+    assert "const hasExplain = Boolean(result.explanation);" in FRONTEND_HTML
+    assert "const hasDebug = Boolean(result.debugging);" in FRONTEND_HTML
+    assert "const hasSuggest = Boolean(result.suggestions);" in FRONTEND_HTML
+    assert (
+        "document.getElementById('tab-explain').style.display = hasExplain ? 'flex' : 'none';"
+        in FRONTEND_HTML
+    )
+    assert (
+        "document.getElementById('tab-debug').style.display = hasDebug ? 'flex' : 'none';"
+        in FRONTEND_HTML
+    )
+    assert (
+        "document.getElementById('tab-suggest').style.display = hasSuggest ? 'flex' : 'none';"
+        in FRONTEND_HTML
+    )
+
+
+def test_render_results_switches_to_first_available_tab():
+    """Test that renderResults selects the first available active tab instead of defaulting to explain."""
+    assert (
+        "const firstAvailableTab = hasExplain ? 'explain' : (hasDebug ? 'debug' : (hasSuggest ? 'suggest' : 'explain'));"
+        in FRONTEND_HTML
+    )
+    assert (
+        "const targetTab = availableTabs[tabOrder[selectedMode]] ? tabOrder[selectedMode] : firstAvailableTab;"
+        in FRONTEND_HTML
+    )
+
+
+def test_reset_results_restores_tab_buttons_display():
+    """Test that resetResults restores default display styles for all three result tabs."""
+    assert (
+        "['tab-explain', 'tab-debug', 'tab-suggest'].forEach(id => {" in FRONTEND_HTML
+    )

--- a/docs/CHANGELOG.md
+++ b/docs/CHANGELOG.md
@@ -16,6 +16,9 @@ All notable changes to QyverixAI are documented in this file.
 ### Changed
 - Linked the changelog from `README.md` for faster discoverability.
 
+### Fixed
+- Fixed frontend result tabs visibility to dynamically show only tabs with data present in the analysis result and default to the first available tab, resolving visual ambiguity between Full and Explain analysis modes.
+
 ### Security
 - Hardened authentication against token replay: access tokens now carry a
   unique `jti`, and revoked tokens (e.g. after logout) are rejected via a

--- a/frontend/index.html
+++ b/frontend/index.html
@@ -4150,13 +4150,27 @@ details.issue-card[open] {
         if (result.debugging) renderDebug(result.debugging);
         if (result.suggestions) renderSuggest(result.suggestions);
 
+        const hasExplain = Boolean(result.explanation);
+        const hasDebug = Boolean(result.debugging);
+        const hasSuggest = Boolean(result.suggestions);
+
+        document.getElementById('tab-explain').style.display = hasExplain ? 'flex' : 'none';
+        document.getElementById('tab-debug').style.display = hasDebug ? 'flex' : 'none';
+        document.getElementById('tab-suggest').style.display = hasSuggest ? 'flex' : 'none';
+
         // Auto-switch to relevant tab
         const tabOrder = { analyze: 'explain', explain: 'explain', debug: 'debug', suggest: 'suggest' };
-        const targetTab = tabOrder[selectedMode] || 'explain';
-        document.querySelector(`[data-rtab="${targetTab}"]`).click();
+        const availableTabs = { explain: hasExplain, debug: hasDebug, suggest: hasSuggest };
+        const firstAvailableTab = hasExplain ? 'explain' : (hasDebug ? 'debug' : (hasSuggest ? 'suggest' : 'explain'));
+        const targetTab = availableTabs[tabOrder[selectedMode]] ? tabOrder[selectedMode] : firstAvailableTab;
+        const tabEl = document.querySelector(`[data-rtab="${targetTab}"]`);
+        if (tabEl) tabEl.click();
       }
 
       function renderZipResults(project) {
+        ['tab-explain', 'tab-debug', 'tab-suggest'].forEach(id => {
+          document.getElementById(id).style.display = 'flex';
+        });
         ['emptyExplain', 'emptyDebug', 'emptySuggest'].forEach(id => {
           document.getElementById(id).style.display = 'none';
         });
@@ -4725,6 +4739,9 @@ details.issue-card[open] {
       }
 
       function resetResults() {
+        ['tab-explain', 'tab-debug', 'tab-suggest'].forEach(id => {
+          document.getElementById(id).style.display = 'flex';
+        });
         ['explainResult', 'debugResult', 'suggestResult'].forEach(id => {
           const el = document.getElementById(id);
           el.style.display = 'none';


### PR DESCRIPTION
## Description
<!-- What does this PR do? Be specific. -->
Resolves visual ambiguity between Full Analysis and Explain modes where clicking "Explain" previously showed all 3 result tabs (Explain, Debug, Improve) with an identical appearance to Full Analysis.

Specifically:
1. Modified `renderResults(result, code)` in `frontend/index.html` to extract whether `explanation`, `debugging`, and `suggestions` are present in the analysis result, dynamically hide tab buttons (`tab-explain`, `tab-debug`, `tab-suggest`) when their corresponding data is missing, and switch the active selected tab (`targetTab`) to the first available/active tab instead of always defaulting to 'explain'.
2. Modified `resetResults()` in `frontend/index.html` to restore default display styles (`'flex'`) for all three tabs so that they become visible again when the session is cleared.
3. Added automated unit tests in `backend/tests/test_frontend_results_tabs_visibility.py` and documented the fix in `docs/CHANGELOG.md`.

## Related Issue
<!-- Required — link the issue this PR fixes -->
Fixes #1700


## Type of change
- [x] Bug fix
- [ ] New feature / enhancement
- [x] Documentation update
- [x] Test addition
- [ ] Refactor

## Checklist
<!-- All boxes must be checked before requesting review -->
- [x] I have read [CONTRIBUTING.md](../CONTRIBUTING.md)
- [x] My branch is up to date with `main`
- [x] I have run `pytest -v` and all tests pass
- [x] I have not introduced duplicate issues or features
- [x] My PR title follows the format: `feat/fix/docs/test: short description`
- [x] I have added tests for new features (Level 2 and 3 issues)
- [x] No hardcoded secrets or API keys in my code
- [x] This PR is linked to a GSSoC 2026 issue

## Screenshots (if frontend change)
<!-- Add before/after screenshots -->
- **Before:** Running an Explain-only analysis displayed all three result tabs (**Explain**, **Debug**, **Improve**), making the UI look identical to Full Analysis.
- **After:** Running an Explain-only analysis displays **only** the **Explain** tab button (Debug and Improve tab buttons are hidden). Running Full Analysis displays all three tab buttons. Clicking **Clear** restores all tab buttons to their default visible state.

## Test evidence
<!-- Paste pytest output here -->
```bash
pytest -v
# paste output
tests\test_frontend_results_tabs_visibility.py::test_render_results_toggles_tab_buttons_visibility PASSED
tests\test_frontend_results_tabs_visibility.py::test_render_results_switches_to_first_available_tab PASSED
tests\test_frontend_results_tabs_visibility.py::test_reset_results_restores_tab_buttons_display PASSED

===================== 469 passed, 116 warnings in 32.76s ======================
