### PR TITLE
test(llm_analysis): add regression tests for LLM analysis service

### DIFF
--- a/backend/tests/test_llm_analysis.py
+++ b/backend/tests/test_llm_analysis.py
@@ -1,0 +1,401 @@
+"""
+Unit tests for backend/app/services/llm_analysis.py
+
+Covers LLMAnalysisClient:
+- enabled property
+- _chat_completion success and error paths
+- _extract_json plain / fenced / invalid payloads
+- summarize_code, analyze_code_structured, chat_reply
+
+No real API calls — httpx is mocked offline.
+Run: cd backend && pytest tests/test_llm_analysis.py -v
+"""
+
+from __future__ import annotations
+
+import json
+from unittest.mock import AsyncMock, MagicMock, patch
+
+import httpx
+import pytest
+from app.services.llm_analysis import LLMAnalysisClient, LLMAnalysisError
+
+
+def _make_llm_response(text: str) -> MagicMock:
+    """Return a fake httpx.Response with an OpenAI-compatible JSON body."""
+    resp = MagicMock()
+    resp.json.return_value = {
+        "choices": [{"message": {"role": "assistant", "content": text}}]
+    }
+    resp.raise_for_status = MagicMock()
+    return resp
+
+
+def _make_error_response(status_code: int = 500) -> MagicMock:
+    """Return a fake httpx.Response whose raise_for_status() raises."""
+    resp = MagicMock()
+    resp.status_code = status_code
+    mock_response = MagicMock()
+    mock_response.status_code = status_code
+    resp.raise_for_status.side_effect = httpx.HTTPStatusError(
+        message=f"HTTP {status_code}",
+        request=MagicMock(),
+        response=mock_response,
+    )
+    return resp
+
+
+def _patch_httpx(mock_response: MagicMock):
+    """Patch llm_analysis.httpx.AsyncClient to return mock_response."""
+    mock_client = AsyncMock()
+    mock_client.post = AsyncMock(return_value=mock_response)
+
+    patcher = patch("app.services.llm_analysis.httpx.AsyncClient")
+    mock_cls = patcher.start()
+    mock_cls.return_value.__aenter__ = AsyncMock(return_value=mock_client)
+    mock_cls.return_value.__aexit__ = AsyncMock(return_value=False)
+    return patcher, mock_client
+
+
+@pytest.fixture()
+def enabled_client(monkeypatch):
+    """LLMAnalysisClient with LLM enabled and a test API key."""
+    monkeypatch.setattr("app.services.llm_analysis.settings.llm_enabled", True)
+    monkeypatch.setattr("app.services.llm_analysis.settings.llm_api_key", "sk-test-key")
+    monkeypatch.setattr(
+        "app.services.llm_analysis.settings.llm_base_url",
+        "https://api.openai.com/v1",
+    )
+    monkeypatch.setattr("app.services.llm_analysis.settings.llm_model", "gpt-4o-mini")
+    monkeypatch.setattr("app.services.llm_analysis.settings.llm_timeout_seconds", 30)
+    return LLMAnalysisClient()
+
+
+@pytest.fixture()
+def disabled_client(monkeypatch):
+    """LLMAnalysisClient with LLM disabled."""
+    monkeypatch.setattr("app.services.llm_analysis.settings.llm_enabled", False)
+    monkeypatch.setattr("app.services.llm_analysis.settings.llm_api_key", "sk-test-key")
+    return LLMAnalysisClient()
+
+
+@pytest.fixture()
+def no_key_client(monkeypatch):
+    """LLMAnalysisClient with empty API key."""
+    monkeypatch.setattr("app.services.llm_analysis.settings.llm_enabled", True)
+    monkeypatch.setattr("app.services.llm_analysis.settings.llm_api_key", "")
+    return LLMAnalysisClient()
+
+
+class TestEnabled:
+    def test_true_when_enabled_and_key_present(self, enabled_client):
+        assert enabled_client.enabled is True
+
+    def test_false_when_llm_disabled(self, disabled_client):
+        assert disabled_client.enabled is False
+
+    def test_false_when_api_key_empty(self, no_key_client):
+        assert no_key_client.enabled is False
+
+    def test_false_when_api_key_none(self, monkeypatch):
+        monkeypatch.setattr("app.services.llm_analysis.settings.llm_enabled", True)
+        monkeypatch.setattr("app.services.llm_analysis.settings.llm_api_key", None)
+        client = LLMAnalysisClient()
+        assert client.enabled is False
+
+
+class TestChatCompletion:
+    @pytest.mark.asyncio
+    async def test_raises_when_disabled(self, disabled_client):
+        with pytest.raises(LLMAnalysisError, match="llm_disabled"):
+            await disabled_client._chat_completion([{"role": "user", "content": "hi"}])
+
+    @pytest.mark.asyncio
+    async def test_returns_stripped_content(self, enabled_client):
+        patcher, _ = _patch_httpx(_make_llm_response("  Hello from LLM!  "))
+        try:
+            result = await enabled_client._chat_completion(
+                [{"role": "user", "content": "hi"}]
+            )
+        finally:
+            patcher.stop()
+        assert result == "Hello from LLM!"
+
+    @pytest.mark.asyncio
+    async def test_raises_on_empty_content(self, enabled_client):
+        patcher, _ = _patch_httpx(_make_llm_response("   \n  "))
+        try:
+            with pytest.raises(LLMAnalysisError, match="empty_llm_response"):
+                await enabled_client._chat_completion(
+                    [{"role": "user", "content": "hi"}]
+                )
+        finally:
+            patcher.stop()
+
+    @pytest.mark.asyncio
+    async def test_raises_on_http_error(self, enabled_client):
+        patcher, _ = _patch_httpx(_make_error_response(500))
+        try:
+            with pytest.raises(LLMAnalysisError):
+                await enabled_client._chat_completion(
+                    [{"role": "user", "content": "hi"}]
+                )
+        finally:
+            patcher.stop()
+
+    @pytest.mark.asyncio
+    async def test_raises_on_timeout(self, enabled_client):
+        mock_client = AsyncMock()
+        mock_client.post = AsyncMock(side_effect=httpx.TimeoutException("timed out"))
+
+        with patch("app.services.llm_analysis.httpx.AsyncClient") as MockCls:
+            MockCls.return_value.__aenter__ = AsyncMock(return_value=mock_client)
+            MockCls.return_value.__aexit__ = AsyncMock(return_value=False)
+            with pytest.raises(LLMAnalysisError):
+                await enabled_client._chat_completion(
+                    [{"role": "user", "content": "hi"}]
+                )
+
+    @pytest.mark.asyncio
+    async def test_raises_on_connect_error(self, enabled_client):
+        mock_client = AsyncMock()
+        mock_client.post = AsyncMock(
+            side_effect=httpx.ConnectError("connection refused")
+        )
+
+        with patch("app.services.llm_analysis.httpx.AsyncClient") as MockCls:
+            MockCls.return_value.__aenter__ = AsyncMock(return_value=mock_client)
+            MockCls.return_value.__aexit__ = AsyncMock(return_value=False)
+            with pytest.raises(LLMAnalysisError):
+                await enabled_client._chat_completion(
+                    [{"role": "user", "content": "hi"}]
+                )
+
+    @pytest.mark.asyncio
+    async def test_sends_correct_payload_and_auth(self, enabled_client):
+        patcher, mock_client = _patch_httpx(_make_llm_response("ok"))
+        messages = [
+            {"role": "system", "content": "be helpful"},
+            {"role": "user", "content": "what is python?"},
+        ]
+        try:
+            await enabled_client._chat_completion(messages, temperature=0.3)
+        finally:
+            patcher.stop()
+
+        url_called = mock_client.post.call_args[0][0]
+        assert url_called == "https://api.openai.com/v1/chat/completions"
+
+        _, kwargs = mock_client.post.call_args
+        assert kwargs["headers"]["Authorization"] == "Bearer sk-test-key"
+        assert kwargs["headers"]["Content-Type"] == "application/json"
+        payload = kwargs["json"]
+        assert payload["model"] == "gpt-4o-mini"
+        assert payload["temperature"] == 0.3
+        assert payload["messages"] == messages
+
+
+class TestExtractJson:
+    def test_plain_json_object(self):
+        raw = '{"summary": "ok", "score": 1}'
+        result = LLMAnalysisClient._extract_json(raw)
+        assert result == {"summary": "ok", "score": 1}
+
+    def test_fenced_json_response(self):
+        raw = '```json\n{"explanation": {"summary": "loop"}}\n```'
+        result = LLMAnalysisClient._extract_json(raw)
+        assert result["explanation"]["summary"] == "loop"
+
+    def test_json_with_surrounding_text(self):
+        raw = 'Here is the result:\n{"a": 1}\nThanks!'
+        result = LLMAnalysisClient._extract_json(raw)
+        assert result == {"a": 1}
+
+    def test_no_braces_raises_invalid_json_payload(self):
+        with pytest.raises(LLMAnalysisError, match="invalid_json_payload"):
+            LLMAnalysisClient._extract_json("not json at all")
+
+    def test_empty_braces_order_raises(self):
+        with pytest.raises(LLMAnalysisError, match="invalid_json_payload"):
+            LLMAnalysisClient._extract_json("}{")
+
+    def test_invalid_json_between_braces_raises_json_decode(self):
+        # Current contract: json.loads raises JSONDecodeError (not wrapped).
+        with pytest.raises(json.JSONDecodeError):
+            LLMAnalysisClient._extract_json("{not valid json}")
+
+
+class TestSummarizeCode:
+    @pytest.mark.asyncio
+    async def test_raises_when_disabled(self, disabled_client):
+        with pytest.raises(LLMAnalysisError, match="llm_disabled"):
+            await disabled_client.summarize_code("print(1)", "Python")
+
+    @pytest.mark.asyncio
+    async def test_success_returns_text(self, enabled_client):
+        patcher, _ = _patch_httpx(_make_llm_response("This prints one."))
+        try:
+            result = await enabled_client.summarize_code("print(1)", "Python")
+        finally:
+            patcher.stop()
+        assert result == "This prints one."
+
+    @pytest.mark.asyncio
+    async def test_request_includes_user_code_tags(self, enabled_client):
+        sample = "def add(a, b):\n    return a + b"
+        patcher, mock_client = _patch_httpx(_make_llm_response("summary"))
+        try:
+            await enabled_client.summarize_code(sample, "Python")
+        finally:
+            patcher.stop()
+
+        _, kwargs = mock_client.post.call_args
+        user_content = kwargs["json"]["messages"][1]["content"]
+        assert "<user_code>" in user_content
+        assert "</user_code>" in user_content
+        assert sample in user_content
+        assert "Language guess: Python" in user_content
+
+    @pytest.mark.asyncio
+    async def test_http_failure_raises(self, enabled_client):
+        patcher, _ = _patch_httpx(_make_error_response(401))
+        try:
+            with pytest.raises(LLMAnalysisError):
+                await enabled_client.summarize_code("print(1)", "Python")
+        finally:
+            patcher.stop()
+
+
+class TestAnalyzeCodeStructured:
+    @pytest.mark.asyncio
+    async def test_parses_valid_json(self, enabled_client):
+        payload = {
+            "explanation": {"summary": "adds numbers"},
+            "debugging": {"issues": [], "quick_checks": []},
+            "suggestions": {"suggestions": [], "next_steps": []},
+            "complexity": {"time": "O(1)", "space": "O(1)"},
+            "optimized_version": "def add(a, b): return a + b",
+        }
+        patcher, _ = _patch_httpx(_make_llm_response(json.dumps(payload)))
+        try:
+            result = await enabled_client.analyze_code_structured(
+                "def add(a, b): return a + b", "Python"
+            )
+        finally:
+            patcher.stop()
+        assert result["explanation"]["summary"] == "adds numbers"
+        assert result["complexity"]["time"] == "O(1)"
+
+    @pytest.mark.asyncio
+    async def test_parses_fenced_json(self, enabled_client):
+        inner = {"explanation": {"summary": "fenced"}, "debugging": {"issues": []}}
+        fenced = f"```json\n{json.dumps(inner)}\n```"
+        patcher, _ = _patch_httpx(_make_llm_response(fenced))
+        try:
+            result = await enabled_client.analyze_code_structured("x = 1", "Python")
+        finally:
+            patcher.stop()
+        assert result["explanation"]["summary"] == "fenced"
+
+    @pytest.mark.asyncio
+    async def test_invalid_payload_raises(self, enabled_client):
+        patcher, _ = _patch_httpx(_make_llm_response("no json here"))
+        try:
+            with pytest.raises(LLMAnalysisError):
+                await enabled_client.analyze_code_structured("x = 1", "Python")
+        finally:
+            patcher.stop()
+
+    @pytest.mark.asyncio
+    async def test_request_includes_user_code_tags(self, enabled_client):
+        sample = "print('hello')"
+        patcher, mock_client = _patch_httpx(
+            _make_llm_response('{"explanation": {"summary": "hi"}}')
+        )
+        try:
+            await enabled_client.analyze_code_structured(sample, "Python")
+        finally:
+            patcher.stop()
+
+        _, kwargs = mock_client.post.call_args
+        user_content = kwargs["json"]["messages"][1]["content"]
+        assert "<user_code>" in user_content
+        assert sample in user_content
+
+
+class TestChatReply:
+    @pytest.mark.asyncio
+    async def test_success_returns_reply(self, enabled_client):
+        patcher, _ = _patch_httpx(_make_llm_response("Use a for-loop."))
+        try:
+            result = await enabled_client.chat_reply(
+                message="How do I iterate?",
+                code="items = [1, 2]",
+                history=["prev q"],
+                level="beginner",
+            )
+        finally:
+            patcher.stop()
+        assert result == "Use a for-loop."
+
+    @pytest.mark.asyncio
+    async def test_payload_includes_xml_tags(self, enabled_client):
+        patcher, mock_client = _patch_httpx(_make_llm_response("ok"))
+        try:
+            await enabled_client.chat_reply(
+                message="explain this",
+                code="print(1)",
+                history=["h1", "h2"],
+                level="intermediate",
+            )
+        finally:
+            patcher.stop()
+
+        _, kwargs = mock_client.post.call_args
+        user_content = kwargs["json"]["messages"][1]["content"]
+        assert "<chat_history>" in user_content
+        assert "h1" in user_content
+        assert "h2" in user_content
+        assert "<user_code>" in user_content
+        assert "print(1)" in user_content
+        assert "<user_question>" in user_content
+        assert "explain this" in user_content
+
+    @pytest.mark.asyncio
+    async def test_history_truncates_to_last_eight(self, enabled_client):
+        history = [f"msg-{i}" for i in range(12)]
+        patcher, mock_client = _patch_httpx(_make_llm_response("ok"))
+        try:
+            await enabled_client.chat_reply(
+                message="q",
+                code=None,
+                history=history,
+                level="beginner",
+            )
+        finally:
+            patcher.stop()
+
+        _, kwargs = mock_client.post.call_args
+        user_content = kwargs["json"]["messages"][1]["content"]
+        history_block = user_content.split("<chat_history>")[1].split(
+            "</chat_history>"
+        )[0]
+        history_lines = [line for line in history_block.strip().splitlines() if line]
+        assert history_lines == [f"msg-{i}" for i in range(4, 12)]
+
+    @pytest.mark.asyncio
+    async def test_none_code_becomes_empty_string(self, enabled_client):
+        patcher, mock_client = _patch_httpx(_make_llm_response("ok"))
+        try:
+            await enabled_client.chat_reply(
+                message="hi",
+                code=None,
+                history=[],
+                level="beginner",
+            )
+        finally:
+            patcher.stop()
+
+        _, kwargs = mock_client.post.call_args
+        user_content = kwargs["json"]["messages"][1]["content"]
+        assert "<user_code>\n\n</user_code>" in user_content

--- a/docs/CHANGELOG.md
+++ b/docs/CHANGELOG.md
@@ -5,6 +5,7 @@ All notable changes to QyverixAI are documented in this file.
 ## [Unreleased]
 
 ### Added
+- Added regression tests for the LLM analysis service (`llm_analysis.py`).
 - Added a dedicated changelog page in `docs/CHANGELOG.md`.
 - Added changelog guidance for contributors and PR authors.
 - Added `POST /auth/logout` to revoke the caller's access token.


### PR DESCRIPTION
## Description

Adds offline regression tests for the LLM analysis service (`backend/app/services/llm_analysis.py`).

There was no dedicated test coverage for `LLMAnalysisClient`. This PR adds focused unit tests covering:

- `enabled` property (enabled / disabled / missing API key)
- `_chat_completion` success, empty response, HTTP/timeout/connect errors, and request payload/auth
- `_extract_json` for plain JSON, fenced markdown JSON, surrounding text, and invalid payloads
- `summarize_code` success, disabled path, `<user_code>` isolation, and HTTP failures
- `analyze_code_structured` valid/fenced JSON parsing and invalid payload handling
- `chat_reply` success, XML tag isolation, and history truncation to the last 8 messages

All HTTP calls are mocked with `httpx` — no real API keys or network calls.

**Tests only — no production behavior change.**

## Related Issue

Fixes #1455

## Type of change

- [ ] Bug fix
- [ ] New feature / enhancement
- [ ] Documentation update
- [x] Test addition
- [ ] Refactor

## Checklist

- [x] I have read [CONTRIBUTING.md](./CONTRIBUTING.md)
- [x] My branch is up to date with `main`
- [x] I have run `pytest tests/test_llm_analysis.py -v` and all new tests pass (29 passed)
- [x] I have not introduced duplicate issues or features
- [x] My PR title follows the format: `feat/fix/docs/test: short description`
- [x] I have added tests for this change
- [x] No hardcoded secrets or API keys in my code
- [x] This PR is linked to a GSSoC 2026 issue
- [x] `docs/CHANGELOG.md` updated

## Test evidence

```bash
pytest tests/test_llm_analysis.py -v