### PR TITLE
feat: expose observability metrics in subscribe router

### DIFF
--- a/backend/app/observability.py
+++ b/backend/app/observability.py
@@ -139,6 +139,24 @@ DB_OPERATION_DURATION_SECONDS = Histogram(
     labelnames=("operation",),
 )
 
+SUBSCRIBE_ATTEMPTS_TOTAL = Counter(
+    "qyverixai_subscribe_attempts_total",
+    "Total number of subscription attempts, labelled by result.",
+    labelnames=("result",),
+)
+
+UNSUBSCRIBE_POST_ATTEMPTS_TOTAL = Counter(
+    "qyverixai_unsubscribe_post_attempts_total",
+    "Total number of POST unsubscribe attempts, labelled by result.",
+    labelnames=("result",),
+)
+
+UNSUBSCRIBE_GET_ATTEMPTS_TOTAL = Counter(
+    "qyverixai_unsubscribe_get_attempts_total",
+    "Total number of GET unsubscribe attempts, labelled by result.",
+    labelnames=("result",),
+)
+
 
 def initialise_app_info(version: str, ai_provider: str) -> None:
     """Set the app_info gauge once at startup so dashboards can display it."""

--- a/backend/app/routers/subscribe.py
+++ b/backend/app/routers/subscribe.py
@@ -7,6 +7,11 @@ from sqlalchemy.orm import Session
 
 from ..database import get_db
 from ..models import DigestSubscription
+from ..observability import (
+    SUBSCRIBE_ATTEMPTS_TOTAL,
+    UNSUBSCRIBE_GET_ATTEMPTS_TOTAL,
+    UNSUBSCRIBE_POST_ATTEMPTS_TOTAL,
+)
 from ..schemas import SubscribeRequest, SubscribeResponse, UnsubscribeRequest
 from ..services.email_service import _generate_token
 
@@ -57,6 +62,7 @@ def subscribe(body: SubscribeRequest, db: Session = Depends(get_db)):
 
     if existing:
         if existing.is_active:
+            SUBSCRIBE_ATTEMPTS_TOTAL.labels(result="duplicate").inc()
             raise HTTPException(
                 status_code=409,
                 detail="This email is already subscribed to the weekly digest.",
@@ -64,6 +70,7 @@ def subscribe(body: SubscribeRequest, db: Session = Depends(get_db)):
         existing.is_active = True
         existing.unsubscribe_token = _generate_token()
         db.commit()
+        SUBSCRIBE_ATTEMPTS_TOTAL.labels(result="reactivated").inc()
         return SubscribeResponse(
             message="Subscription re-activated. Welcome back!",
             email=email,
@@ -76,6 +83,7 @@ def subscribe(body: SubscribeRequest, db: Session = Depends(get_db)):
     )
     db.add(sub)
     db.commit()
+    SUBSCRIBE_ATTEMPTS_TOTAL.labels(result="success").inc()
     return SubscribeResponse(
         message="You're subscribed! You'll receive your first digest next Sunday.",
         email=email,
@@ -130,15 +138,18 @@ def unsubscribe(body: UnsubscribeRequest, db: Session = Depends(get_db)):
     )
 
     if not sub:
+        UNSUBSCRIBE_POST_ATTEMPTS_TOTAL.labels(result="not_found").inc()
         raise HTTPException(
             status_code=404, detail="Subscription not found or already inactive."
         )
 
     if sub.unsubscribe_token != body.token:
+        UNSUBSCRIBE_POST_ATTEMPTS_TOTAL.labels(result="invalid_token").inc()
         raise HTTPException(status_code=403, detail="Invalid unsubscribe token.")
 
     sub.is_active = False
     db.commit()
+    UNSUBSCRIBE_POST_ATTEMPTS_TOTAL.labels(result="success").inc()
     return {
         "message": "You've been unsubscribed from the weekly digest.",
         "email": email,
@@ -198,11 +209,14 @@ def unsubscribe_via_get(
     )
 
     if not sub:
+        UNSUBSCRIBE_GET_ATTEMPTS_TOTAL.labels(result="not_found").inc()
         return {"message": "Subscription not found or already inactive."}
 
     if sub.unsubscribe_token != token:
+        UNSUBSCRIBE_GET_ATTEMPTS_TOTAL.labels(result="invalid_token").inc()
         return {"message": "Invalid unsubscribe link."}
 
     sub.is_active = False
     db.commit()
+    UNSUBSCRIBE_GET_ATTEMPTS_TOTAL.labels(result="success").inc()
     return {"message": "You've been unsubscribed from the weekly digest."}

--- a/backend/tests/test_subscribe_observability.py
+++ b/backend/tests/test_subscribe_observability.py
@@ -1,0 +1,186 @@
+"""Tests verifying that subscribe router increments observability counters."""
+
+from __future__ import annotations
+
+import pytest
+from app import observability
+from app.database import Base, get_db
+from app.main import app as fastapi_app
+from app.models import DigestSubscription
+from fastapi.testclient import TestClient
+from sqlalchemy import create_engine
+from sqlalchemy.orm import sessionmaker
+from sqlalchemy.pool import StaticPool
+
+# ── In-memory test database setup ─────────────────────────────────────────────
+
+TEST_ENGINE = create_engine(
+    "sqlite:///:memory:",
+    connect_args={"check_same_thread": False},
+    poolclass=StaticPool,
+)
+TEST_SESSION_LOCAL = sessionmaker(bind=TEST_ENGINE)
+
+
+def _override_db():
+    db = TEST_SESSION_LOCAL()
+    try:
+        yield db
+    finally:
+        db.close()
+
+
+@pytest.fixture(autouse=True)
+def setup_db():
+    Base.metadata.create_all(TEST_ENGINE)
+    fastapi_app.dependency_overrides[get_db] = _override_db
+    yield
+    fastapi_app.dependency_overrides.clear()
+    Base.metadata.drop_all(TEST_ENGINE)
+
+
+client = TestClient(fastapi_app)
+
+
+# ── Helper ────────────────────────────────────────────────────────────────────
+
+
+def _get_token(email: str) -> str:
+    client.post("/subscribe/", json={"email": email})
+    db = TEST_SESSION_LOCAL()
+    try:
+        sub = (
+            db.query(DigestSubscription)
+            .filter(DigestSubscription.email == email.lower())
+            .first()
+        )
+        return sub.unsubscribe_token
+    finally:
+        db.close()
+
+
+def _counter_value(counter, **labels) -> float:
+    return counter.labels(**labels)._value.get()
+
+
+# ── Subscribe POST observability ──────────────────────────────────────────────
+
+
+def test_subscribe_success_increments_counter():
+    before = _counter_value(observability.SUBSCRIBE_ATTEMPTS_TOTAL, result="success")
+    client.post("/subscribe/", json={"email": "obs_success@example.com"})
+    after = _counter_value(observability.SUBSCRIBE_ATTEMPTS_TOTAL, result="success")
+    assert after == before + 1
+
+
+def test_subscribe_duplicate_increments_counter():
+    email = "obs_duplicate@example.com"
+    client.post("/subscribe/", json={"email": email})
+
+    before = _counter_value(observability.SUBSCRIBE_ATTEMPTS_TOTAL, result="duplicate")
+    client.post("/subscribe/", json={"email": email})
+    after = _counter_value(observability.SUBSCRIBE_ATTEMPTS_TOTAL, result="duplicate")
+    assert after == before + 1
+
+
+def test_subscribe_reactivated_increments_counter():
+    email = "obs_reactivate@example.com"
+    token = _get_token(email)
+    client.post("/subscribe/unsubscribe", json={"email": email, "token": token})
+
+    before = _counter_value(
+        observability.SUBSCRIBE_ATTEMPTS_TOTAL, result="reactivated"
+    )
+    client.post("/subscribe/", json={"email": email})
+    after = _counter_value(observability.SUBSCRIBE_ATTEMPTS_TOTAL, result="reactivated")
+    assert after == before + 1
+
+
+# ── Unsubscribe POST observability ────────────────────────────────────────────
+
+
+def test_unsubscribe_post_success_increments_counter():
+    email = "obs_unsub_success@example.com"
+    token = _get_token(email)
+
+    before = _counter_value(
+        observability.UNSUBSCRIBE_POST_ATTEMPTS_TOTAL, result="success"
+    )
+    client.post("/subscribe/unsubscribe", json={"email": email, "token": token})
+    after = _counter_value(
+        observability.UNSUBSCRIBE_POST_ATTEMPTS_TOTAL, result="success"
+    )
+    assert after == before + 1
+
+
+def test_unsubscribe_post_not_found_increments_counter():
+    before = _counter_value(
+        observability.UNSUBSCRIBE_POST_ATTEMPTS_TOTAL, result="not_found"
+    )
+    client.post(
+        "/subscribe/unsubscribe",
+        json={"email": "ghost@example.com", "token": "anytoken"},
+    )
+    after = _counter_value(
+        observability.UNSUBSCRIBE_POST_ATTEMPTS_TOTAL, result="not_found"
+    )
+    assert after == before + 1
+
+
+def test_unsubscribe_post_invalid_token_increments_counter():
+    email = "obs_wrong_token@example.com"
+    client.post("/subscribe/", json={"email": email})
+
+    before = _counter_value(
+        observability.UNSUBSCRIBE_POST_ATTEMPTS_TOTAL, result="invalid_token"
+    )
+    client.post(
+        "/subscribe/unsubscribe",
+        json={"email": email, "token": "wrongtoken"},
+    )
+    after = _counter_value(
+        observability.UNSUBSCRIBE_POST_ATTEMPTS_TOTAL, result="invalid_token"
+    )
+    assert after == before + 1
+
+
+# ── Unsubscribe GET observability ─────────────────────────────────────────────
+
+
+def test_unsubscribe_get_success_increments_counter():
+    email = "obs_get_success@example.com"
+    token = _get_token(email)
+
+    before = _counter_value(
+        observability.UNSUBSCRIBE_GET_ATTEMPTS_TOTAL, result="success"
+    )
+    client.get(f"/subscribe/unsubscribe?email={email}&token={token}")
+    after = _counter_value(
+        observability.UNSUBSCRIBE_GET_ATTEMPTS_TOTAL, result="success"
+    )
+    assert after == before + 1
+
+
+def test_unsubscribe_get_not_found_increments_counter():
+    before = _counter_value(
+        observability.UNSUBSCRIBE_GET_ATTEMPTS_TOTAL, result="not_found"
+    )
+    client.get("/subscribe/unsubscribe?email=ghost@example.com&token=any")
+    after = _counter_value(
+        observability.UNSUBSCRIBE_GET_ATTEMPTS_TOTAL, result="not_found"
+    )
+    assert after == before + 1
+
+
+def test_unsubscribe_get_invalid_token_increments_counter():
+    email = "obs_get_wrong_token@example.com"
+    client.post("/subscribe/", json={"email": email})
+
+    before = _counter_value(
+        observability.UNSUBSCRIBE_GET_ATTEMPTS_TOTAL, result="invalid_token"
+    )
+    client.get(f"/subscribe/unsubscribe?email={email}&token=wrongtoken")
+    after = _counter_value(
+        observability.UNSUBSCRIBE_GET_ATTEMPTS_TOTAL, result="invalid_token"
+    )
+    assert after == before + 1


### PR DESCRIPTION
Fixes #1529

## Summary
This PR adds Prometheus observability counters to the subscribe router and a dedicated test file verifying all counters increment correctly.

## Changes Made

**`app/observability.py`**
- Added `SUBSCRIBE_ATTEMPTS_TOTAL` counter — tracks subscription attempts labelled by `result` (`success`, `duplicate`, `reactivated`)
- Added `UNSUBSCRIBE_POST_ATTEMPTS_TOTAL` counter — tracks POST unsubscribe attempts labelled by `result` (`success`, `not_found`, `invalid_token`)
- Added `UNSUBSCRIBE_GET_ATTEMPTS_TOTAL` counter — tracks GET unsubscribe attempts labelled by `result` (`success`, `not_found`, `invalid_token`)

**`app/routers/subscribe.py`**
- Imported the three new counters
- Wired `.inc()` calls at every subscription and unsubscription outcome

**`tests/test_subscribe_observability.py`** (new file)
- 9 tests verifying each counter increments correctly for every outcome

## New Tests Added (9 total)
- `test_subscribe_success_increments_counter`
- `test_subscribe_duplicate_increments_counter`
- `test_subscribe_reactivated_increments_counter`
- `test_unsubscribe_post_success_increments_counter`
- `test_unsubscribe_post_not_found_increments_counter`
- `test_unsubscribe_post_invalid_token_increments_counter`
- `test_unsubscribe_get_success_increments_counter`
- `test_unsubscribe_get_not_found_increments_counter`
- `test_unsubscribe_get_invalid_token_increments_counter`

## Test Results
- All 9 tests pass
- No new dependencies required — uses existing Prometheus client
- No unrelated behavior changed

## Checklist
- [x] Observability counters added for all subscribe/unsubscribe outcomes
- [x] Tests verify counters increment correctly
- [x] All existing tests still pass
- [x] No unrelated behavior changed