### PR TITLE
test(frontend): cover empty states in static and e2e tests

### DIFF
--- a/frontend/package.json
+++ b/frontend/package.json
@@ -4,7 +4,7 @@
   "version": "0.0.0",
   "description": "Playwright end-to-end tests for the QyverixAI frontend.",
   "scripts": {
-    "test:static": "node tests/sample-comments.test.js && node tests/shortcut-ui.test.js",
+    "test:static": "node tests/sample-comments.test.js && node tests/shortcut-ui.test.js && node tests/empty-states.test.js",
     "test:e2e": "playwright test",
     "test:e2e:ci": "playwright test --reporter=list",
     "test:e2e:headed": "playwright test --headed"

--- a/frontend/tests/README.md
+++ b/frontend/tests/README.md
@@ -20,5 +20,6 @@ npm test
 - Keyboard shortcut matching, editable-field safety, and cleanup
 - Simulated analysis panel rendering (all XSS payload categories)
 - Stored `localStorage` attack normalization
+- Empty-state markup (`empty-states.test.js`) and Playwright visibility (`e2e/empty-states.spec.js`)
 
 Manual browser checks: `docs/SECURITY_MANUAL_TEST_CHECKLIST.md`

--- a/frontend/tests/e2e/empty-states.spec.js
+++ b/frontend/tests/e2e/empty-states.spec.js
@@ -1,0 +1,41 @@
+import { test, expect } from '@playwright/test';
+
+test.beforeEach(async ({ page }) => {
+  await page.addInitScript(() => {
+    localStorage.clear();
+  });
+});
+
+test('surfaces result empty states before any analysis', async ({ page }) => {
+  await page.goto('/app/');
+
+  const emptyExplain = page.locator('#emptyExplain');
+  await expect(emptyExplain).toBeVisible();
+  await expect(emptyExplain.locator('.empty-title')).toHaveText('No analysis yet');
+  await expect(page.locator('#explainResult')).toBeHidden();
+
+  await page.locator('#tab-debug').click();
+  const emptyDebug = page.locator('#emptyDebug');
+  await expect(emptyDebug).toBeVisible();
+  await expect(emptyDebug.locator('.empty-title')).toHaveText('No bugs scanned');
+  await expect(page.locator('#debugResult')).toBeHidden();
+
+  await page.locator('#tab-suggest').click();
+  const emptySuggest = page.locator('#emptySuggest');
+  await expect(emptySuggest).toBeVisible();
+  await expect(emptySuggest.locator('.empty-title')).toHaveText('No suggestions yet');
+  await expect(page.locator('#suggestResult')).toBeHidden();
+});
+
+test('surfaces history and favorites empty states with no saved data', async ({ page }) => {
+  await page.route('**/history/**', (route) => route.abort());
+  await page.goto('/app/');
+
+  await expect(page.locator('#historyList .list-empty')).toBeVisible();
+  await expect(page.locator('#historyList .list-empty')).toHaveText(
+    'No history yet. Run your first analysis.'
+  );
+
+  await expect(page.locator('#favList .list-empty')).toBeVisible();
+  await expect(page.locator('#favList .list-empty')).toHaveText('No favorites saved yet.');
+});

--- a/frontend/tests/empty-states.test.js
+++ b/frontend/tests/empty-states.test.js
@@ -1,0 +1,61 @@
+import assert from 'node:assert';
+import fs from 'node:fs';
+import path from 'node:path';
+import { fileURLToPath } from 'node:url';
+
+const __dirname = path.dirname(fileURLToPath(import.meta.url));
+const indexHtml = fs.readFileSync(path.resolve(__dirname, '..', 'index.html'), 'utf8');
+
+const resultEmptyStates = [
+  {
+    id: 'emptyExplain',
+    titleKey: 'empty_explain_title',
+    title: 'No analysis yet',
+    descKey: 'empty_explain_desc',
+    desc: 'Paste your code and click Analyze to see results',
+  },
+  {
+    id: 'emptyDebug',
+    titleKey: 'empty_debug_title',
+    title: 'No bugs scanned',
+    descKey: 'empty_debug_desc',
+    desc: 'Run analysis to detect issues in your code',
+  },
+  {
+    id: 'emptySuggest',
+    titleKey: 'empty_suggest_title',
+    title: 'No suggestions yet',
+    descKey: 'empty_suggest_desc',
+    desc: 'Run analysis to get improvement ideas',
+  },
+];
+
+for (const state of resultEmptyStates) {
+  const block = indexHtml.match(
+    new RegExp(`<div class="empty-state" id="${state.id}">([\\s\\S]*?)</div>\\s*<div id=`)
+  );
+  assert.ok(block, `Missing empty-state markup for #${state.id}`);
+  assert.match(
+    block[1],
+    new RegExp(`data-i18n="${state.titleKey}">${state.title}<`),
+    `#${state.id} should surface title "${state.title}"`
+  );
+  assert.match(
+    block[1],
+    new RegExp(`data-i18n="${state.descKey}">${state.desc}<`),
+    `#${state.id} should surface description "${state.desc}"`
+  );
+  assert.match(block[1], /class="empty-icon"/, `#${state.id} should include an empty-icon`);
+}
+
+assert.match(
+  indexHtml,
+  /id="historyList"[\s\S]*?<div class="list-empty" data-i18n="empty_history">No history yet\. Run your first analysis\.<\/div>/,
+  'History panel should surface its empty state'
+);
+
+assert.match(
+  indexHtml,
+  /id="favList"[\s\S]*?<div class="list-empty" data-i18n="empty_favorites">No favorites saved yet\.<\/div>/,
+  'Favorites panel should surface its empty state'
+);


### PR DESCRIPTION
## Summary
- Add static frontend tests that assert Explain/Debug/Improve and history/favorites empty-state markup in `index.html`
- Add Playwright e2e coverage that switches result tabs (inactive panes are hidden) and checks history/favorites empty messages
- Wire the static suite into `npm run test:static` and document coverage in `frontend/tests/README.md`

Fixes #1607

## Test plan
- [x] `cd frontend && npm run test:static`
- [ ] `cd frontend && npm run test:e2e -- tests/e2e/empty-states.spec.js` (requires Playwright browsers)
- [ ] Confirm initial load still shows Explain empty state, and Debug/Improve empty states after switching tabs
- [ ] Confirm empty history/favorites copy with cleared localStorage
