### PR TITLE
test: add integration tests for real-time collaboration WebSocket sessions

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,5 +1,6 @@
 <div align="center">
 
+
 <img src="./assets/logo-dark.svg" alt="QyverixAI" width="300"/>
 
 <br/>

--- a/README.md
+++ b/README.md
@@ -1,6 +1,5 @@
 <div align="center">
 
-
 <img src="./assets/logo-dark.svg" alt="QyverixAI" width="300"/>
 
 <br/>

--- a/backend/tests/test_collaboration_ws.py
+++ b/backend/tests/test_collaboration_ws.py
@@ -1,5 +1,7 @@
 """Tests for real-time collaboration WebSocket sessions."""
 
+import pytest
+from fastapi import WebSocketDisconnect
 from app import main as app_main
 from app.routers.collaboration import manager
 from fastapi.testclient import TestClient
@@ -162,3 +164,84 @@ def test_collaboration_ping_returns_pong():
         response = websocket.receive_json()
 
         assert response["type"] == "pong"
+
+
+def test_presence_sync_broadcasts_on_join_and_leave():
+    # Alice connects
+    with client.websocket_connect("/collaboration/ws/presence-test?name=Alice") as alice:
+        alice_state = alice.receive_json()
+        alice_presence1 = alice.receive_json()
+        
+        assert alice_state["type"] == "session_state"
+        assert alice_presence1["type"] == "presence_update"
+        assert len(alice_presence1["users"]) == 1
+        assert alice_presence1["users"][0]["name"] == "Alice"
+
+        # Bob connects
+        with client.websocket_connect("/collaboration/ws/presence-test?name=Bob") as bob:
+            bob_state = bob.receive_json()
+            
+            # Alice receives presence update for Bob's join
+            alice_presence2 = alice.receive_json()
+            # Bob receives presence update after joining
+            bob_presence = bob.receive_json()
+
+            assert alice_presence2["type"] == "presence_update"
+            assert len(alice_presence2["users"]) == 2
+            names = {u["name"] for u in alice_presence2["users"]}
+            assert names == {"Alice", "Bob"}
+
+            assert bob_presence["type"] == "presence_update"
+            assert len(bob_presence["users"]) == 2
+
+        # Bob has disconnected. Alice should receive a presence update with only Alice remaining.
+        alice_presence3 = alice.receive_json()
+        assert alice_presence3["type"] == "presence_update"
+        assert len(alice_presence3["users"]) == 1
+        assert alice_presence3["users"][0]["name"] == "Alice"
+
+
+def test_presence_sync_handles_name_sanitization():
+    # 1. Empty name parameter (or not provided)
+    with client.websocket_connect("/collaboration/ws/name-test") as ws1:
+        state1 = ws1.receive_json()
+        assert state1["users"][0]["name"] == "Anonymous"
+
+    # 2. Whitespace-only name parameter
+    with client.websocket_connect("/collaboration/ws/name-test?name=%20%20%20") as ws2:
+        state2 = ws2.receive_json()
+        assert state2["users"][0]["name"] == "Anonymous"
+
+    # 3. Truncate long name parameter (>40 characters) - FastAPI constraint raises WebSocketDisconnect (1008)
+    long_name = "A" * 50
+    with pytest.raises(WebSocketDisconnect) as exc_info:
+        with client.websocket_connect(f"/collaboration/ws/name-test?name={long_name}"):
+            pass
+    assert exc_info.value.code == 1008
+
+
+def test_presence_sync_session_cleanup():
+    # Alice joins and updates code
+    with client.websocket_connect("/collaboration/ws/cleanup-test?name=Alice") as alice:
+        alice_state = alice.receive_json()
+        alice.receive_json()  # presence_update
+
+        alice.send_json(
+            {
+                "type": "code_update",
+                "code": "print('hello')",
+                "language": "python",
+                "version": alice_state["version"],
+            }
+        )
+        alice.receive_json()  # receive echo of code update
+
+    # Alice disconnected, room should be deleted.
+    # Bob joins the same room. Room should be recreated with fresh state.
+    with client.websocket_connect("/collaboration/ws/cleanup-test?name=Bob") as bob:
+        bob_state = bob.receive_json()
+        assert bob_state["code"] == ""
+        assert bob_state["version"] == 0
+        assert len(bob_state["users"]) == 1
+        assert bob_state["users"][0]["name"] == "Bob"
+

--- a/backend/tests/test_collaboration_ws.py
+++ b/backend/tests/test_collaboration_ws.py
@@ -1,6 +1,5 @@
 """Tests for real-time collaboration WebSocket sessions."""
 
-
 import pytest
 from app import main as app_main
 from app.routers.collaboration import manager

--- a/backend/tests/test_collaboration_ws.py
+++ b/backend/tests/test_collaboration_ws.py
@@ -168,19 +168,23 @@ def test_collaboration_ping_returns_pong():
 
 def test_presence_sync_broadcasts_on_join_and_leave():
     # Alice connects
-    with client.websocket_connect("/collaboration/ws/presence-test?name=Alice") as alice:
+    with client.websocket_connect(
+        "/collaboration/ws/presence-test?name=Alice"
+    ) as alice:
         alice_state = alice.receive_json()
         alice_presence1 = alice.receive_json()
-        
+
         assert alice_state["type"] == "session_state"
         assert alice_presence1["type"] == "presence_update"
         assert len(alice_presence1["users"]) == 1
         assert alice_presence1["users"][0]["name"] == "Alice"
 
         # Bob connects
-        with client.websocket_connect("/collaboration/ws/presence-test?name=Bob") as bob:
+        with client.websocket_connect(
+            "/collaboration/ws/presence-test?name=Bob"
+        ) as bob:
             bob_state = bob.receive_json()
-            
+
             # Alice receives presence update for Bob's join
             alice_presence2 = alice.receive_json()
             # Bob receives presence update after joining
@@ -244,4 +248,3 @@ def test_presence_sync_session_cleanup():
         assert bob_state["version"] == 0
         assert len(bob_state["users"]) == 1
         assert bob_state["users"][0]["name"] == "Bob"
-

--- a/backend/tests/test_collaboration_ws.py
+++ b/backend/tests/test_collaboration_ws.py
@@ -1,9 +1,9 @@
 """Tests for real-time collaboration WebSocket sessions."""
 
 import pytest
-from fastapi import WebSocketDisconnect
 from app import main as app_main
 from app.routers.collaboration import manager
+from fastapi import WebSocketDisconnect
 from fastapi.testclient import TestClient
 
 client = TestClient(app_main.app)

--- a/backend/tests/test_collaboration_ws.py
+++ b/backend/tests/test_collaboration_ws.py
@@ -1,5 +1,6 @@
 """Tests for real-time collaboration WebSocket sessions."""
 
+
 import pytest
 from app import main as app_main
 from app.routers.collaboration import manager


### PR DESCRIPTION
…sions

## Description
Added integration tests for real-time collaboration WebSocket sessions to verify user presence synchronization, name parameter sanitization, and connection/session cleanup.
Specifically, added:
- `test_presence_sync_broadcasts_on_join_and_leave`: Verifies that presence updates are correctly broadcasted when clients join or disconnect.
- `test_presence_sync_handles_name_sanitization`: Verifies name defaults (`Anonymous`), handling of whitespace, and enforcing name length limit constraints (throwing `1008` code).
- `test_presence_sync_session_cleanup`: Verifies that rooms are deleted and cleanly reset upon user disconnection.

## Related Issue
<!-- Required — link the issue this PR fixes -->
Fixes #

## Type of change
- [ ] Bug fix
- [ ] New feature / enhancement
- [ ] Documentation update
- [x] Test addition
- [ ] Refactor

## Checklist
- [x] I have read CONTRIBUTING.md
- [x] My branch is up to date with main
- [x] I have run pytest -v and all tests pass
- [x] I have not introduced duplicate issues or features
- [x] My PR title follows the format: feat/fix/docs/test: short description
- [x] I have added tests for new features (Level 2 and 3 issues)
- [x] No hardcoded secrets or API keys in my code
- [x] This PR is linked to a GSSoC 2026 issue

## Screenshots (if frontend change)
<!-- Add before/after screenshots -->

## Test evidence
backend/tests/test_collaboration_ws.py::test_collaboration_ws_connection PASSED
backend/tests/test_collaboration_ws.py::test_collaboration_ws_invalid_session PASSED
backend/tests/test_collaboration_code_update_broadcasts PASSED
backend/tests/test_collaboration_multiple_clients PASSED
backend/tests/test_collaboration_invalid_json_message PASSED
backend/tests/test_collaboration_ping_returns_pong PASSED
backend/tests/test_collaboration_ws.py::test_presence_sync_broadcasts_on_join_and_leave PASSED
backend/tests/test_collaboration_ws.py::test_presence_sync_handles_name_sanitization PASSED
backend/tests/test_collaboration_ws.py::test_presence_sync_session_cleanup PASSED

======================= 9 passed, 116 warnings in 5.72s =======================
```bash
pytest -v
# paste output
```
