### PR TITLE
docs: clarify language support in README

### DIFF
--- a/README.md
+++ b/README.md
@@ -72,7 +72,7 @@ No account required for the core analysis. No API key needed. Works fully offlin
 |---|---|
 | **40+ Bug Patterns** | ZeroDivisionError, bare except, hardcoded secrets, eval/exec, memory leaks, XSS, NullPointerException, unsafe `unwrap()`, and more |
 
-| **5 Languages Detected** | Python, JavaScript, TypeScript, Java, C++ - the first 5 have dedicated bug-pattern checks today |
+| **5 Languages with Dedicated Bug Checks** | Python, JavaScript, TypeScript, Java, C++ - the first 5 have dedicated bug-pattern checks today |
 | **Project / ZIP Analysis** | `POST /analyze/zip/` scans up to 20 source files in an uploaded archive and returns one aggregated project score plus a per-file breakdown |
 | **Streaming Analysis (SSE)** | `GET/POST /analyze/stream` streams explanation → debugging → suggestions as they complete, instead of waiting for the full response |
 | **Live Collaboration (WebSocket)** | `WS /ws/{session_id}` — multiple users join a session, see each other's presence (name + colour), live code sync, and shared inline comments |


### PR DESCRIPTION
This PR updates the README to make the language support information clearer.

Changed “5 Languages Detected” to “5 Languages with Dedicated Bug Checks”
Clarifies that the five listed languages currently have dedicated bug-pattern checks
Documentation-only change; no code functionality is affected.