### PR TITLE
Harden session lifecycle handling in collaboration router

### DIFF
--- a/backend/app/routers/collaboration.py
+++ b/backend/app/routers/collaboration.py
@@ -8,7 +8,7 @@ from dataclasses import dataclass, field
 from datetime import datetime, timezone
 from typing import Any
 
-from fastapi import APIRouter, Query, WebSocket, WebSocketDisconnect
+from fastapi import APIRouter, Path, Query, WebSocket, WebSocketDisconnect
 
 router = APIRouter()
 
@@ -56,6 +56,7 @@ class CollaborationManager:
         room: CollaborationRoom,
         client_id: str,
         detail: str,
+        status: int = 400,
     ) -> None:
         """Send an error message to a collaboration client if connected."""
         socket = room.sockets.get(client_id)
@@ -64,6 +65,7 @@ class CollaborationManager:
                 {
                     "type": "error",
                     "detail": detail,
+                    "status": status,
                 }
             )
 
@@ -201,12 +203,16 @@ class CollaborationManager:
         data: dict[str, Any],
     ) -> None:
         room = self._get_room(session_id)
-        code = data.get("code", "")
+        code = data.get("code")
         language = data.get("language")
-        incoming_version = int(data.get("version", 0))
+        raw_version = data.get("version", 0)
+
+        if code is None:
+            await self._send_error(room, client_id, "code is required", status=400)
+            return
 
         if not isinstance(code, str):
-            await self._send_error(room, client_id, "code must be a string")
+            await self._send_error(room, client_id, "code must be a string", status=400)
             return
 
         if len(code) > MAX_CODE_CHARS:
@@ -214,7 +220,14 @@ class CollaborationManager:
                 room,
                 client_id,
                 f"code exceeds {MAX_CODE_CHARS} characters",
+                status=400,
             )
+            return
+
+        try:
+            incoming_version = int(raw_version)
+        except (ValueError, TypeError):
+            await self._send_error(room, client_id, "version must be an integer", status=400)
             return
 
         async with room.lock:
@@ -251,15 +264,24 @@ class CollaborationManager:
         room = self._get_room(session_id)
         raw_cursor = data.get("cursor")
 
-        if not isinstance(raw_cursor, dict):
+        if raw_cursor is None:
+            await self._send_error(room, client_id, "cursor is required", status=400)
             return
 
-        cursor = {
-            "line": max(1, int(raw_cursor.get("line", 1))),
-            "column": max(1, int(raw_cursor.get("column", 1))),
-            "selectionStart": max(0, int(raw_cursor.get("selectionStart", 0))),
-            "selectionEnd": max(0, int(raw_cursor.get("selectionEnd", 0))),
-        }
+        if not isinstance(raw_cursor, dict):
+            await self._send_error(room, client_id, "cursor must be a JSON object", status=400)
+            return
+
+        try:
+            cursor = {
+                "line": max(1, int(raw_cursor.get("line", 1))),
+                "column": max(1, int(raw_cursor.get("column", 1))),
+                "selectionStart": max(0, int(raw_cursor.get("selectionStart", 0))),
+                "selectionEnd": max(0, int(raw_cursor.get("selectionEnd", 0))),
+            }
+        except (ValueError, TypeError):
+            await self._send_error(room, client_id, "cursor fields must be integers", status=400)
+            return
 
         async with room.lock:
             user = room.users.get(client_id)
@@ -280,11 +302,20 @@ class CollaborationManager:
         data: dict[str, Any],
     ) -> None:
         room = self._get_room(session_id)
-        text = str(data.get("text", "")).strip()
-        line = max(1, int(data.get("line", 1)))
+        raw_text = data.get("text")
+        raw_line = data.get("line", 1)
 
+        if raw_text is None:
+            await self._send_error(room, client_id, "comment text is required", status=400)
+            return
+
+        if not isinstance(raw_text, str):
+            await self._send_error(room, client_id, "comment text must be a string", status=400)
+            return
+
+        text = raw_text.strip()
         if not text:
-            await self._send_error(room, client_id, "comment text is required")
+            await self._send_error(room, client_id, "comment text cannot be empty", status=400)
             return
 
         if len(text) > MAX_COMMENT_CHARS:
@@ -292,7 +323,14 @@ class CollaborationManager:
                 room,
                 client_id,
                 f"comment exceeds {MAX_COMMENT_CHARS} characters",
+                status=400,
             )
+            return
+
+        try:
+            line = max(1, int(raw_line))
+        except (ValueError, TypeError):
+            await self._send_error(room, client_id, "line must be an integer", status=400)
             return
 
         async with room.lock:
@@ -322,7 +360,7 @@ manager = CollaborationManager()
 @router.websocket("/ws/{session_id}")
 async def collaboration_websocket(
     websocket: WebSocket,
-    session_id: str,
+    session_id: str = Path(..., min_length=1, max_length=100),
     name: str = Query(default="Anonymous", max_length=40),
 ) -> None:
     client_id = await manager.connect(session_id, websocket, name)
@@ -335,11 +373,11 @@ async def collaboration_websocket(
                     await manager.handle_message(session_id, client_id, data)
                 else:
                     await websocket.send_json(
-                        {"type": "error", "detail": "message payload must be a JSON object"}
+                        {"type": "error", "detail": "message payload must be a JSON object", "status": 400}
                     )
             except asyncio.TimeoutError:
-                await websocket.send_json({"type": "error", "detail": "Request timeout"})
+                await websocket.send_json({"type": "error", "detail": "Request timeout", "status": 408})
             except ValueError:
-                await websocket.send_json({"type": "error", "detail": "Invalid JSON payload"})
+                await websocket.send_json({"type": "error", "detail": "Invalid JSON payload", "status": 400})
     except WebSocketDisconnect:
         await manager.disconnect(session_id, client_id)

--- a/backend/app/routers/collaboration.py
+++ b/backend/app/routers/collaboration.py
@@ -329,12 +329,17 @@ async def collaboration_websocket(
 
     try:
         while True:
-            data = await websocket.receive_json()
-            if isinstance(data, dict):
-                await manager.handle_message(session_id, client_id, data)
-            else:
-                await websocket.send_json(
-                    {"type": "error", "detail": "message payload must be a JSON object"}
-                )
+            try:
+                data = await websocket.receive_json()
+                if isinstance(data, dict):
+                    await manager.handle_message(session_id, client_id, data)
+                else:
+                    await websocket.send_json(
+                        {"type": "error", "detail": "message payload must be a JSON object"}
+                    )
+            except asyncio.TimeoutError:
+                await websocket.send_json({"type": "error", "detail": "Request timeout"})
+            except ValueError:
+                await websocket.send_json({"type": "error", "detail": "Invalid JSON payload"})
     except WebSocketDisconnect:
         await manager.disconnect(session_id, client_id)

--- a/backend/app/routers/collaboration.py
+++ b/backend/app/routers/collaboration.py
@@ -227,7 +227,9 @@ class CollaborationManager:
         try:
             incoming_version = int(raw_version)
         except (ValueError, TypeError):
-            await self._send_error(room, client_id, "version must be an integer", status=400)
+            await self._send_error(
+                room, client_id, "version must be an integer", status=400
+            )
             return
 
         async with room.lock:
@@ -269,7 +271,9 @@ class CollaborationManager:
             return
 
         if not isinstance(raw_cursor, dict):
-            await self._send_error(room, client_id, "cursor must be a JSON object", status=400)
+            await self._send_error(
+                room, client_id, "cursor must be a JSON object", status=400
+            )
             return
 
         try:
@@ -280,7 +284,9 @@ class CollaborationManager:
                 "selectionEnd": max(0, int(raw_cursor.get("selectionEnd", 0))),
             }
         except (ValueError, TypeError):
-            await self._send_error(room, client_id, "cursor fields must be integers", status=400)
+            await self._send_error(
+                room, client_id, "cursor fields must be integers", status=400
+            )
             return
 
         async with room.lock:
@@ -306,16 +312,22 @@ class CollaborationManager:
         raw_line = data.get("line", 1)
 
         if raw_text is None:
-            await self._send_error(room, client_id, "comment text is required", status=400)
+            await self._send_error(
+                room, client_id, "comment text is required", status=400
+            )
             return
 
         if not isinstance(raw_text, str):
-            await self._send_error(room, client_id, "comment text must be a string", status=400)
+            await self._send_error(
+                room, client_id, "comment text must be a string", status=400
+            )
             return
 
         text = raw_text.strip()
         if not text:
-            await self._send_error(room, client_id, "comment text cannot be empty", status=400)
+            await self._send_error(
+                room, client_id, "comment text cannot be empty", status=400
+            )
             return
 
         if len(text) > MAX_COMMENT_CHARS:
@@ -330,7 +342,9 @@ class CollaborationManager:
         try:
             line = max(1, int(raw_line))
         except (ValueError, TypeError):
-            await self._send_error(room, client_id, "line must be an integer", status=400)
+            await self._send_error(
+                room, client_id, "line must be an integer", status=400
+            )
             return
 
         async with room.lock:
@@ -373,11 +387,19 @@ async def collaboration_websocket(
                     await manager.handle_message(session_id, client_id, data)
                 else:
                     await websocket.send_json(
-                        {"type": "error", "detail": "message payload must be a JSON object", "status": 400}
+                        {
+                            "type": "error",
+                            "detail": "message payload must be a JSON object",
+                            "status": 400,
+                        }
                     )
             except asyncio.TimeoutError:
-                await websocket.send_json({"type": "error", "detail": "Request timeout", "status": 408})
+                await websocket.send_json(
+                    {"type": "error", "detail": "Request timeout", "status": 408}
+                )
             except ValueError:
-                await websocket.send_json({"type": "error", "detail": "Invalid JSON payload", "status": 400})
+                await websocket.send_json(
+                    {"type": "error", "detail": "Invalid JSON payload", "status": 400}
+                )
     except WebSocketDisconnect:
         await manager.disconnect(session_id, client_id)

--- a/backend/tests/test_collaboration_ws.py
+++ b/backend/tests/test_collaboration_ws.py
@@ -266,8 +266,11 @@ def test_collaboration_rejects_unsupported_message_type():
             "status": 400,
         }
 
+
 def test_collaboration_handles_invalid_json():
-    with client.websocket_connect("/collaboration/ws/session-invalid?name=Alice") as websocket:
+    with client.websocket_connect(
+        "/collaboration/ws/session-invalid?name=Alice"
+    ) as websocket:
         websocket.receive_json()
         websocket.receive_json()
 
@@ -280,54 +283,91 @@ def test_collaboration_handles_invalid_json():
             "status": 400,
         }
 
+
 def test_collaboration_handles_missing_and_malformed_code_updates():
-    with client.websocket_connect("/collaboration/ws/session-malformed1?name=Alice") as websocket:
+    with client.websocket_connect(
+        "/collaboration/ws/session-malformed1?name=Alice"
+    ) as websocket:
         websocket.receive_json()
         websocket.receive_json()
 
         # Missing code
         websocket.send_json({"type": "code_update", "version": 1})
         response = websocket.receive_json()
-        assert response == {"type": "error", "detail": "code is required", "status": 400}
+        assert response == {
+            "type": "error",
+            "detail": "code is required",
+            "status": 400,
+        }
 
         # Malformed version
-        websocket.send_json({"type": "code_update", "code": "print(1)", "version": "abc"})
+        websocket.send_json(
+            {"type": "code_update", "code": "print(1)", "version": "abc"}
+        )
         response = websocket.receive_json()
-        assert response == {"type": "error", "detail": "version must be an integer", "status": 400}
+        assert response == {
+            "type": "error",
+            "detail": "version must be an integer",
+            "status": 400,
+        }
 
         # Code too long
         websocket.send_json({"type": "code_update", "code": "A" * 50001, "version": 1})
         response = websocket.receive_json()
-        assert response == {"type": "error", "detail": "code exceeds 50000 characters", "status": 400}
+        assert response == {
+            "type": "error",
+            "detail": "code exceeds 50000 characters",
+            "status": 400,
+        }
+
 
 def test_collaboration_handles_missing_and_malformed_cursor_updates():
-    with client.websocket_connect("/collaboration/ws/session-malformed2?name=Alice") as websocket:
+    with client.websocket_connect(
+        "/collaboration/ws/session-malformed2?name=Alice"
+    ) as websocket:
         websocket.receive_json()
         websocket.receive_json()
 
         # Missing cursor
         websocket.send_json({"type": "cursor_update"})
         response = websocket.receive_json()
-        assert response == {"type": "error", "detail": "cursor is required", "status": 400}
+        assert response == {
+            "type": "error",
+            "detail": "cursor is required",
+            "status": 400,
+        }
 
         # Malformed cursor fields
         websocket.send_json({"type": "cursor_update", "cursor": {"line": "abc"}})
         response = websocket.receive_json()
-        assert response == {"type": "error", "detail": "cursor fields must be integers", "status": 400}
+        assert response == {
+            "type": "error",
+            "detail": "cursor fields must be integers",
+            "status": 400,
+        }
+
 
 def test_collaboration_handles_missing_and_malformed_comment_updates():
-    with client.websocket_connect("/collaboration/ws/session-malformed3?name=Alice") as websocket:
+    with client.websocket_connect(
+        "/collaboration/ws/session-malformed3?name=Alice"
+    ) as websocket:
         websocket.receive_json()
         websocket.receive_json()
 
         # Missing text
         websocket.send_json({"type": "comment_added", "line": 1})
         response = websocket.receive_json()
-        assert response == {"type": "error", "detail": "comment text is required", "status": 400}
+        assert response == {
+            "type": "error",
+            "detail": "comment text is required",
+            "status": 400,
+        }
 
         # Empty text
         websocket.send_json({"type": "comment_added", "text": "   ", "line": 1})
         response = websocket.receive_json()
-        assert response == {"type": "error", "detail": "comment text cannot be empty", "status": 400}
-
-
+        assert response == {
+            "type": "error",
+            "detail": "comment text cannot be empty",
+            "status": 400,
+        }

--- a/backend/tests/test_collaboration_ws.py
+++ b/backend/tests/test_collaboration_ws.py
@@ -264,3 +264,17 @@ def test_collaboration_rejects_unsupported_message_type():
             "type": "error",
             "detail": "Unsupported collaboration message type: unknown_event",
         }
+
+def test_collaboration_handles_invalid_json():
+    with client.websocket_connect("/collaboration/ws/session-invalid?name=Alice") as websocket:
+        websocket.receive_json()
+        websocket.receive_json()
+
+        websocket.send_text("not a valid json")
+        response = websocket.receive_json()
+
+        assert response == {
+            "type": "error",
+            "detail": "Invalid JSON payload",
+        }
+

--- a/backend/tests/test_collaboration_ws.py
+++ b/backend/tests/test_collaboration_ws.py
@@ -263,6 +263,7 @@ def test_collaboration_rejects_unsupported_message_type():
         assert response == {
             "type": "error",
             "detail": "Unsupported collaboration message type: unknown_event",
+            "status": 400,
         }
 
 def test_collaboration_handles_invalid_json():
@@ -276,5 +277,57 @@ def test_collaboration_handles_invalid_json():
         assert response == {
             "type": "error",
             "detail": "Invalid JSON payload",
+            "status": 400,
         }
+
+def test_collaboration_handles_missing_and_malformed_code_updates():
+    with client.websocket_connect("/collaboration/ws/session-malformed1?name=Alice") as websocket:
+        websocket.receive_json()
+        websocket.receive_json()
+
+        # Missing code
+        websocket.send_json({"type": "code_update", "version": 1})
+        response = websocket.receive_json()
+        assert response == {"type": "error", "detail": "code is required", "status": 400}
+
+        # Malformed version
+        websocket.send_json({"type": "code_update", "code": "print(1)", "version": "abc"})
+        response = websocket.receive_json()
+        assert response == {"type": "error", "detail": "version must be an integer", "status": 400}
+
+        # Code too long
+        websocket.send_json({"type": "code_update", "code": "A" * 50001, "version": 1})
+        response = websocket.receive_json()
+        assert response == {"type": "error", "detail": "code exceeds 50000 characters", "status": 400}
+
+def test_collaboration_handles_missing_and_malformed_cursor_updates():
+    with client.websocket_connect("/collaboration/ws/session-malformed2?name=Alice") as websocket:
+        websocket.receive_json()
+        websocket.receive_json()
+
+        # Missing cursor
+        websocket.send_json({"type": "cursor_update"})
+        response = websocket.receive_json()
+        assert response == {"type": "error", "detail": "cursor is required", "status": 400}
+
+        # Malformed cursor fields
+        websocket.send_json({"type": "cursor_update", "cursor": {"line": "abc"}})
+        response = websocket.receive_json()
+        assert response == {"type": "error", "detail": "cursor fields must be integers", "status": 400}
+
+def test_collaboration_handles_missing_and_malformed_comment_updates():
+    with client.websocket_connect("/collaboration/ws/session-malformed3?name=Alice") as websocket:
+        websocket.receive_json()
+        websocket.receive_json()
+
+        # Missing text
+        websocket.send_json({"type": "comment_added", "line": 1})
+        response = websocket.receive_json()
+        assert response == {"type": "error", "detail": "comment text is required", "status": 400}
+
+        # Empty text
+        websocket.send_json({"type": "comment_added", "text": "   ", "line": 1})
+        response = websocket.receive_json()
+        assert response == {"type": "error", "detail": "comment text cannot be empty", "status": 400}
+
 


### PR DESCRIPTION
Fixes #1332

Add robust manual validation for collaboration websocket inputs, returning a predictable status 400 in the error payload for missing or malformed fields.

---

## Description
<!-- What does this PR do? Be specific. -->

## Related Issue
<!-- Required — link the issue this PR fixes -->
Fixes #

## Type of change
- [ ] Bug fix
- [ ] New feature / enhancement
- [ ] Documentation update
- [ ] Test addition
- [ ] Refactor

## Checklist
<!-- All boxes must be checked before requesting review -->
- [ ] I have read [CONTRIBUTING.md](../CONTRIBUTING.md)
- [ ] My branch is up to date with `main`
- [ ] I have run `pytest -v` and all tests pass
- [ ] I have not introduced duplicate issues or features
- [ ] My PR title follows the format: `feat/fix/docs/test: short description`
- [ ] I have added tests for new features (Level 2 and 3 issues)
- [ ] No hardcoded secrets or API keys in my code
- [ ] This PR is linked to a GSSoC 2026 issue

## Screenshots (if frontend change)
<!-- Add before/after screenshots -->

## Test evidence
<!-- Paste pytest output here -->
```bash
pytest -v
# paste output
```