### PR TITLE
refactor(collaboration): centralize error responses

### DIFF
--- a/backend/app/routers/collaboration.py
+++ b/backend/app/routers/collaboration.py
@@ -51,6 +51,22 @@ class CollaborationManager:
     def _users_payload(self, room: CollaborationRoom) -> list[dict[str, Any]]:
         return list(room.users.values())
 
+    async def _send_error(
+        self,
+        room: CollaborationRoom,
+        client_id: str,
+        detail: str,
+    ) -> None:
+        """Send an error message to a collaboration client if connected."""
+        socket = room.sockets.get(client_id)
+        if socket is not None:
+            await socket.send_json(
+                {
+                    "type": "error",
+                    "detail": detail,
+                }
+            )
+
     def _state_payload(
         self,
         session_id: str,
@@ -172,14 +188,11 @@ class CollaborationManager:
             await self._handle_comment_added(session_id, client_id, data)
             return
 
-        socket = room.sockets.get(client_id)
-        if socket is not None:
-            await socket.send_json(
-                {
-                    "type": "error",
-                    "detail": f"Unsupported collaboration message type: {message_type}",
-                }
-            )
+        await self._send_error(
+            room,
+            client_id,
+            f"Unsupported collaboration message type: {message_type}",
+        )
 
     async def _handle_code_update(
         self,
@@ -188,26 +201,20 @@ class CollaborationManager:
         data: dict[str, Any],
     ) -> None:
         room = self._get_room(session_id)
-        socket = room.sockets.get(client_id)
         code = data.get("code", "")
         language = data.get("language")
         incoming_version = int(data.get("version", 0))
 
         if not isinstance(code, str):
-            if socket is not None:
-                await socket.send_json(
-                    {"type": "error", "detail": "code must be a string"}
-                )
+            await self._send_error(room, client_id, "code must be a string")
             return
 
         if len(code) > MAX_CODE_CHARS:
-            if socket is not None:
-                await socket.send_json(
-                    {
-                        "type": "error",
-                        "detail": f"code exceeds {MAX_CODE_CHARS} characters",
-                    }
-                )
+            await self._send_error(
+                room,
+                client_id,
+                f"code exceeds {MAX_CODE_CHARS} characters",
+            )
             return
 
         async with room.lock:
@@ -276,23 +283,16 @@ class CollaborationManager:
         text = str(data.get("text", "")).strip()
         line = max(1, int(data.get("line", 1)))
 
-        socket = room.sockets.get(client_id)
-
         if not text:
-            if socket is not None:
-                await socket.send_json(
-                    {"type": "error", "detail": "comment text is required"}
-                )
+            await self._send_error(room, client_id, "comment text is required")
             return
 
         if len(text) > MAX_COMMENT_CHARS:
-            if socket is not None:
-                await socket.send_json(
-                    {
-                        "type": "error",
-                        "detail": f"comment exceeds {MAX_COMMENT_CHARS} characters",
-                    }
-                )
+            await self._send_error(
+                room,
+                client_id,
+                f"comment exceeds {MAX_COMMENT_CHARS} characters",
+            )
             return
 
         async with room.lock:

--- a/backend/tests/test_collaboration_ws.py
+++ b/backend/tests/test_collaboration_ws.py
@@ -248,3 +248,19 @@ def test_presence_sync_session_cleanup():
         assert bob_state["version"] == 0
         assert len(bob_state["users"]) == 1
         assert bob_state["users"][0]["name"] == "Bob"
+
+
+def test_collaboration_rejects_unsupported_message_type():
+    with client.websocket_connect(
+        "/collaboration/ws/session-g?name=Alice"
+    ) as websocket:
+        websocket.receive_json()
+        websocket.receive_json()
+
+        websocket.send_json({"type": "unknown_event"})
+        response = websocket.receive_json()
+
+        assert response == {
+            "type": "error",
+            "detail": "Unsupported collaboration message type: unknown_event",
+        }


### PR DESCRIPTION
## Description

Refactors repeated WebSocket error-response logic in the collaboration router into a shared `_send_error` helper. This reduces duplicated code while preserving the existing collaboration behavior.

Also adds a focused regression test for unsupported collaboration message types.

## Related Issue

Fixes #1566

## Type of change

- [ ] Bug fix
- [ ] New feature / enhancement
- [ ] Documentation update
- [x] Test addition
- [x] Refactor

## Checklist

- [x] I have read [CONTRIBUTING.md](../CONTRIBUTING.md)
- [x] My branch is up to date with `main`
- [x] I have run `pytest -v` and all tests pass
- [x] I have not introduced duplicate issues or features
- [x] My PR title follows the required format
- [x] I have added tests for the changed behavior
- [x] No hardcoded secrets or API keys in my code
- [x] This PR is linked to a GSSoC 2026 issue

## Screenshots (if frontend change)

Not applicable — backend-only refactor.

## Test evidence

```bash
pytest -v
563 passed, 114 warnings in 75.05s

pytest backend/tests/test_collaboration_ws.py -v
10 passed, 114 warnings in 3.84s
```