### PR TITLE
feat(debugging): detect unsafe subprocess shell=True usage

### DIFF
--- a/backend/app/services/ast_analyzer.py
+++ b/backend/app/services/ast_analyzer.py
@@ -62,6 +62,34 @@ class PythonASTAnalyzer(ast.NodeVisitor):
                 "error",
                 node.lineno,
             ))
+
+        if (
+            isinstance(node.func, ast.Attribute)
+            and isinstance(node.func.value, ast.Name)
+            and node.func.value.id == "subprocess"
+            and node.func.attr in {
+                "run",
+                "call",
+                "Popen",
+                "check_call",
+                "check_output",
+            }
+        ):
+            for keyword in node.keywords:
+                if (
+                    keyword.arg == "shell"
+                    and isinstance(keyword.value, ast.Constant)
+                    and keyword.value.value is True
+                ):
+                    self.issues.append(_issue(
+                        "Shell=True Usage",
+                        "`shell=True` allows shell command interpretation and can lead to command injection vulnerabilities.",
+                        "Avoid `shell=True`. Pass the command as a list of arguments unless shell features are explicitly required.",
+                        "warning",
+                        node.lineno,
+                    ))
+                    break
+
         self.generic_visit(node)
 
     def visit_Assign(self, node: ast.Assign) -> None:

--- a/backend/app/services/code_assistant.py
+++ b/backend/app/services/code_assistant.py
@@ -318,14 +318,6 @@ BUG_PATTERNS: list[BugPattern] = [
         ["Python"],
     ),
     BugPattern(
-        "Shell=True Usage",
-        r"\bsubprocess\.(run|call|Popen|check_call|check_output)\s*\([^)]*shell\s*=\s*True",
-        "`shell=True` allows shell command interpretation and can lead to command injection vulnerabilities.",
-        "Avoid `shell=True`. Pass the command as a list of arguments unless shell features are explicitly required.",
-        "warning",
-        ["Python"],
-    ),
-    BugPattern(
         "Mutable Default Arg",
         r"def\s+\w+\s*\([^)]*=\s*(\[\]|\{\}|\(\))",
         "Mutable default argument shared across all calls — classic Python gotcha.",

--- a/backend/app/services/code_assistant.py
+++ b/backend/app/services/code_assistant.py
@@ -318,6 +318,14 @@ BUG_PATTERNS: list[BugPattern] = [
         ["Python"],
     ),
     BugPattern(
+        "Shell=True Usage",
+        r"\bsubprocess\.(run|call|Popen|check_call|check_output)\s*\([^)]*shell\s*=\s*True",
+        "`shell=True` allows shell command interpretation and can lead to command injection vulnerabilities.",
+        "Avoid `shell=True`. Pass the command as a list of arguments unless shell features are explicitly required.",
+        "warning",
+        ["Python"],
+    ),
+    BugPattern(
         "Mutable Default Arg",
         r"def\s+\w+\s*\([^)]*=\s*(\[\]|\{\}|\(\))",
         "Mutable default argument shared across all calls — classic Python gotcha.",

--- a/backend/tests/test_endpoints.py
+++ b/backend/tests/test_endpoints.py
@@ -4,12 +4,12 @@ Run: cd backend && pytest -v
 """
 
 import json
+import os
+import sys
+from pathlib import Path
 
 import pytest
-from pathlib import Path
 from fastapi.testclient import TestClient
-import sys
-import os
 
 sys.path.insert(0, os.path.dirname(os.path.dirname(__file__)))
 from app import main as app_main
@@ -18,8 +18,11 @@ client = TestClient(app_main.app)
 
 FIXTURES_DIR = Path(__file__).parent / "fixtures"
 
+
 def load_fixture(filename: str) -> str:
     return (FIXTURES_DIR / filename).read_text(encoding="utf-8")
+
+
 @pytest.fixture(autouse=True)
 def reset_rate_limit_state():
     app_main._request_counts.clear()
@@ -398,6 +401,25 @@ def test_debug_detects_eval():
     assert "Eval Usage" in types
 
 
+def test_debug_detects_shell_true_usage():
+    code = """
+import subprocess
+
+subprocess.run("ls -la", shell=True)
+"""
+
+    r = client.post(
+        "/debugging/",
+        json={"code": code, "language": "python"},
+    )
+
+    assert r.status_code == 200
+
+    types = [issue["type"] for issue in r.json()["issues"]]
+
+    assert "Shell=True Usage" in types
+
+
 def test_debug_clean_code():
     r = client.post("/debugging/", json={"code": PYTHON_CLEAN, "language": "python"})
     assert r.status_code == 200
@@ -481,7 +503,6 @@ def test_debug_kotlin():
     assert d is not None
 
 
-
 def test_debug_cpp_syntax_errors():
     code = "void main() {\n    cout << 'Hello World'\n}"
     r = client.post("/debugging/", json={"code": code, "language": "cpp"})
@@ -562,15 +583,20 @@ def test_add():
     d = r.json()
     assert d["overall_score"] >= 60  # clean code should score reasonably
 
+
 def test_suggestions_observability_print_only_python():
     # Pasting code with print() in Java should NOT trigger the Observability suggestion
-    r_java = client.post("/suggestions/", json={"code": 'print("hello");', "language": "java"})
+    r_java = client.post(
+        "/suggestions/", json={"code": 'print("hello");', "language": "java"}
+    )
     assert r_java.status_code == 200
     s_java = [s["category"] for s in r_java.json()["suggestions"]]
     assert "Observability" not in s_java
 
     # Pasting code with print() in Python SHOULD trigger the Observability suggestion
-    r_py = client.post("/suggestions/", json={"code": 'print("hello")', "language": "python"})
+    r_py = client.post(
+        "/suggestions/", json={"code": 'print("hello")', "language": "python"}
+    )
     assert r_py.status_code == 200
     s_py = [s["category"] for s in r_py.json()["suggestions"]]
     assert "Observability" in s_py
@@ -724,7 +750,9 @@ def test_get_stream_done_event_present():
 
 
 def test_get_stream_with_language_hint():
-    r = client.get("/analyze/stream", params={"code": JS_CODE, "language": "javascript"})
+    r = client.get(
+        "/analyze/stream", params={"code": JS_CODE, "language": "javascript"}
+    )
     assert r.status_code == 200
     events = _parse_sse_events(r.text)
     exp = next(e["data"] for e in events if e["type"] == "explanation")

--- a/backend/tests/test_endpoints.py
+++ b/backend/tests/test_endpoints.py
@@ -420,6 +420,47 @@ subprocess.run("ls -la", shell=True)
     assert "Shell=True Usage" in types
 
 
+def test_debug_detects_multiline_shell_true_usage():
+    code = """
+import subprocess
+
+subprocess.run(
+    ["ls", "-la"],
+    shell=True,
+)
+"""
+
+    r = client.post(
+        "/debugging/",
+        json={"code": code, "language": "python"},
+    )
+
+    assert r.status_code == 200
+
+    types = [issue["type"] for issue in r.json()["issues"]]
+
+    assert "Shell=True Usage" in types
+
+
+def test_debug_detects_shell_true_with_nested_call():
+    code = """
+import subprocess
+
+subprocess.run(cmd.split(), shell=True)
+"""
+
+    r = client.post(
+        "/debugging/",
+        json={"code": code, "language": "python"},
+    )
+
+    assert r.status_code == 200
+
+    types = [issue["type"] for issue in r.json()["issues"]]
+
+    assert "Shell=True Usage" in types
+
+
 def test_debug_clean_code():
     r = client.post("/debugging/", json={"code": PYTHON_CLEAN, "language": "python"})
     assert r.status_code == 200


### PR DESCRIPTION
## Description

This PR adds a new Python bug detection pattern that detects unsafe usage of `shell=True` in Python's `subprocess` module.

The new rule detects:
- `subprocess.run()`
- `subprocess.call()`
- `subprocess.Popen()`
- `subprocess.check_call()`
- `subprocess.check_output()`

when `shell=True` is used.

A corresponding endpoint test has also been added to verify the new detection.

## Related Issue

Fixes #1728

## Type of change

- [ ] Bug fix
- [x] New feature / enhancement
- [ ] Documentation update
- [x] Test addition
- [ ] Refactor

## Checklist

- [x] I have read [CONTRIBUTING.md](./CONTRIBUTING.md)
- [x] My branch is up to date with `main`
- [x] I have run `pytest -v` and all tests pass
- [x] I have not introduced duplicate issues or features
- [x] My PR title follows the format: `feat/fix/docs/test: short description`
- [x] I have added tests for new features (Level 2 and 3 issues)
- [x] No hardcoded secrets or API keys in my code
- [x] This PR is linked to a GSSoC 2026 issue

## Screenshots (if frontend change)

N/A

## Test evidence

```bash
pytest tests/test_endpoints.py -k shell_true -v
```

Result:

```
1 passed
```