### PR TITLE
Improve reconnect and conflict handling in collaboration router

### DIFF
--- a/backend/app/routers/collaboration.py
+++ b/backend/app/routers/collaboration.py
@@ -335,11 +335,18 @@ async def collaboration_websocket(
                     await manager.handle_message(session_id, client_id, data)
                 else:
                     await websocket.send_json(
-                        {"type": "error", "detail": "message payload must be a JSON object"}
+                        {
+                            "type": "error",
+                            "detail": "message payload must be a JSON object",
+                        }
                     )
             except asyncio.TimeoutError:
-                await websocket.send_json({"type": "error", "detail": "Request timeout"})
+                await websocket.send_json(
+                    {"type": "error", "detail": "Request timeout"}
+                )
             except ValueError:
-                await websocket.send_json({"type": "error", "detail": "Invalid JSON payload"})
+                await websocket.send_json(
+                    {"type": "error", "detail": "Invalid JSON payload"}
+                )
     except WebSocketDisconnect:
         await manager.disconnect(session_id, client_id)

--- a/backend/app/routers/collaboration.py
+++ b/backend/app/routers/collaboration.py
@@ -329,12 +329,17 @@ async def collaboration_websocket(
 
     try:
         while True:
-            data = await websocket.receive_json()
-            if isinstance(data, dict):
-                await manager.handle_message(session_id, client_id, data)
-            else:
-                await websocket.send_json(
-                    {"type": "error", "detail": "message payload must be a JSON object"}
-                )
+            try:
+                data = await websocket.receive_json()
+                if isinstance(data, dict):
+                    await manager.handle_message(session_id, client_id, data)
+                else:
+                    await websocket.send_json(
+                        {"type": "error", "detail": "message payload must be a JSON object"}
+                    )
+            except asyncio.TimeoutError:
+                await websocket.send_json({"type": "error", "detail": "Request timeout"})
+            except ValueError:
+                await websocket.send_json({"type": "error", "detail": "Invalid JSON payload"})
     except WebSocketDisconnect:
         await manager.disconnect(session_id, client_id)

--- a/backend/tests/test_collaboration_ws.py
+++ b/backend/tests/test_collaboration_ws.py
@@ -264,3 +264,17 @@ def test_collaboration_rejects_unsupported_message_type():
             "type": "error",
             "detail": "Unsupported collaboration message type: unknown_event",
         }
+
+def test_collaboration_handles_invalid_json():
+    with client.websocket_connect("/collaboration/ws/session-invalid?name=Alice") as websocket:
+        websocket.receive_json()
+        websocket.receive_json()
+
+        websocket.send_text("not a valid json")
+        response = websocket.receive_json()
+
+        assert response == {
+            "type": "error",
+            "detail": "Invalid JSON payload",
+        }
+

--- a/backend/tests/test_collaboration_ws.py
+++ b/backend/tests/test_collaboration_ws.py
@@ -265,8 +265,11 @@ def test_collaboration_rejects_unsupported_message_type():
             "detail": "Unsupported collaboration message type: unknown_event",
         }
 
+
 def test_collaboration_handles_invalid_json():
-    with client.websocket_connect("/collaboration/ws/session-invalid?name=Alice") as websocket:
+    with client.websocket_connect(
+        "/collaboration/ws/session-invalid?name=Alice"
+    ) as websocket:
         websocket.receive_json()
         websocket.receive_json()
 
@@ -277,4 +280,3 @@ def test_collaboration_handles_invalid_json():
             "type": "error",
             "detail": "Invalid JSON payload",
         }
-


### PR DESCRIPTION
Fixes #1333

Wraps the collaboration websocket receive loop to gracefully catch ValueError (invalid JSON) and asyncio.TimeoutError without crashing the connection, returning consistent error-shaped payloads instead.

**Testing:** Added test_collaboration_handles_invalid_json in test_collaboration_ws.py, asserting invalid JSON returns the standard error payload without disconnecting. Verified as a real regression test: reverted the fix and confirmed the same test fails with an unhandled JSONDecodeError.

---

## Description
<!-- What does this PR do? Be specific. -->

## Related Issue
<!-- Required — link the issue this PR fixes -->
Fixes #

## Type of change
- [x] Bug fix
- [ ] New feature / enhancement
- [ ] Documentation update
- [ ] Test addition
- [ ] Refactor

## Checklist
<!-- All boxes must be checked before requesting review -->
- [ ] I have read [CONTRIBUTING.md](../CONTRIBUTING.md)
- [ ] My branch is up to date with `main`
- [ ] I have run `pytest -v` and all tests pass
- [ ] I have not introduced duplicate issues or features
- [ ] My PR title follows the format: `feat/fix/docs/test: short description`
- [ ] I have added tests for new features (Level 2 and 3 issues)
- [ ] No hardcoded secrets or API keys in my code
- [ ] This PR is linked to a GSSoC 2026 issue

## Screenshots (if frontend change)
<!-- Add before/after screenshots -->

## Test evidence
<!-- Paste pytest output here -->
```bash
pytest -v
# paste output
```