### PR TITLE
feat(analyze): hybrid rule+LLM pipeline for POST /analyze/

### DIFF
--- a/backend/app/routers/analyze.py
+++ b/backend/app/routers/analyze.py
@@ -18,10 +18,12 @@ from ..services.cache import cache
 from ..services.code_assistant import (
     detect_language,
     full_analysis,
+    hybrid_analysis,
     run_bug_detection,
     run_explanation,
     run_suggestions,
 )
+from ..services.llm_analysis import llm_analysis_client
 
 router = APIRouter()
 
@@ -196,15 +198,18 @@ async def analyze_stream_get(
 )
 async def analyze(req: CodeRequest, response: Response):
     cache_input = f"{req.language or 'auto'}\n{req.code}"
-    cached_payload = cache.get("analyze:v1", cache_input)
+    # Separate cache namespaces so hybrid and rule-only results never collide.
+    mode_key = "hybrid" if llm_analysis_client.enabled else "rule-based"
+    namespace = f"analyze:v2:{mode_key}"
+    cached_payload = cache.get(namespace, cache_input)
 
     if cached_payload is not None:
         response.headers["X-Cache"] = "HIT"
         return cached_payload
 
-    payload = full_analysis(req.code, req.language)
+    payload = await hybrid_analysis(req.code, req.language)
 
-    cache.set("analyze:v1", cache_input, payload)
+    cache.set(namespace, cache_input, payload)
 
     response.headers["X-Cache"] = "MISS"
     return payload

--- a/backend/app/schemas.py
+++ b/backend/app/schemas.py
@@ -275,6 +275,16 @@ class AnalyzeResponse(BaseModel):
         description="Total time taken to run all three analyses, in milliseconds.",
         example=1.84,
     )
+    mode: str = Field(
+        default="rule-based",
+        description="Analysis mode: `rule-based`, `hybrid`, or `degraded`.",
+        example="hybrid",
+    )
+    optimized_version: str | None = Field(
+        default=None,
+        description="LLM-suggested optimized rewrite of the code, when mode is `hybrid`.",
+        example=None,
+    )
 
 
 # ── Zip Analysis ──────────────────────────────────────────────────────────────

--- a/backend/app/services/code_assistant.py
+++ b/backend/app/services/code_assistant.py
@@ -6,11 +6,15 @@ Covers 40+ patterns across Python, JavaScript, TypeScript, Java, C++, PHP and Ru
 from __future__ import annotations
 
 import ast
+import logging
 import re
 import time
 from dataclasses import dataclass, field
 
 from .ast_analyzer import analyze as ast_analyze
+from .llm_analysis import LLMAnalysisError, llm_analysis_client
+
+logger = logging.getLogger("ai_assistant.api")
 
 # ── Language Detection ─────────────────────────────────────────────────────────
 LANG_SIGNATURES: dict[str, list[str]] = {
@@ -1481,4 +1485,133 @@ def full_analysis(code: str, language_hint: str | None = None) -> dict:
         "debugging": debugging,
         "suggestions": sugg,
         "analysis_time_ms": round(elapsed_ms, 2),
+        "mode": "rule-based",
+        "optimized_version": None,
     }
+
+
+def _merge_explanation(rule_explanation: dict, llm_explanation: dict | None) -> dict:
+    """Layer LLM insight onto the rule-based explanation without breaking schema."""
+    merged = dict(rule_explanation)
+    if not isinstance(llm_explanation, dict):
+        return merged
+
+    key_points = list(merged.get("key_points") or [])
+    llm_summary = llm_explanation.get("summary")
+    if isinstance(llm_summary, str) and llm_summary.strip():
+        insight = f"LLM insight: {llm_summary.strip()}"
+        if insight not in key_points:
+            key_points.append(insight)
+
+    llm_points = llm_explanation.get("key_points") or []
+    if isinstance(llm_points, list):
+        for point in llm_points:
+            if isinstance(point, str) and point.strip() and point not in key_points:
+                key_points.append(point.strip())
+
+    beginner_tip = llm_explanation.get("beginner_tip")
+    if isinstance(beginner_tip, str) and beginner_tip.strip():
+        tip = f"Beginner tip: {beginner_tip.strip()}"
+        if tip not in key_points:
+            key_points.append(tip)
+
+    merged["key_points"] = key_points
+    return merged
+
+
+def _merge_suggestions(rule_suggestions: dict, llm_suggestions: dict | None) -> dict:
+    """Append LLM suggestions onto the rule-based suggestions list."""
+    merged = dict(rule_suggestions)
+    suggestions = list(merged.get("suggestions") or [])
+    if not isinstance(llm_suggestions, dict):
+        return merged
+
+    llm_items = llm_suggestions.get("suggestions") or []
+    if isinstance(llm_items, list):
+        for item in llm_items:
+            if not isinstance(item, dict):
+                continue
+            title = item.get("title") or "AI Suggestion"
+            reason = item.get("reason") or title
+            after = item.get("after")
+            before = item.get("before")
+            example = after if isinstance(after, str) and after.strip() else None
+            if example is None and isinstance(before, str) and before.strip():
+                example = before
+            suggestions.append(
+                {
+                    "category": "AI Suggestion",
+                    "description": f"{title}: {reason}" if title != reason else reason,
+                    "line_number": None,
+                    "line_range": None,
+                    "code_context": before if isinstance(before, str) else None,
+                    "example": example,
+                    "priority": "medium",
+                }
+            )
+
+    next_steps = llm_suggestions.get("next_steps") or []
+    if isinstance(next_steps, list) and next_steps:
+        first = next((s for s in next_steps if isinstance(s, str) and s.strip()), None)
+        if first and not merged.get("next_step"):
+            merged["next_step"] = first.strip()
+        elif first:
+            # Prefer keeping the rule next_step; surface LLM next steps as a suggestion.
+            suggestions.append(
+                {
+                    "category": "AI Suggestion",
+                    "description": f"Next step: {first.strip()}",
+                    "line_number": None,
+                    "line_range": None,
+                    "code_context": None,
+                    "example": None,
+                    "priority": "low",
+                }
+            )
+
+    merged["suggestions"] = suggestions
+    return merged
+
+
+async def hybrid_analysis(code: str, language_hint: str | None = None) -> dict:
+    """Run rule-based analysis, optionally enriching with structured LLM output.
+
+    Always keeps deterministic debugging issues from the rule engine. When the
+    LLM is enabled and succeeds, explanation/suggestions are enriched and an
+    optimized_version may be attached. On any LLM failure the request degrades
+    to rule-only results with mode=\"degraded\" (never raises to the caller).
+    """
+    base = full_analysis(code, language_hint)
+
+    if not llm_analysis_client.enabled:
+        base["mode"] = "rule-based"
+        return base
+
+    try:
+        llm_result = await llm_analysis_client.analyze_code_structured(
+            code, base["explanation"]["language"]
+        )
+    except LLMAnalysisError as exc:
+        logger.warning("hybrid_analysis_degraded detail=%s", str(exc))
+        base["mode"] = "degraded"
+        return base
+    except Exception as exc:  # noqa: BLE001 — never crash /analyze on LLM errors
+        logger.warning("hybrid_analysis_unexpected_error detail=%s", str(exc))
+        base["mode"] = "degraded"
+        return base
+
+    # Keep rule-based debugging.issues; enrich explanation/suggestions only.
+    base["provider"] = llm_analysis_client.provider_name
+    base["model"] = llm_analysis_client.model
+    base["mode"] = "hybrid"
+    base["explanation"] = _merge_explanation(
+        base["explanation"], llm_result.get("explanation")
+    )
+    base["suggestions"] = _merge_suggestions(
+        base["suggestions"], llm_result.get("suggestions")
+    )
+    optimized = llm_result.get("optimized_version")
+    base["optimized_version"] = (
+        optimized if isinstance(optimized, str) and optimized.strip() else None
+    )
+    return base

--- a/backend/app/services/llm_analysis.py
+++ b/backend/app/services/llm_analysis.py
@@ -40,6 +40,11 @@ class LLMAnalysisClient:
     def enabled(self) -> bool:
         return bool(settings.llm_enabled and self.api_key)
 
+    @property
+    def provider_name(self) -> str:
+        """Stable provider label for API responses (matches chat endpoints)."""
+        return "openai-compatible"
+
     async def _chat_completion(
         self, messages: list[dict], temperature: float = 0.2
     ) -> str:

--- a/backend/tests/test_hybrid_analysis.py
+++ b/backend/tests/test_hybrid_analysis.py
@@ -1,0 +1,234 @@
+"""
+Unit + API tests for hybrid rule+LLM analysis (issue #1737).
+
+Covers:
+- LLM disabled → mode=rule-based
+- LLM success → mode=hybrid, rule debugging retained, optimized_version set
+- LLMAnalysisError / unexpected errors → mode=degraded (HTTP 200, no 500)
+- Cache namespaces separate hybrid vs rule-based results
+
+No real API calls — LLM is mocked.
+Run: cd backend && pytest tests/test_hybrid_analysis.py -v
+"""
+
+from __future__ import annotations
+
+from unittest.mock import AsyncMock, patch
+
+import pytest
+from app import main as app_main
+from app.services.code_assistant import full_analysis, hybrid_analysis
+from app.services.llm_analysis import LLMAnalysisError
+from fastapi.testclient import TestClient
+
+client = TestClient(app_main.app)
+
+SAMPLE_CODE = "def add(a, b):\n    return a + b\n"
+
+
+def _valid_llm_payload() -> dict:
+    return {
+        "explanation": {
+            "summary": "adds two numbers",
+            "key_points": ["Pure function"],
+            "beginner_tip": "Name parameters clearly",
+        },
+        "debugging": {"issues": [], "quick_checks": []},
+        "suggestions": {
+            "suggestions": [
+                {
+                    "title": "Add type hints",
+                    "reason": "Improves readability",
+                    "before": "def add(a, b):",
+                    "after": "def add(a: int, b: int) -> int:",
+                }
+            ],
+            "next_steps": ["Add unit tests"],
+        },
+        "complexity": {"time": "O(1)", "space": "O(1)"},
+        "optimized_version": "def add(a: int, b: int) -> int:\n    return a + b\n",
+    }
+
+
+@pytest.fixture(autouse=True)
+def reset_rate_limit_and_cache():
+    from app.services.cache import cache
+
+    app_main._request_counts.clear()
+    cache.clear_memory()
+    yield
+    app_main._request_counts.clear()
+    cache.clear_memory()
+
+
+@pytest.fixture()
+def enable_llm(monkeypatch):
+    monkeypatch.setattr("app.services.llm_analysis.settings.llm_enabled", True)
+    monkeypatch.setattr("app.services.llm_analysis.settings.llm_api_key", "sk-test-key")
+    monkeypatch.setattr("app.services.llm_analysis.settings.llm_model", "gpt-4o-mini")
+    # Refresh singleton fields that were copied at construction time.
+    from app.services.llm_analysis import llm_analysis_client
+
+    llm_analysis_client.api_key = "sk-test-key"
+    llm_analysis_client.model = "gpt-4o-mini"
+    return llm_analysis_client
+
+
+@pytest.fixture()
+def disable_llm(monkeypatch):
+    monkeypatch.setattr("app.services.llm_analysis.settings.llm_enabled", False)
+    monkeypatch.setattr("app.services.llm_analysis.settings.llm_api_key", "")
+    from app.services.llm_analysis import llm_analysis_client
+
+    llm_analysis_client.api_key = ""
+    return llm_analysis_client
+
+
+@pytest.mark.asyncio
+async def test_hybrid_analysis_llm_disabled_returns_rule_based_mode(disable_llm):
+    rule = full_analysis(SAMPLE_CODE, "python")
+    result = await hybrid_analysis(SAMPLE_CODE, "python")
+
+    assert result["mode"] == "rule-based"
+    assert result["provider"] == "rule-based"
+    assert result["optimized_version"] is None
+    assert result["debugging"]["issues"] == rule["debugging"]["issues"]
+
+
+@pytest.mark.asyncio
+async def test_hybrid_analysis_llm_success_returns_hybrid_mode(enable_llm):
+    rule = full_analysis(SAMPLE_CODE, "python")
+    payload = _valid_llm_payload()
+
+    with patch.object(
+        enable_llm,
+        "analyze_code_structured",
+        new=AsyncMock(return_value=payload),
+    ):
+        result = await hybrid_analysis(SAMPLE_CODE, "python")
+
+    assert result["mode"] == "hybrid"
+    assert result["provider"] == "openai-compatible"
+    assert result["model"] == "gpt-4o-mini"
+    assert result["optimized_version"].startswith("def add")
+    # Rule debugging must be retained (not replaced by LLM debugging).
+    assert result["debugging"]["issues"] == rule["debugging"]["issues"]
+    assert any(
+        "LLM insight: adds two numbers" in point
+        for point in result["explanation"]["key_points"]
+    )
+    assert any(
+        s.get("category") == "AI Suggestion"
+        for s in result["suggestions"]["suggestions"]
+    )
+
+
+@pytest.mark.asyncio
+async def test_hybrid_analysis_llm_failure_degrades(enable_llm):
+    rule = full_analysis(SAMPLE_CODE, "python")
+
+    with patch.object(
+        enable_llm,
+        "analyze_code_structured",
+        new=AsyncMock(side_effect=LLMAnalysisError("invalid_json_payload")),
+    ):
+        result = await hybrid_analysis(SAMPLE_CODE, "python")
+
+    assert result["mode"] == "degraded"
+    assert result["provider"] == "rule-based"
+    assert result["optimized_version"] is None
+    assert result["debugging"]["issues"] == rule["debugging"]["issues"]
+
+
+@pytest.mark.asyncio
+async def test_hybrid_analysis_unexpected_exception_degrades(enable_llm):
+    with patch.object(
+        enable_llm,
+        "analyze_code_structured",
+        new=AsyncMock(side_effect=RuntimeError("boom")),
+    ):
+        result = await hybrid_analysis(SAMPLE_CODE, "python")
+
+    assert result["mode"] == "degraded"
+    assert result["provider"] == "rule-based"
+
+
+def test_analyze_endpoint_llm_disabled_is_rule_based(disable_llm):
+    response = client.post(
+        "/analyze/", json={"code": SAMPLE_CODE, "language": "python"}
+    )
+    assert response.status_code == 200
+    data = response.json()
+    assert data["mode"] == "rule-based"
+    assert data["provider"] == "rule-based"
+    assert data["optimized_version"] is None
+
+
+def test_analyze_endpoint_llm_success_is_hybrid(enable_llm):
+    payload = _valid_llm_payload()
+    with patch(
+        "app.services.code_assistant.llm_analysis_client.analyze_code_structured",
+        new=AsyncMock(return_value=payload),
+    ):
+        response = client.post(
+            "/analyze/", json={"code": SAMPLE_CODE, "language": "python"}
+        )
+
+    assert response.status_code == 200
+    data = response.json()
+    assert data["mode"] == "hybrid"
+    assert data["provider"] == "openai-compatible"
+    assert data["optimized_version"].startswith("def add")
+    assert "debugging" in data
+    assert isinstance(data["debugging"]["issues"], list)
+
+
+def test_analyze_endpoint_llm_failure_degrades_http_200(enable_llm):
+    with patch(
+        "app.services.code_assistant.llm_analysis_client.analyze_code_structured",
+        new=AsyncMock(side_effect=LLMAnalysisError("timeout")),
+    ):
+        response = client.post(
+            "/analyze/", json={"code": SAMPLE_CODE, "language": "python"}
+        )
+
+    assert response.status_code == 200
+    data = response.json()
+    assert data["mode"] == "degraded"
+    assert data["provider"] == "rule-based"
+
+
+def test_analyze_endpoint_cache_key_separates_modes(monkeypatch):
+    from app.services.cache import cache
+    from app.services.llm_analysis import llm_analysis_client
+
+    cache.clear_memory()
+    payload = {"code": SAMPLE_CODE, "language": "python"}
+
+    # 1) Rule-based path — MISS then HIT under rule-based namespace
+    monkeypatch.setattr("app.services.llm_analysis.settings.llm_enabled", False)
+    llm_analysis_client.api_key = ""
+    first = client.post("/analyze/", json=payload)
+    second = client.post("/analyze/", json=payload)
+    assert first.status_code == 200
+    assert first.headers["X-Cache"] == "MISS"
+    assert second.headers["X-Cache"] == "HIT"
+    assert first.json()["mode"] == "rule-based"
+
+    # 2) Flip LLM on — must be a fresh MISS (not stale rule-based HIT)
+    monkeypatch.setattr("app.services.llm_analysis.settings.llm_enabled", True)
+    llm_analysis_client.api_key = "sk-test-key"
+    llm_analysis_client.model = "gpt-4o-mini"
+
+    with patch(
+        "app.services.code_assistant.llm_analysis_client.analyze_code_structured",
+        new=AsyncMock(return_value=_valid_llm_payload()),
+    ):
+        hybrid_first = client.post("/analyze/", json=payload)
+        hybrid_second = client.post("/analyze/", json=payload)
+
+    assert hybrid_first.status_code == 200
+    assert hybrid_first.headers["X-Cache"] == "MISS"
+    assert hybrid_first.json()["mode"] == "hybrid"
+    assert hybrid_second.headers["X-Cache"] == "HIT"
+    assert hybrid_second.json()["mode"] == "hybrid"

--- a/docs/CHANGELOG.md
+++ b/docs/CHANGELOG.md
@@ -5,6 +5,10 @@ All notable changes to QyverixAI are documented in this file.
 ## [Unreleased]
 
 ### Added
+- Added hybrid rule+LLM analysis to `POST /analyze/`: LLM enrichment
+  (explanation insight, suggestions, `optimized_version`) layered on top of
+  deterministic rule-based debugging, with graceful `degraded` fallback on LLM
+  failure and mode-aware caching.
 - Added regression tests for the LLM analysis service (`llm_analysis.py`).
 - Added a dedicated changelog page in `docs/CHANGELOG.md`.
 - Added changelog guidance for contributors and PR authors.


### PR DESCRIPTION
## Description
Wires the existing `LLMAnalysisClient.analyze_code_structured()` path into the main product analysis flow so `POST /analyze/` can run as a **hybrid rule + LLM** pipeline.

- Always runs the deterministic rule/AST engine first and **keeps rule-based debugging issues**
- When LLM is enabled and succeeds: enriches explanation/suggestions, attaches `optimized_version`, sets `mode: "hybrid"`
- When LLM fails (timeout/parse/provider/unexpected): returns HTTP 200 with rule-only results and `mode: "degraded"` (no 500)
- When LLM is disabled: behavior stays rule-based (`mode: "rule-based"`)
- Analyze cache namespace is now mode-aware (`analyze:v2:hybrid` vs `analyze:v2:rule-based`) so results are not mixed
- Additive schema fields only (`mode`, `optimized_version`) — no required frontend changes
- `/analyze/stream` and `/analyze/zip/` intentionally remain rule-only for this PR

### Architecture

```mermaid
flowchart TD
    Client -->|"POST /analyze/"| Router[analyze.py: analyze]
    Router --> CacheGet["cache.get(namespace_by_mode, input)"]
    CacheGet -->|hit| ReturnCached[Return cached payload]
    CacheGet -->|miss| RunHybrid[run_hybrid_analysis]
    RunHybrid --> RuleEngine["full_analysis() rule/AST engine"]
    RuleEngine --> CheckLLM{"llm_analysis_client.enabled?"}
    CheckLLM -->|no| RuleOnly["mode = rule-based\nprovider = rule-based"]
    CheckLLM -->|yes| CallLLM["analyze_code_structured(code, language)"]
    CallLLM -->|success| Merge["merge: keep rule debugging.issues\nenrich explanation/suggestions\nattach optimized_version\nmode = hybrid"]
    CallLLM -->|LLMAnalysisError / timeout| Degrade["mode = degraded\nprovider = rule-based\nlog warning"]
    RuleOnly --> CacheSet[cache.set keyed by mode]
    Merge --> CacheSet
    Degrade --> CacheSet
    CacheSet --> Response["AnalyzeResponse (mode, optimized_version additive)"]
```

## Related Issue
Fixes #1737

## Type of change
- [ ] Bug fix
- [x] New feature / enhancement
- [ ] Documentation update
- [x] Test addition
- [ ] Refactor

## Checklist
- [x] I have read [CONTRIBUTING.md](../CONTRIBUTING.md)
- [x] My branch is up to date with `main`
- [x] I have run `pytest -v` and all tests pass
- [x] I have not introduced duplicate issues or features
- [x] My PR title follows the format: `feat/fix/docs/test: short description`
- [x] I have added tests for new features (Level 2 and 3 issues)
- [x] No hardcoded secrets or API keys in my code
- [x] This PR is linked to a GSSoC 2026 issue

## Screenshots (if frontend change)
N/A — backend-only

## Test evidence

```bash
cd backend
python -m pytest tests/test_hybrid_analysis.py tests/test_endpoints.py tests/test_llm_analysis.py -v
```

Results:
- `tests/test_hybrid_analysis.py` → **8 passed**
- `tests/test_endpoints.py` → **55 passed**
- `tests/test_llm_analysis.py` → **37 passed**

Notes:
- Warnings seen are pre-existing (`pytest-asyncio` fixture loop scope unset, Pydantic `Field(example=...)` deprecation) and are unrelated to this change.
