### PR TITLE
test: add regression tests for database service

### DIFF
--- a/backend/tests/test_database_service.py
+++ b/backend/tests/test_database_service.py
@@ -7,7 +7,7 @@ import pytest
 from app.services import database
 
 
-#Use a temporary db so tests never modify the application's real db.
+# Use a temporary db so tests never modify the application's real db.
 @pytest.fixture
 def temp_db():
     tmp = tempfile.NamedTemporaryFile(suffix=".db", delete=False)
@@ -22,6 +22,7 @@ def temp_db():
 
     database.DB_PATH = old_path
 
+
 # Verify that hashing is deterministic and input-dependent.
 def test_hash_code_is_deterministic():
     hash1 = database.hash_code("print('hello')")
@@ -30,6 +31,7 @@ def test_hash_code_is_deterministic():
 
     assert hash1 == hash2
     assert hash1 != hash3
+
 
 # Verify that a saved entry can be retrieved unchanged.
 def test_save_and_get_entry(temp_db):
@@ -49,6 +51,7 @@ def test_save_and_get_entry(temp_db):
     assert entry["score"] == 95
     assert entry["issue_count"] == 1
     assert entry["code"] == "print('hello')"
+
 
 # Verify that the entry count reflects successful inserts.
 def test_count_entries(temp_db):
@@ -137,7 +140,7 @@ def test_search_entries(temp_db):
     results = asyncio.run(database.search_entries("hello"))
 
     assert len(results) == 1
-    
+
     assert results[0]["language"] == "Python"
     assert "hello world" in results[0]["code_preview"]
 
@@ -168,6 +171,7 @@ def test_get_entries_default_order(temp_db):
     assert entries[0]["code_preview"] == "print('second')"
     assert entries[1]["code_preview"] == "print('first')"
 
+
 # Verify that an invalid sort column safely falls back to the default.
 def test_invalid_sort_by_fallback(temp_db):
     asyncio.run(
@@ -179,12 +183,11 @@ def test_invalid_sort_by_fallback(temp_db):
         )
     )
 
-    entries = asyncio.run(
-        database.get_entries(sort_by="definitely_not_a_column")
-    )
+    entries = asyncio.run(database.get_entries(sort_by="definitely_not_a_column"))
 
     assert len(entries) == 1
     assert entries[0]["language"] == "Python"
+
 
 # Verify that an invalid sort order safely falls back to the default.
 def test_invalid_order_fallback(temp_db):
@@ -197,9 +200,7 @@ def test_invalid_order_fallback(temp_db):
         )
     )
 
-    entries = asyncio.run(
-        database.get_entries(order="banana")
-    )
+    entries = asyncio.run(database.get_entries(order="banana"))
 
     assert len(entries) == 1
     assert entries[0]["language"] == "Python"

--- a/backend/tests/test_database_service.py
+++ b/backend/tests/test_database_service.py
@@ -1,0 +1,205 @@
+from __future__ import annotations
+
+import asyncio
+import tempfile
+
+import pytest
+from app.services import database
+
+
+#Use a temporary db so tests never modify the application's real db.
+@pytest.fixture
+def temp_db():
+    tmp = tempfile.NamedTemporaryFile(suffix=".db", delete=False)
+    tmp.close()
+
+    old_path = database.DB_PATH
+    database.DB_PATH = tmp.name
+
+    asyncio.run(database.init_db())
+
+    yield
+
+    database.DB_PATH = old_path
+
+# Verify that hashing is deterministic and input-dependent.
+def test_hash_code_is_deterministic():
+    hash1 = database.hash_code("print('hello')")
+    hash2 = database.hash_code("print('hello')")
+    hash3 = database.hash_code("print('bye')")
+
+    assert hash1 == hash2
+    assert hash1 != hash3
+
+# Verify that a saved entry can be retrieved unchanged.
+def test_save_and_get_entry(temp_db):
+    row_id = asyncio.run(
+        database.save_entry(
+            code="print('hello')",
+            language="Python",
+            score=95,
+            issue_count=1,
+        )
+    )
+
+    entry = asyncio.run(database.get_entry(row_id))
+
+    assert entry is not None
+    assert entry["language"] == "Python"
+    assert entry["score"] == 95
+    assert entry["issue_count"] == 1
+    assert entry["code"] == "print('hello')"
+
+# Verify that the entry count reflects successful inserts.
+def test_count_entries(temp_db):
+    assert asyncio.run(database.count_entries()) == 0
+
+    asyncio.run(
+        database.save_entry(
+            code="print('one')",
+            language="Python",
+            score=100,
+            issue_count=0,
+        )
+    )
+
+    asyncio.run(
+        database.save_entry(
+            code="print('two')",
+            language="Python",
+            score=90,
+            issue_count=1,
+        )
+    )
+
+    assert asyncio.run(database.count_entries()) == 2
+
+
+# Verify that deleting an entry removes it from the database.
+def test_delete_entry(temp_db):
+    row_id = asyncio.run(
+        database.save_entry(
+            code="print('hello')",
+            language="Python",
+            score=95,
+            issue_count=1,
+        )
+    )
+
+    assert asyncio.run(database.count_entries()) == 1
+
+    deleted = asyncio.run(database.delete_entry(row_id))
+
+    assert deleted is True
+    assert asyncio.run(database.count_entries()) == 0
+    assert asyncio.run(database.get_entry(row_id)) is None
+
+
+# Verify that all entries can be cleared in a single operation.
+def test_clear_entries(temp_db):
+    asyncio.run(
+        database.save_entry(
+            code="print('one')",
+            language="Python",
+            score=100,
+            issue_count=0,
+        )
+    )
+
+    asyncio.run(
+        database.save_entry(
+            code="print('two')",
+            language="Python",
+            score=90,
+            issue_count=1,
+        )
+    )
+
+    assert asyncio.run(database.count_entries()) == 2
+
+    deleted_count = asyncio.run(database.clear_entries())
+
+    assert deleted_count == 2
+    assert asyncio.run(database.count_entries()) == 0
+
+
+# Verify that full-text search returns matching entries.
+def test_search_entries(temp_db):
+    asyncio.run(
+        database.save_entry(
+            code="print('hello world')",
+            language="Python",
+            score=95,
+            issue_count=1,
+        )
+    )
+
+    results = asyncio.run(database.search_entries("hello"))
+
+    assert len(results) == 1
+    
+    assert results[0]["language"] == "Python"
+    assert "hello world" in results[0]["code_preview"]
+
+
+# Verify that entries are returned in the default descending order.
+def test_get_entries_default_order(temp_db):
+    asyncio.run(
+        database.save_entry(
+            code="print('first')",
+            language="Python",
+            score=80,
+            issue_count=2,
+        )
+    )
+
+    asyncio.run(
+        database.save_entry(
+            code="print('second')",
+            language="Python",
+            score=90,
+            issue_count=1,
+        )
+    )
+
+    entries = asyncio.run(database.get_entries())
+
+    assert len(entries) == 2
+    assert entries[0]["code_preview"] == "print('second')"
+    assert entries[1]["code_preview"] == "print('first')"
+
+# Verify that an invalid sort column safely falls back to the default.
+def test_invalid_sort_by_fallback(temp_db):
+    asyncio.run(
+        database.save_entry(
+            code="print('hello')",
+            language="Python",
+            score=95,
+            issue_count=1,
+        )
+    )
+
+    entries = asyncio.run(
+        database.get_entries(sort_by="definitely_not_a_column")
+    )
+
+    assert len(entries) == 1
+    assert entries[0]["language"] == "Python"
+
+# Verify that an invalid sort order safely falls back to the default.
+def test_invalid_order_fallback(temp_db):
+    asyncio.run(
+        database.save_entry(
+            code="print('hello')",
+            language="Python",
+            score=95,
+            issue_count=1,
+        )
+    )
+
+    entries = asyncio.run(
+        database.get_entries(order="banana")
+    )
+
+    assert len(entries) == 1
+    assert entries[0]["language"] == "Python"


### PR DESCRIPTION
## Description
Added Regression tests for database service 

## Related Issue
<!-- Required — link the issue this PR fixes -->
Fixes #1539 

## Type of change
- [ ] Bug fix
- [ ] New feature / enhancement
- [ ] Documentation update
- [x] Test addition
- [ ] Refactor

## Checklist
<!-- All boxes must be checked before requesting review -->
- [x] I have read [CONTRIBUTING.md](../CONTRIBUTING.md)
- [x] My branch is up to date with `main`
- [x] I have run `pytest -v` and all tests pass
- [x] I have not introduced duplicate issues or features
- [x] My PR title follows the format: `feat/fix/docs/test: short description`
- [ ] I have added tests for new features (Level 2 and 3 issues)
- [x] No hardcoded secrets or API keys in my code
- [x] This PR is linked to a GSSoC 2026 issue

## Screenshots (if frontend change)
<!-- Add before/after screenshots -->

## Test evidence
<!-- Paste pytest output here -->
```bash
pytest backend/tests/test_database_server.py
# Regression test
============================================================================= test session starts ==============================================================================
platform darwin -- Python 3.11.7, pytest-9.1.1, pluggy-1.6.0
rootdir: /Users/pranu/Desktop/AI-dev-assistant
configfile: pyproject.toml
plugins: asyncio-1.4.0, anyio-4.2.0
asyncio: mode=Mode.STRICT, debug=False, asyncio_default_fixture_loop_scope=None, asyncio_default_test_loop_scope=function
collected 9 items                                                                                                                                                              

backend/tests/test_database_service.py .........                                                                                                                         [100%]

============================================================================== 9 passed in 0.87s ==============================================================================

#pytest backend/tests 
============================================================================= test session starts ==============================================================================
platform darwin -- Python 3.11.7, pytest-9.1.1, pluggy-1.6.0
rootdir: /Users/pranu/Desktop/AI-dev-assistant
configfile: pyproject.toml
plugins: asyncio-1.4.0, anyio-4.2.0
asyncio: mode=Mode.STRICT, debug=False, asyncio_default_fixture_loop_scope=None, asyncio_default_test_loop_scope=function
collected 469 items                                                                                                                                                            

backend/tests/test_admin_audit.py .......                                                                                                                                [  1%]
backend/tests/test_ai_provider.py ........................                                                                                                               [  6%]
backend/tests/test_ast_analyzer.py ........................................                                                                                              [ 15%]
backend/tests/test_auth_and_user_data.py .                                                                                                                               [ 15%]
backend/tests/test_auth_endpoints.py ........                                                                                                                            [ 17%]
backend/tests/test_cache.py ..                                                                                                                                           [ 17%]
backend/tests/test_code_assistant.py ...                                                                                                                                 [ 18%]
backend/tests/test_collaboration_ws.py ......                                                                                                                            [ 19%]
backend/tests/test_database_observability.py ..                                                                                                                          [ 19%]
backend/tests/test_database_service.py .........                                                                                                                         [ 21%]
backend/tests/test_digest.py .............                                                                                                                               [ 24%]
backend/tests/test_endpoints.py .......................................................                                                                                  [ 36%]
backend/tests/test_file_upload.py ................                                                                                                                       [ 39%]
backend/tests/test_frontend_quiet_startup_ping.py ....                                                                                                                   [ 40%]
backend/tests/test_frontend_saved_entry_restore.py ...                                                                                                                   [ 41%]
backend/tests/test_health_metrics.py ........                                                                                                                            [ 42%]
backend/tests/test_history.py .............                                                                                                                              [ 45%]
backend/tests/test_logging_config.py ............                                                                                                                        [ 48%]
backend/tests/test_ping.py .                                                                                                                                             [ 48%]
backend/tests/test_python_ast_analyzer.py .......                                                                                                                        [ 49%]
backend/tests/test_sanitization.py .....................                                                                                                                 [ 54%]
backend/tests/test_sanitization_payloads.py ............................................................................................................................ [ 80%]
............................................................                                                                                                             [ 93%]
backend/tests/test_schema_smoke.py ............                                                                                                                          [ 96%]
backend/tests/test_share.py ....                                                                                                                                         [ 97%]
backend/tests/test_user_data_purge.py ..........                                                                                                                         [ 99%]
backend/tests/test_vscode_extension_package.py .                                                                                                                         [ 99%]
backend/tests/test_zip_dos.py ...                                                                                                                                        [100%]

=============================================================================== warnings summary ===============================================================================
../../../../opt/anaconda3/lib/python3.11/site-packages/pydantic/fields.py:1042: 114 warnings
  /opt/anaconda3/lib/python3.11/site-packages/pydantic/fields.py:1042: PydanticDeprecatedSince20: Using extra keyword arguments on `Field` is deprecated and will be removed. Use `json_schema_extra` instead. (Extra keys: 'example'). Deprecated in Pydantic V2.0 to be removed in V3.0. See Pydantic V2 Migration Guide at https://errors.pydantic.dev/2.10/migration/
    warn(

-- Docs: https://docs.pytest.org/en/stable/how-to/capture-warnings.html
====================================================================== 469 passed, 114 warnings in 35.27s ======================================================================
```
