### PR TITLE
Expose observability in user data router

### DIFF
--- a/backend/app/logging_config.py
+++ b/backend/app/logging_config.py
@@ -46,6 +46,7 @@ COMPONENT_LOGGER_MAP: dict[str, str] = {
     "error_tracking": "ai_assistant.api",
     "upload": "app.routers.upload_file",
     "file_validator": "app.utils.file_validator",
+    "user_data": "app.routers.user_data",
     "main": "app.main",
 }
 

--- a/backend/app/observability.py
+++ b/backend/app/observability.py
@@ -157,6 +157,24 @@ UNSUBSCRIBE_GET_ATTEMPTS_TOTAL = Counter(
     labelnames=("result",),
 )
 
+USER_DATA_PURGE_ATTEMPTS_TOTAL = Counter(
+    "qyverixai_user_data_purge_attempts_total",
+    "Total number of self-service account/data purge attempts, labelled by result.",
+    labelnames=("result",),
+)
+
+USER_DATA_HISTORY_OPERATIONS_TOTAL = Counter(
+    "qyverixai_user_data_history_operations_total",
+    "Total number of history record operations via the user data router, labelled by operation and result.",
+    labelnames=("operation", "result"),
+)
+
+USER_DATA_FAVORITE_OPERATIONS_TOTAL = Counter(
+    "qyverixai_user_data_favorite_operations_total",
+    "Total number of favorite record operations via the user data router, labelled by operation and result.",
+    labelnames=("operation", "result"),
+)
+
 
 def initialise_app_info(version: str, ai_provider: str) -> None:
     """Set the app_info gauge once at startup so dashboards can display it."""

--- a/backend/app/routers/user_data.py
+++ b/backend/app/routers/user_data.py
@@ -1,11 +1,17 @@
+import logging
 from typing import cast
 
-from fastapi import APIRouter, Depends, HTTPException, Path, Query, status
+from fastapi import APIRouter, Depends, HTTPException, Path, Query, Request, status
 from sqlalchemy import CursorResult, delete, select
 from sqlalchemy.orm import Session
 
 from ..database import get_db
 from ..models import FavoriteResult, QueryHistory, User
+from ..observability import (
+    USER_DATA_FAVORITE_OPERATIONS_TOTAL,
+    USER_DATA_HISTORY_OPERATIONS_TOTAL,
+    USER_DATA_PURGE_ATTEMPTS_TOTAL,
+)
 from ..schemas import (
     FavoriteCreateRequest,
     FavoriteRecord,
@@ -16,9 +22,16 @@ from ..schemas import (
     UserDataPurgeResponse,
 )
 from ..security import get_current_user
+from ..services.audit import record_audit
 from ..services.user_deletion import preview_user_data_purge, purge_user_data
 
+logger = logging.getLogger("app.routers.user_data")
+
 router = APIRouter(prefix="/user", tags=["User Data"])
+
+
+def _client_ip(request: Request) -> str | None:
+    return request.client.host if request.client else None
 
 
 @router.get("/data-purge/preview", response_model=UserDataPurgePreviewResponse)
@@ -42,10 +55,51 @@ def preview_data_purge(
 @router.post("/data-purge", response_model=UserDataPurgeResponse)
 def purge_data(
     payload: UserDataPurgeRequest,
+    request: Request,
     current_user: User = Depends(get_current_user),
     db: Session = Depends(get_db),
 ):
-    result = purge_user_data(db, current_user, payload.confirmation)
+    try:
+        result = purge_user_data(db, current_user, payload.confirmation)
+    except HTTPException:
+        USER_DATA_PURGE_ATTEMPTS_TOTAL.labels(result="invalid_confirmation").inc()
+        logger.warning(
+            "user_data_purge_failed user_id=%s reason=invalid_confirmation",
+            current_user.id,
+        )
+        raise
+
+    if result.status == "deletion_already_scheduled":
+        USER_DATA_PURGE_ATTEMPTS_TOTAL.labels(result="already_scheduled").inc()
+        logger.info(
+            "user_data_purge_already_scheduled user_id=%s scheduled_for=%s",
+            current_user.id,
+            result.deletion_scheduled_for,
+        )
+    else:
+        USER_DATA_PURGE_ATTEMPTS_TOTAL.labels(result="scheduled").inc()
+        record_audit(
+            db,
+            actor=current_user,
+            action="user.self_delete",
+            target_type="user",
+            target_id=current_user.id,
+            details={
+                "scheduled_for": (
+                    result.deletion_scheduled_for.isoformat()
+                    if result.deletion_scheduled_for
+                    else None
+                )
+            },
+            ip_address=_client_ip(request),
+        )
+        db.commit()
+        logger.info(
+            "user_data_purge_scheduled user_id=%s scheduled_for=%s",
+            current_user.id,
+            result.deletion_scheduled_for,
+        )
+
     return UserDataPurgeResponse(
         status=result.status,
         history_deleted=result.history_deleted,
@@ -104,6 +158,15 @@ def create_history(
     db.commit()
     db.refresh(record)
 
+    USER_DATA_HISTORY_OPERATIONS_TOTAL.labels(
+        operation="create", result="success"
+    ).inc()
+    logger.info(
+        "user_history_created user_id=%s history_id=%s",
+        current_user.id,
+        record.id,
+    )
+
     return HistoryRecord(
         id=record.id,
         action=record.action,
@@ -125,12 +188,25 @@ def delete_history(
         )
     ).scalar_one_or_none()
     if record is None:
+        USER_DATA_HISTORY_OPERATIONS_TOTAL.labels(
+            operation="delete", result="not_found"
+        ).inc()
         raise HTTPException(
             status_code=status.HTTP_404_NOT_FOUND, detail="History record not found"
         )
 
     db.delete(record)
     db.commit()
+
+    USER_DATA_HISTORY_OPERATIONS_TOTAL.labels(
+        operation="delete", result="success"
+    ).inc()
+    logger.info(
+        "user_history_deleted user_id=%s history_id=%s",
+        current_user.id,
+        history_id,
+    )
+
     return {"status": "deleted", "history_id": history_id}
 
 
@@ -143,7 +219,16 @@ def clear_history(
         delete(QueryHistory).where(QueryHistory.user_id == current_user.id)
     )
     db.commit()
-    return {"status": "cleared", "deleted": cast(CursorResult, result).rowcount or 0}
+    deleted = cast(CursorResult, result).rowcount or 0
+
+    USER_DATA_HISTORY_OPERATIONS_TOTAL.labels(operation="clear", result="success").inc()
+    logger.info(
+        "user_history_cleared user_id=%s deleted=%s",
+        current_user.id,
+        deleted,
+    )
+
+    return {"status": "cleared", "deleted": deleted}
 
 
 @router.get("/favorites", response_model=list[FavoriteRecord])
@@ -195,6 +280,15 @@ def create_favorite(
     db.commit()
     db.refresh(record)
 
+    USER_DATA_FAVORITE_OPERATIONS_TOTAL.labels(
+        operation="create", result="success"
+    ).inc()
+    logger.info(
+        "user_favorite_created user_id=%s favorite_id=%s",
+        current_user.id,
+        record.id,
+    )
+
     return FavoriteRecord(
         id=record.id,
         title=record.title,
@@ -217,12 +311,25 @@ def delete_favorite(
         )
     ).scalar_one_or_none()
     if record is None:
+        USER_DATA_FAVORITE_OPERATIONS_TOTAL.labels(
+            operation="delete", result="not_found"
+        ).inc()
         raise HTTPException(
             status_code=status.HTTP_404_NOT_FOUND, detail="Favorite not found"
         )
 
     db.delete(record)
     db.commit()
+
+    USER_DATA_FAVORITE_OPERATIONS_TOTAL.labels(
+        operation="delete", result="success"
+    ).inc()
+    logger.info(
+        "user_favorite_deleted user_id=%s favorite_id=%s",
+        current_user.id,
+        favorite_id,
+    )
+
     return {"status": "deleted", "favorite_id": favorite_id}
 
 
@@ -235,4 +342,15 @@ def clear_favorites(
         delete(FavoriteResult).where(FavoriteResult.user_id == current_user.id)
     )
     db.commit()
-    return {"status": "cleared", "deleted": cast(CursorResult, result).rowcount or 0}
+    deleted = cast(CursorResult, result).rowcount or 0
+
+    USER_DATA_FAVORITE_OPERATIONS_TOTAL.labels(
+        operation="clear", result="success"
+    ).inc()
+    logger.info(
+        "user_favorites_cleared user_id=%s deleted=%s",
+        current_user.id,
+        deleted,
+    )
+
+    return {"status": "cleared", "deleted": deleted}

--- a/backend/tests/test_user_data_observability.py
+++ b/backend/tests/test_user_data_observability.py
@@ -1,0 +1,289 @@
+"""Tests verifying that the user data router increments observability counters
+and that self-service account deletion is recorded in the shared admin audit
+log (in addition to the existing UserDataPurgeAudit record)."""
+
+from __future__ import annotations
+
+import pytest
+from app import observability
+from app.database import Base, get_db
+from app.main import app as fastapi_app
+from app.models import AuditLog
+from app.services.user_deletion import CONFIRMATION_PHRASE
+from fastapi.testclient import TestClient
+from sqlalchemy import create_engine, select
+from sqlalchemy.orm import sessionmaker
+from sqlalchemy.pool import StaticPool
+
+TEST_ENGINE = create_engine(
+    "sqlite:///:memory:",
+    connect_args={"check_same_thread": False},
+    poolclass=StaticPool,
+)
+TEST_SESSION_LOCAL = sessionmaker(bind=TEST_ENGINE)
+
+
+def _override_db():
+    db = TEST_SESSION_LOCAL()
+    try:
+        yield db
+    finally:
+        db.close()
+
+
+@pytest.fixture
+def client():
+    previous_override = fastapi_app.dependency_overrides.get(get_db)
+    fastapi_app.dependency_overrides[get_db] = _override_db
+
+    with TestClient(fastapi_app) as test_client:
+        yield test_client
+
+    if previous_override is None:
+        fastapi_app.dependency_overrides.pop(get_db, None)
+    else:
+        fastapi_app.dependency_overrides[get_db] = previous_override
+
+
+@pytest.fixture(autouse=True)
+def _recreate_tables():
+    Base.metadata.drop_all(bind=TEST_ENGINE)
+    Base.metadata.create_all(bind=TEST_ENGINE)
+    yield
+    Base.metadata.drop_all(bind=TEST_ENGINE)
+
+
+def _signup(
+    client: TestClient, email: str, password: str = "StrongPass123!"
+) -> dict[str, str]:
+    response = client.post("/auth/signup", json={"email": email, "password": password})
+    assert response.status_code == 200
+    return {"Authorization": f"Bearer {response.json()['access_token']}"}
+
+
+def _counter_value(counter, **labels) -> float:
+    return counter.labels(**labels)._value.get()
+
+
+def _audit_actions(action: str) -> list[AuditLog]:
+    db = TEST_SESSION_LOCAL()
+    try:
+        return (
+            db.execute(select(AuditLog).where(AuditLog.action == action))
+            .scalars()
+            .all()
+        )
+    finally:
+        db.close()
+
+
+# ── Purge observability ───────────────────────────────────────────────────────
+
+
+def test_purge_success_increments_counter_and_writes_audit_log(client: TestClient):
+    headers = _signup(client, "obs_purge_success@example.com")
+
+    before = _counter_value(
+        observability.USER_DATA_PURGE_ATTEMPTS_TOTAL, result="scheduled"
+    )
+    response = client.post(
+        "/user/data-purge", headers=headers, json={"confirmation": CONFIRMATION_PHRASE}
+    )
+    after = _counter_value(
+        observability.USER_DATA_PURGE_ATTEMPTS_TOTAL, result="scheduled"
+    )
+
+    assert response.status_code == 200
+    assert after == before + 1
+
+    entries = _audit_actions("user.self_delete")
+    assert len(entries) == 1
+    assert entries[0].target_type == "user"
+
+
+def test_purge_invalid_confirmation_increments_counter_without_audit(
+    client: TestClient,
+):
+    headers = _signup(client, "obs_purge_invalid@example.com")
+
+    before = _counter_value(
+        observability.USER_DATA_PURGE_ATTEMPTS_TOTAL, result="invalid_confirmation"
+    )
+    response = client.post(
+        "/user/data-purge", headers=headers, json={"confirmation": "wrong phrase"}
+    )
+    after = _counter_value(
+        observability.USER_DATA_PURGE_ATTEMPTS_TOTAL, result="invalid_confirmation"
+    )
+
+    assert response.status_code == 400
+    assert after == before + 1
+    assert _audit_actions("user.self_delete") == []
+
+
+# ── History observability ─────────────────────────────────────────────────────
+
+
+def test_history_create_increments_counter(client: TestClient):
+    headers = _signup(client, "obs_history_create@example.com")
+
+    before = _counter_value(
+        observability.USER_DATA_HISTORY_OPERATIONS_TOTAL,
+        operation="create",
+        result="success",
+    )
+    client.post(
+        "/user/history",
+        headers=headers,
+        json={"action": "debugging", "code": "print(1)", "result_json": "{}"},
+    )
+    after = _counter_value(
+        observability.USER_DATA_HISTORY_OPERATIONS_TOTAL,
+        operation="create",
+        result="success",
+    )
+    assert after == before + 1
+
+
+def test_history_delete_not_found_increments_counter(client: TestClient):
+    headers = _signup(client, "obs_history_delete_missing@example.com")
+
+    before = _counter_value(
+        observability.USER_DATA_HISTORY_OPERATIONS_TOTAL,
+        operation="delete",
+        result="not_found",
+    )
+    response = client.delete("/user/history/999999", headers=headers)
+    after = _counter_value(
+        observability.USER_DATA_HISTORY_OPERATIONS_TOTAL,
+        operation="delete",
+        result="not_found",
+    )
+
+    assert response.status_code == 404
+    assert after == before + 1
+
+
+def test_history_delete_success_increments_counter(client: TestClient):
+    headers = _signup(client, "obs_history_delete_success@example.com")
+    created = client.post(
+        "/user/history",
+        headers=headers,
+        json={"action": "debugging", "code": "print(1)", "result_json": "{}"},
+    ).json()
+
+    before = _counter_value(
+        observability.USER_DATA_HISTORY_OPERATIONS_TOTAL,
+        operation="delete",
+        result="success",
+    )
+    response = client.delete(f"/user/history/{created['id']}", headers=headers)
+    after = _counter_value(
+        observability.USER_DATA_HISTORY_OPERATIONS_TOTAL,
+        operation="delete",
+        result="success",
+    )
+
+    assert response.status_code == 200
+    assert after == before + 1
+
+
+def test_history_clear_increments_counter(client: TestClient):
+    headers = _signup(client, "obs_history_clear@example.com")
+    client.post(
+        "/user/history",
+        headers=headers,
+        json={"action": "debugging", "code": "print(1)", "result_json": "{}"},
+    )
+
+    before = _counter_value(
+        observability.USER_DATA_HISTORY_OPERATIONS_TOTAL,
+        operation="clear",
+        result="success",
+    )
+    response = client.delete("/user/history", headers=headers)
+    after = _counter_value(
+        observability.USER_DATA_HISTORY_OPERATIONS_TOTAL,
+        operation="clear",
+        result="success",
+    )
+
+    assert response.status_code == 200
+    assert after == before + 1
+
+
+# ── Favorite observability ─────────────────────────────────────────────────────
+
+
+def test_favorite_create_increments_counter(client: TestClient):
+    headers = _signup(client, "obs_favorite_create@example.com")
+
+    before = _counter_value(
+        observability.USER_DATA_FAVORITE_OPERATIONS_TOTAL,
+        operation="create",
+        result="success",
+    )
+    client.post(
+        "/user/favorites",
+        headers=headers,
+        json={
+            "title": "Saved",
+            "action": "debugging",
+            "code": "print(1)",
+            "result_json": "{}",
+        },
+    )
+    after = _counter_value(
+        observability.USER_DATA_FAVORITE_OPERATIONS_TOTAL,
+        operation="create",
+        result="success",
+    )
+    assert after == before + 1
+
+
+def test_favorite_delete_not_found_increments_counter(client: TestClient):
+    headers = _signup(client, "obs_favorite_delete_missing@example.com")
+
+    before = _counter_value(
+        observability.USER_DATA_FAVORITE_OPERATIONS_TOTAL,
+        operation="delete",
+        result="not_found",
+    )
+    response = client.delete("/user/favorites/999999", headers=headers)
+    after = _counter_value(
+        observability.USER_DATA_FAVORITE_OPERATIONS_TOTAL,
+        operation="delete",
+        result="not_found",
+    )
+
+    assert response.status_code == 404
+    assert after == before + 1
+
+
+def test_favorite_clear_increments_counter(client: TestClient):
+    headers = _signup(client, "obs_favorite_clear@example.com")
+    client.post(
+        "/user/favorites",
+        headers=headers,
+        json={
+            "title": "Saved",
+            "action": "debugging",
+            "code": "print(1)",
+            "result_json": "{}",
+        },
+    )
+
+    before = _counter_value(
+        observability.USER_DATA_FAVORITE_OPERATIONS_TOTAL,
+        operation="clear",
+        result="success",
+    )
+    response = client.delete("/user/favorites", headers=headers)
+    after = _counter_value(
+        observability.USER_DATA_FAVORITE_OPERATIONS_TOTAL,
+        operation="clear",
+        result="success",
+    )
+
+    assert response.status_code == 200
+    assert after == before + 1


### PR DESCRIPTION
## Summary

Closes #1523.

`backend/app/routers/user_data.py` (account/data purge, history, favorites) had no domain-specific observability — only the blanket HTTP middleware metrics. This adds the same pattern already used in `routers/subscribe.py` and `services/database.py`:

- `USER_DATA_PURGE_ATTEMPTS_TOTAL` — labelled by `result` (`scheduled`, `already_scheduled`, `invalid_confirmation`)
- `USER_DATA_HISTORY_OPERATIONS_TOTAL` — labelled by `operation` (`create`/`delete`/`clear`) and `result` (`success`/`not_found`)
- `USER_DATA_FAVORITE_OPERATIONS_TOTAL` — same shape as history

Structured log lines (`app.routers.user_data`) are emitted for every mutation and failure, and `"user_data"` is registered in `logging_config.COMPONENT_LOGGER_MAP` so its verbosity can be tuned independently via `LOG_LEVEL_USER_DATA`.

**Bonus fix included in scope:** self-service account deletion previously wrote only to the internal `UserDataPurgeAudit` table, so it never showed up for admins. It's now also recorded via the existing `record_audit()` helper (`action="user.self_delete"`), so it appears in `GET /admin/audit-logs` right alongside admin-initiated deletions.

No API/schema changes, no behavior changes to existing responses — purely additive instrumentation.

### Known follow-up (not fixed here, out of scope)
While testing, I found that `security.py`'s `get_current_user` immediately 401s any user whose `deletion_status == "pending_deletion"`. That means the `purge_user_data()` "already scheduled" duplicate-request branch can never actually be reached through the API today (the user is locked out after the first successful request). Flagging it here rather than fixing it silently, since it's unrelated to this issue.

## Test plan
- [x] Added `backend/tests/test_user_data_observability.py` — 9 tests asserting counter increments for purge (success/invalid confirmation), history (create/delete/delete-not-found/clear), and favorites (create/delete-not-found/clear), plus asserting the new `AuditLog` row on successful purge.
- [x] `pytest backend/tests/test_user_data_observability.py backend/tests/test_user_data_purge.py backend/tests/test_user_data_validation.py backend/tests/test_auth_and_user_data.py backend/tests/test_admin_audit.py` — all pass.
- [x] `black --check` / `isort --check` / `flake8` clean on all changed files.

🤖 Generated with [Claude Code](https://claude.com/claude-code)