### PR TITLE
fix(cache): harden input validation in cache service

### DIFF
--- a/backend/app/services/cache.py
+++ b/backend/app/services/cache.py
@@ -65,6 +65,17 @@ class AppCache:
         if not settings.cache_enabled:
             return
 
+         # Input  Validation
+
+        if not isinstance(namespace, str) or not namespace.strip():
+            raise TypeError("Namespace must be a non-empty string")
+
+        if not isinstance(code, str) or not code.strip():
+            raise TypeError("Code must be a non-empty string")
+
+        if not isinstance(payload, dict):
+            raise TypeError("Payload must be a dictionary")
+
         key = self._make_key(namespace, code)
         if self._redis_client is not None:
             try:


### PR DESCRIPTION
## Summary

Adds basic input validation in the cache service before storing data.

### Changes
- Validate namespace is a non-empty string.
- Validate code is a non-empty string.
- Validate payload is a dictionary.

This preserves the existing cache behavior while preventing invalid inputs from being stored.

Fixes #1531