### PR TITLE
fix(database): improve error handling in history DB service

### DIFF
--- a/backend/app/services/database.py
+++ b/backend/app/services/database.py
@@ -7,7 +7,9 @@ from __future__ import annotations
 
 import contextlib
 import hashlib
+import logging
 import os
+import sqlite3
 import time
 
 import aiosqlite
@@ -17,6 +19,8 @@ from ..observability import (
     DB_OPERATIONS_TOTAL,
     metrics_enabled,
 )
+
+logger = logging.getLogger("ai_assistant.api")
 
 DB_PATH = os.getenv("HISTORY_DB_PATH", "history.db")
 
@@ -40,42 +44,70 @@ def record_db_metric(operation: str):
         DB_OPERATIONS_TOTAL.labels(operation=operation, status=status).inc()
 
 
+def _log_db_failure(operation: str, exc: BaseException) -> None:
+    """Log a database failure with operation context before re-raising."""
+    logger.error(
+        "db_operation_failed operation=%s detail=%s",
+        operation,
+        str(exc),
+        exc_info=True,
+    )
+
+
+def _is_duplicate_column_error(exc: BaseException) -> bool:
+    """Return True when SQLite reports that an ALTER ADD COLUMN is redundant."""
+    message = str(exc).lower()
+    return "duplicate column" in message
+
+
+async def _safe_add_column(db: aiosqlite.Connection, ddl: str) -> None:
+    """Run an ALTER TABLE ADD COLUMN, ignoring only duplicate-column errors."""
+    try:
+        await db.execute(ddl)
+    except Exception as exc:
+        if _is_duplicate_column_error(exc):
+            logger.debug("db_migration_skip detail=%s", str(exc))
+            return
+        _log_db_failure("init_db_migration", exc)
+        raise
+
+
 async def init_db() -> None:
     with record_db_metric("init_db"):
-        async with aiosqlite.connect(DB_PATH) as db:
-            await db.execute(
+        try:
+            async with aiosqlite.connect(DB_PATH) as db:
+                await db.execute(
+                    """
+                    CREATE TABLE IF NOT EXISTS history (
+                        id          INTEGER PRIMARY KEY AUTOINCREMENT,
+                        code_hash   TEXT NOT NULL,
+                        language    TEXT NOT NULL,
+                        score       INTEGER,
+                        issue_count INTEGER,
+                        timestamp   TEXT NOT NULL DEFAULT (datetime('now')),
+                        code_preview TEXT NOT NULL,
+                        code        TEXT,
+                        result_json TEXT
+                    )
                 """
-                CREATE TABLE IF NOT EXISTS history (
-                    id          INTEGER PRIMARY KEY AUTOINCREMENT,
-                    code_hash   TEXT NOT NULL,
-                    language    TEXT NOT NULL,
-                    score       INTEGER,
-                    issue_count INTEGER,
-                    timestamp   TEXT NOT NULL DEFAULT (datetime('now')),
-                    code_preview TEXT NOT NULL,
-                    code        TEXT,
-                    result_json TEXT
                 )
-            """
-            )
-            try:
-                await db.execute("ALTER TABLE history ADD COLUMN code TEXT")
-            except Exception:
-                pass
-            try:
-                await db.execute("ALTER TABLE history ADD COLUMN result_json TEXT")
-            except Exception:
-                pass
-            await db.execute(
+                await _safe_add_column(db, "ALTER TABLE history ADD COLUMN code TEXT")
+                await _safe_add_column(
+                    db, "ALTER TABLE history ADD COLUMN result_json TEXT"
+                )
+                await db.execute(
+                    """
+                    CREATE VIRTUAL TABLE IF NOT EXISTS fts_history
+                    USING fts5(code_preview, content=history, content_rowid=id)
                 """
-                CREATE VIRTUAL TABLE IF NOT EXISTS fts_history
-                USING fts5(code_preview, content=history, content_rowid=id)
-            """
-            )
-            await db.execute(
-                "CREATE INDEX IF NOT EXISTS idx_timestamp ON history(timestamp DESC)"
-            )
-            await db.commit()
+                )
+                await db.execute(
+                    "CREATE INDEX IF NOT EXISTS idx_timestamp ON history(timestamp DESC)"
+                )
+                await db.commit()
+        except Exception as exc:
+            _log_db_failure("init_db", exc)
+            raise
 
 
 def hash_code(code: str) -> str:
@@ -90,108 +122,154 @@ async def save_entry(
     result_json: str | None = None,
 ) -> int:
     with record_db_metric("save_entry"):
-        code_hash = hash_code(code)
-        preview = code.strip()[:120].replace("\n", " ")
-        async with aiosqlite.connect(DB_PATH) as db:
-            cursor = await db.execute(
-                """
-                INSERT INTO history (code_hash, language, score, issue_count, code_preview, code, result_json)
-                VALUES (?, ?, ?, ?, ?, ?, ?)
-                """,
-                (code_hash, language, score, issue_count, preview, code, result_json),
-            )
-            row_id = cursor.lastrowid
-            await db.execute(
-                "INSERT INTO fts_history(rowid, code_preview) VALUES (?, ?)",
-                (row_id, preview),
-            )
-            await db.commit()
-            return row_id
+        try:
+            code_hash = hash_code(code)
+            preview = code.strip()[:120].replace("\n", " ")
+            async with aiosqlite.connect(DB_PATH) as db:
+                cursor = await db.execute(
+                    """
+                    INSERT INTO history (code_hash, language, score, issue_count, code_preview, code, result_json)
+                    VALUES (?, ?, ?, ?, ?, ?, ?)
+                    """,
+                    (
+                        code_hash,
+                        language,
+                        score,
+                        issue_count,
+                        preview,
+                        code,
+                        result_json,
+                    ),
+                )
+                row_id = cursor.lastrowid
+                await db.execute(
+                    "INSERT INTO fts_history(rowid, code_preview) VALUES (?, ?)",
+                    (row_id, preview),
+                )
+                await db.commit()
+                return row_id
+        except Exception as exc:
+            _log_db_failure("save_entry", exc)
+            raise
 
 
 async def count_entries() -> int:
     with record_db_metric("count_entries"):
-        async with aiosqlite.connect(DB_PATH) as db:
-            cursor = await db.execute("SELECT COUNT(*) FROM history")
-            row = await cursor.fetchone()
-            return row[0] if row else 0
+        try:
+            async with aiosqlite.connect(DB_PATH) as db:
+                cursor = await db.execute("SELECT COUNT(*) FROM history")
+                row = await cursor.fetchone()
+                return row[0] if row else 0
+        except Exception as exc:
+            _log_db_failure("count_entries", exc)
+            raise
 
 
 async def get_entries(
     limit: int = 20, offset: int = 0, sort_by: str = "timestamp", order: str = "desc"
 ) -> list[dict]:
     with record_db_metric("get_entries"):
-        allowed_sort_columns = {"timestamp", "score", "issue_count", "id"}
-        allowed_orders = {"asc", "desc"}
-        if sort_by not in allowed_sort_columns:
-            sort_by = "timestamp"
-        if order.lower() not in allowed_orders:
-            order = "desc"
-        async with aiosqlite.connect(DB_PATH) as db:
-            db.row_factory = aiosqlite.Row
-            query = f"""
-                SELECT id, code_hash, language, score, issue_count, timestamp, code_preview
-                FROM history
-                ORDER BY {sort_by} {order}, id DESC
-                LIMIT ? OFFSET ?
-            """
+        try:
+            allowed_sort_columns = {"timestamp", "score", "issue_count", "id"}
+            allowed_orders = {"asc", "desc"}
+            if sort_by not in allowed_sort_columns:
+                sort_by = "timestamp"
+            if order.lower() not in allowed_orders:
+                order = "desc"
+            async with aiosqlite.connect(DB_PATH) as db:
+                db.row_factory = aiosqlite.Row
+                query = f"""
+                    SELECT id, code_hash, language, score, issue_count, timestamp, code_preview
+                    FROM history
+                    ORDER BY {sort_by} {order}, id DESC
+                    LIMIT ? OFFSET ?
+                """
 
-            cursor = await db.execute(query, (limit, offset))
-            rows = await cursor.fetchall()
-            return [dict(row) for row in rows]
+                cursor = await db.execute(query, (limit, offset))
+                rows = await cursor.fetchall()
+                return [dict(row) for row in rows]
+        except Exception as exc:
+            _log_db_failure("get_entries", exc)
+            raise
 
 
 async def search_entries(q: str, limit: int = 20) -> list[dict]:
     with record_db_metric("search_entries"):
         q = q[:200]
-        async with aiosqlite.connect(DB_PATH) as db:
-            db.row_factory = aiosqlite.Row
-            cursor = await db.execute(
-                """
-                SELECT h.id, h.code_hash, h.language, h.score,
-                       h.issue_count, h.timestamp, h.code_preview
-                FROM history h
-                WHERE h.id IN (
-                    SELECT rowid FROM fts_history WHERE fts_history MATCH ?
+        try:
+            async with aiosqlite.connect(DB_PATH) as db:
+                db.row_factory = aiosqlite.Row
+                cursor = await db.execute(
+                    """
+                    SELECT h.id, h.code_hash, h.language, h.score,
+                           h.issue_count, h.timestamp, h.code_preview
+                    FROM history h
+                    WHERE h.id IN (
+                        SELECT rowid FROM fts_history WHERE fts_history MATCH ?
+                    )
+                    ORDER BY h.timestamp DESC
+                    LIMIT ?
+                    """,
+                    (q, limit),
                 )
-                ORDER BY h.timestamp DESC
-                LIMIT ?
-                """,
-                (q, limit),
+                rows = await cursor.fetchall()
+                return [dict(row) for row in rows]
+        except (aiosqlite.Error, sqlite3.Error) as exc:
+            # Invalid FTS MATCH syntax should not 500 the history search API.
+            logger.warning(
+                "search_entries_failed query=%r detail=%s",
+                q,
+                str(exc),
             )
-            rows = await cursor.fetchall()
-            return [dict(row) for row in rows]
+            return []
+        except Exception as exc:
+            _log_db_failure("search_entries", exc)
+            raise
 
 
 async def delete_entry(entry_id: int) -> bool:
     with record_db_metric("delete_entry"):
-        async with aiosqlite.connect(DB_PATH) as db:
-            cursor = await db.execute("DELETE FROM history WHERE id = ?", (entry_id,))
-            await db.execute("DELETE FROM fts_history WHERE rowid = ?", (entry_id,))
-            await db.commit()
-            return cursor.rowcount > 0
+        try:
+            async with aiosqlite.connect(DB_PATH) as db:
+                cursor = await db.execute(
+                    "DELETE FROM history WHERE id = ?", (entry_id,)
+                )
+                await db.execute("DELETE FROM fts_history WHERE rowid = ?", (entry_id,))
+                await db.commit()
+                return cursor.rowcount > 0
+        except Exception as exc:
+            _log_db_failure("delete_entry", exc)
+            raise
 
 
 async def get_entry(entry_id: int) -> dict | None:
     with record_db_metric("get_entry"):
-        async with aiosqlite.connect(DB_PATH) as db:
-            db.row_factory = aiosqlite.Row
-            cursor = await db.execute(
-                """
-                SELECT id, code_hash, language, score, issue_count, timestamp, code_preview, code, result_json
-                FROM history
-                WHERE id = ?
-                """,
-                (entry_id,),
-            )
-            row = await cursor.fetchone()
-            return dict(row) if row else None
+        try:
+            async with aiosqlite.connect(DB_PATH) as db:
+                db.row_factory = aiosqlite.Row
+                cursor = await db.execute(
+                    """
+                    SELECT id, code_hash, language, score, issue_count, timestamp, code_preview, code, result_json
+                    FROM history
+                    WHERE id = ?
+                    """,
+                    (entry_id,),
+                )
+                row = await cursor.fetchone()
+                return dict(row) if row else None
+        except Exception as exc:
+            _log_db_failure("get_entry", exc)
+            raise
 
 
 async def clear_entries() -> int:
     with record_db_metric("clear_entries"):
-        async with aiosqlite.connect(DB_PATH) as db:
-            cursor = await db.execute("DELETE FROM history")
-            await db.execute("DELETE FROM fts_history")
-            await db.commit()
-            return cursor.rowcount
+        try:
+            async with aiosqlite.connect(DB_PATH) as db:
+                cursor = await db.execute("DELETE FROM history")
+                await db.execute("DELETE FROM fts_history")
+                await db.commit()
+                return cursor.rowcount
+        except Exception as exc:
+            _log_db_failure("clear_entries", exc)
+            raise

--- a/backend/tests/test_database_service.py
+++ b/backend/tests/test_database_service.py
@@ -1,7 +1,9 @@
 from __future__ import annotations
 
 import asyncio
+import logging
 import tempfile
+from unittest.mock import patch
 
 import pytest
 from app.services import database
@@ -204,3 +206,55 @@ def test_invalid_order_fallback(temp_db):
 
     assert len(entries) == 1
     assert entries[0]["language"] == "Python"
+
+
+# Verify init_db can run twice (idempotent migrations / duplicate columns).
+def test_init_db_is_idempotent(temp_db):
+    asyncio.run(database.init_db())
+    asyncio.run(database.init_db())
+
+    assert asyncio.run(database.count_entries()) == 0
+
+
+# Invalid FTS MATCH syntax should soft-fail to an empty list, not raise.
+def test_search_invalid_fts_query_returns_empty(temp_db):
+    asyncio.run(
+        database.save_entry(
+            code="print('hello world')",
+            language="Python",
+            score=95,
+            issue_count=1,
+        )
+    )
+
+    results = asyncio.run(database.search_entries('"""'))
+    assert results == []
+
+    results_and = asyncio.run(database.search_entries("AND"))
+    assert results_and == []
+
+
+# Deleting a missing id returns False without raising.
+def test_delete_missing_entry_returns_false(temp_db):
+    deleted = asyncio.run(database.delete_entry(999_999))
+    assert deleted is False
+
+
+# Connection / operational failures are logged and re-raised.
+def test_save_entry_raises_on_connection_failure(temp_db, caplog):
+    with patch(
+        "app.services.database.aiosqlite.connect",
+        side_effect=OSError("connection refused"),
+    ):
+        with caplog.at_level(logging.ERROR, logger="ai_assistant.api"):
+            with pytest.raises(OSError, match="connection refused"):
+                asyncio.run(
+                    database.save_entry(
+                        code="print('fail')",
+                        language="Python",
+                        score=1,
+                        issue_count=0,
+                    )
+                )
+
+    assert any("save_entry" in record.message for record in caplog.records)

--- a/docs/CHANGELOG.md
+++ b/docs/CHANGELOG.md
@@ -16,6 +16,11 @@ All notable changes to QyverixAI are documented in this file.
 ### Changed
 - Linked the changelog from `README.md` for faster discoverability.
 
+### Fixed
+- Improved database service error handling: safer idempotent schema migrations,
+  soft-fail invalid FTS search queries to an empty result, and structured
+  logging before re-raising unexpected SQLite failures.
+
 ### Security
 - Hardened authentication against token replay: access tokens now carry a
   unique `jti`, and revoked tokens (e.g. after logout) are rejected via a


### PR DESCRIPTION
## Description
Improves error handling in the SQLite history database service (`backend/app/services/database.py`).

Specifically:
- Replaces bare `except Exception: pass` on `ALTER TABLE` migrations with duplicate-column-aware handling so unexpected migration errors are logged and re-raised
- Soft-fails invalid FTS `MATCH` queries in `search_entries` by returning `[]` with a warning log (avoids 500s on `/history/search`)
- Adds structured log-and-re-raise for unexpected failures in `init_db`, `save_entry`, `get_entries`, `get_entry`, `count_entries`, `delete_entry`, and `clear_entries`
- Keeps public function signatures and happy-path behavior unchanged (history router needs no edits)
- Adds regression tests in `backend/tests/test_database_service.py`
- Updates `docs/CHANGELOG.md`

## Related Issue
Fixes #1538

## Type of change
- [x] Bug fix
- [ ] New feature / enhancement
- [ ] Documentation update
- [x] Test addition
- [ ] Refactor

## Checklist
- [x] I have read [CONTRIBUTING.md](../CONTRIBUTING.md)
- [x] My branch is up to date with `main`
- [x] I have run `pytest -v` and all tests pass
- [x] I have not introduced duplicate issues or features
- [x] My PR title follows the format: `feat/fix/docs/test: short description`
- [x] I have added tests for new features (Level 2 and 3 issues)
- [x] No hardcoded secrets or API keys in my code
- [x] This PR is linked to a GSSoC 2026 issue

## Test evidence
```bash
pytest tests/test_database_service.py -v
# 13 passed

