### PR TITLE
docs: restore missing POST /suggestions API reference section

### DIFF
--- a/README.md
+++ b/README.md
@@ -253,7 +253,12 @@ Returns detected issues with line numbers, code snippets, and fix suggestions. F
 - Deep nesting warnings are generated only when the nesting depth exceeds three levels.
 ---
 
+### `POST /suggestions/`
 
+Returns improvement suggestions with a quality score and letter grade.
+
+```json
+{
   "suggestions": [
     {
       "category": "Documentation",


### PR DESCRIPTION
## Description

This PR fixes a formatting issue in the `README.md` API Reference.

### Changes made

* Restored the missing `### POST /suggestions/` section heading.
* Added the endpoint description.
* Inserted the missing opening ` ```json ` code fence.
* Restored proper Markdown formatting and JSON syntax highlighting for the example response.
* No API behavior or project code was modified.

## Related Issue

Fixes #1709

## Type of change

* [ ] Bug fix
* [ ] New feature / enhancement
* [x] Documentation update
* [ ] Test addition
* [ ] Refactor

## Checklist

* [x] I have read [[CONTRIBUTING.md](https://chatgpt.com/g/g-p-6a073f056a288191a0dc1c865b7a51e4-gssoc/CONTRIBUTING.md)](../CONTRIBUTING.md)
* [x] My branch is up to date with `main`
* [ ] I have run `pytest -v` and all tests pass *(not applicable – documentation-only change)*
* [x] I have not introduced duplicate issues or features
* [x] My PR title follows the format: `feat/fix/docs/test: short description`
* [ ] I have added tests for new features (Level 2 and 3 issues) *(not applicable)*
* [x] No hardcoded secrets or API keys in my code
* [x] This PR is linked to a GSSoC 2026 issue

## Screenshots (if frontend change)

Not applicable.

## Test evidence

Documentation-only change. No code or tests were modified.