### PR TITLE
fix(debugging): match multi-line bug patterns against full source

### DIFF
--- a/backend/app/services/code_assistant.py
+++ b/backend/app/services/code_assistant.py
@@ -382,7 +382,7 @@ BUG_PATTERNS: list[BugPattern] = [
     ),
     BugPattern(
         "Missing __init__",
-        r"class\s+\w+[^:]*:\n(?!\s+def __init__)",
+        r"class\s+\w+[^:\n]*:\n(?!\s+def __init__)",
         "Class defined without `__init__` — may cause AttributeError on attribute access.",
         "Add `def __init__(self):` to initialize instance state.",
         "info",
@@ -820,6 +820,18 @@ BUG_PATTERNS: list[BugPattern] = [
 ]
 
 
+def _is_multiline_pattern(pattern: str) -> bool:
+    """Return True if a regex pattern is intended to match across multiple lines.
+
+    Such patterns contain constructs (a literal ``\\n``, or a character class
+    such as ``[\\s\\S]`` / ``[\\d\\D]`` / ``[\\w\\W]``) that can only match when
+    the regex is run against the full, un-split source code. The per-line scan
+    in :func:`run_bug_detection` strips newlines, so these patterns would
+    otherwise never fire and remain dead code.
+    """
+    return any(token in pattern for token in (r"\n", r"[\s\S]", r"[\d\D]", r"[\w\W]"))
+
+
 def run_bug_detection(code: str, language: str) -> list[dict]:
     """Run rule-based bug detection for the provided source code.
 
@@ -853,6 +865,36 @@ def run_bug_detection(code: str, language: str) -> list[dict]:
 
     for bp in BUG_PATTERNS:
         if language not in bp.languages and "All" not in bp.languages:
+            continue
+
+        # Multi-line patterns rely on constructs (literal "\n", "[\s\S]", ...)
+        # that span more than one line, so they cannot match when the regex is
+        # applied to a single line. Run them against the full source instead.
+        if _is_multiline_pattern(bp.pattern):
+            for match in re.finditer(bp.pattern, code, re.MULTILINE | re.IGNORECASE):
+                line_no = code[: match.start()].count("\n") + 1
+                key = f"{bp.name}:{line_no}"
+                if key in seen:
+                    continue
+                seen.add(key)
+                snippet = (
+                    lines[line_no - 1].strip()[:120]
+                    if 0 <= line_no - 1 < len(lines)
+                    else ""
+                )
+                found.append(
+                    {
+                        "type": bp.name,
+                        "line": line_no,
+                        "description": bp.description,
+                        "suggestion": bp.suggestion,
+                        "severity": bp.severity,
+                        "code_snippet": snippet,
+                        "code_context": format_code_snippet(
+                            code, [line_no], context_lines=2
+                        ),
+                    }
+                )
             continue
 
         for i, line in enumerate(lines, start=1):

--- a/backend/tests/test_multiline_bug_patterns.py
+++ b/backend/tests/test_multiline_bug_patterns.py
@@ -1,0 +1,133 @@
+"""Regression tests for multi-line BUG_PATTERNS in the rule-based engine.
+
+Three registered patterns span more than one source line and only fire when
+``run_bug_detection`` matches them against the full (un-split) source rather
+than one line at a time:
+
+* ``String Concatenation in Loop`` (Python)
+* ``Missing __init__`` (Python)
+* ``Callback Hell`` (JavaScript / TypeScript)
+
+Regression coverage for
+https://github.com/imDarshanGK/AI-dev-assistant/issues/1731
+"""
+
+import pytest
+from app import main as app_main
+from app.services.code_assistant import run_bug_detection
+from fastapi.testclient import TestClient
+
+client = TestClient(app_main.app)
+
+
+@pytest.fixture(autouse=True)
+def reset_rate_limit_state():
+    app_main._request_counts.clear()
+    yield
+    app_main._request_counts.clear()
+
+
+def _issue_types(code: str, language: str) -> list[str]:
+    return [issue["type"] for issue in run_bug_detection(code, language)]
+
+
+def test_string_concatenation_in_loop_detected():
+    code = (
+        "def build(items):\n"
+        '    r = ""\n'
+        "    for x in items:\n"
+        '        r += "x"\n'
+        "    return r\n"
+    )
+    issues = [
+        issue
+        for issue in run_bug_detection(code, "Python")
+        if issue["type"] == "String Concatenation in Loop"
+    ]
+    assert issues, "Expected String Concatenation in Loop to be detected"
+    # The pattern anchors on the `for` line.
+    assert issues[0]["line"] == 3
+    assert issues[0]["severity"] == "warning"
+
+
+def test_string_concatenation_finds_every_occurrence():
+    # re.finditer must surface every match, not just the first one.
+    code = (
+        "def f(xs):\n"
+        '    r = ""\n'
+        "    for x in xs:\n"
+        '        r += "a"\n'
+        '    s = ""\n'
+        "    for y in xs:\n"
+        '        s += "b"\n'
+        "    return r + s\n"
+    )
+    lines = [
+        issue["line"]
+        for issue in run_bug_detection(code, "Python")
+        if issue["type"] == "String Concatenation in Loop"
+    ]
+    assert lines == [3, 6]
+
+
+def test_missing_init_detected():
+    code = "class Calculator:\n" "    def add(self, a, b):\n" "        return a + b\n"
+    assert "Missing __init__" in _issue_types(code, "Python")
+
+
+def test_missing_init_not_flagged_when_init_present():
+    # The tightened `[^:\n]*` anchor keeps the class header on a single line so
+    # a class that *does* define __init__ is not over-matched.
+    code = "class HasInit:\n" "    def __init__(self):\n" "        pass\n"
+    assert "Missing __init__" not in _issue_types(code, "Python")
+
+
+def test_callback_hell_detected():
+    code = (
+        "const a = function(x, cb) {\n"
+        "    return function() {\n"
+        "        return function() {\n"
+        "            return cb(x);\n"
+        "        };\n"
+        "    };\n"
+        "};"
+    )
+    assert "Callback Hell" in _issue_types(code, "JavaScript")
+
+
+@pytest.mark.parametrize(
+    "code,language,expected",
+    [
+        (
+            "def build(items):\n"
+            '    r = ""\n'
+            "    for x in items:\n"
+            '        r += "x"\n'
+            "    return r\n",
+            "python",
+            "String Concatenation in Loop",
+        ),
+        (
+            "class Calculator:\n" "    def add(self, a, b):\n" "        return a + b\n",
+            "python",
+            "Missing __init__",
+        ),
+        (
+            "const a = function(x, cb) {\n"
+            "    return function() {\n"
+            "        return function() {\n"
+            "            return cb(x);\n"
+            "        };\n"
+            "    };\n"
+            "};",
+            "javascript",
+            "Callback Hell",
+        ),
+    ],
+)
+def test_debugging_endpoint_detects_multiline_patterns(code, language, expected):
+    # End-to-end check via the /debugging/ HTTP endpoint.
+    r = client.post("/debugging/", json={"code": code, "language": language})
+    assert r.status_code == 200
+    types = [issue["type"] for issue in r.json()["issues"]]
+    assert expected in types

--- a/docs/CHANGELOG.md
+++ b/docs/CHANGELOG.md
@@ -16,6 +16,15 @@ All notable changes to QyverixAI are documented in this file.
 ### Changed
 - Linked the changelog from `README.md` for faster discoverability.
 
+### Fixed
+- Multi-line `BUG_PATTERNS` (`String Concatenation in Loop`, `Missing __init__`,
+  `Callback Hell`) now fire correctly. `run_bug_detection` previously matched
+  each regex against a single line, which silently killed patterns that span
+  multiple lines; multi-line patterns are now matched against the full source.
+- Tightened the `Missing __init__` regex (`[^:]*` → `[^:\n]*`) so the class
+  header stays on a single line and classes that do define `__init__` are not
+  flagged once multi-line matching is enabled.
+
 ### Security
 - Hardened authentication against token replay: access tokens now carry a
   unique `jti`, and revoked tokens (e.g. after logout) are rejected via a


### PR DESCRIPTION
## Description

Three registered `BUG_PATTERNS` — `String Concatenation in Loop`, `Missing __init__`, and `Callback Hell` — silently never produced findings because `run_bug_detection` applied every regex to a single line (`code.splitlines()` → `re.search(pat, line)`), stripping the newlines those patterns rely on. This PR makes them fire correctly while leaving all single-line patterns unchanged.

It adds a small `_is_multiline_pattern` helper that routes multi-line patterns (those containing `\n` or `[\s\S]`/`[\d\D]`/`[\w\W]`) through a full-source `re.finditer` pass, reports each occurrence with its line number, and reuses the existing dedup scheme. Single-line patterns keep their current per-line behavior. It also tightens the `Missing __init__` regex (`[^:]*` → `[^:\n]*`) so the class header stays on one line and classes that define `__init__` are not over-matched.

### Changes
- `backend/app/services/code_assistant.py` — added `_is_multiline_pattern()` helper + a multi-line branch in `run_bug_detection`; tightened the `Missing __init__` regex.
- `backend/tests/test_multiline_bug_patterns.py` — new regression tests covering all three patterns, the negative case, multiple occurrences, and the `/debugging/` endpoint end-to-end. Added in a dedicated file to keep this diff focused (touching `test_endpoints.py` would force unrelated formatting churn under CI).
- `docs/CHANGELOG.md` — added a `### Fixed` entry under `[Unreleased]`.

## Related Issue

Fixes #1731

## Type of change

- [x] Bug fix
- [ ] New feature / enhancement
- [ ] Documentation update
- [ ] Test addition
- [ ] Refactor

## Checklist

- [x] I have read [CONTRIBUTING.md](../CONTRIBUTING.md)
- [x] My branch is up to date with `main`
- [x] I have run `pytest -v` and all tests pass
- [x] I have not introduced duplicate issues or features
- [x] My PR title follows the format: `feat/fix/docs/test: short description`
- [x] I have added tests for new features (Level 2 and 3 issues)
- [x] No hardcoded secrets or API keys in my code
- [x] This PR is linked to a GSSoC 2026 issue (#1731)

## Screenshots (if frontend change)

N/A — backend-only change.

## Test evidence

New regression tests:

```bash
$ pytest tests/test_multiline_bug_patterns.py -v
tests/test_multiline_bug_patterns.py::test_string_concatenation_in_loop_detected PASSED [ 12%]
tests/test_multiline_bug_patterns.py::test_string_concatenation_finds_every_occurrence PASSED [ 25%]
tests/test_multiline_bug_patterns.py::test_missing_init_detected PASSED  [ 37%]
tests/test_multiline_bug_patterns.py::test_missing_init_not_flagged_when_init_present PASSED [ 50%]
tests/test_multiline_bug_patterns.py::test_callback_hell_detected PASSED [ 62%]
tests/test_multiline_bug_patterns.py::test_debugging_endpoint_detects_multiline_patterns[...] PASSED [ 75%]
tests/test_multiline_bug_patterns.py::test_debugging_endpoint_detects_multiline_patterns[...] PASSED [ 87%]
tests/test_multiline_bug_patterns.py::test_debugging_endpoint_detects_multiline_patterns[...] PASSED [100%]

======================= 8 passed, 116 warnings in 0.73s ========================
```

Full suite:

```bash
$ pytest -q
521 passed, 116 warnings in 33.81s
```

`ruff check`, `black --check`, and `isort --check-only` are clean on the changed files.
