### PR TITLE
Refactor shared logic in user data router

### DIFF
--- a/backend/app/routers/user_data.py
+++ b/backend/app/routers/user_data.py
@@ -35,12 +35,16 @@ def _list_owned_records(db: Session, model, user_id: int, limit: int, offset: in
     )
 
 
-def _get_owned_record_or_404(db: Session, model, record_id: int, user_id: int, not_found_detail: str):
+def _get_owned_record_or_404(
+    db: Session, model, record_id: int, user_id: int, not_found_detail: str
+):
     record = db.execute(
         select(model).where(model.id == record_id, model.user_id == user_id)
     ).scalar_one_or_none()
     if record is None:
-        raise HTTPException(status_code=status.HTTP_404_NOT_FOUND, detail=not_found_detail)
+        raise HTTPException(
+            status_code=status.HTTP_404_NOT_FOUND, detail=not_found_detail
+        )
     return record
 
 

--- a/backend/app/routers/user_data.py
+++ b/backend/app/routers/user_data.py
@@ -21,6 +21,35 @@ from ..services.user_deletion import preview_user_data_purge, purge_user_data
 router = APIRouter(prefix="/user", tags=["User Data"])
 
 
+def _list_owned_records(db: Session, model, user_id: int, limit: int, offset: int):
+    return (
+        db.execute(
+            select(model)
+            .where(model.user_id == user_id)
+            .order_by(model.id.desc())
+            .limit(limit)
+            .offset(offset)
+        )
+        .scalars()
+        .all()
+    )
+
+
+def _get_owned_record_or_404(db: Session, model, record_id: int, user_id: int, not_found_detail: str):
+    record = db.execute(
+        select(model).where(model.id == record_id, model.user_id == user_id)
+    ).scalar_one_or_none()
+    if record is None:
+        raise HTTPException(status_code=status.HTTP_404_NOT_FOUND, detail=not_found_detail)
+    return record
+
+
+def _clear_owned_records(db: Session, model, user_id: int) -> int:
+    result = db.execute(delete(model).where(model.user_id == user_id))
+    db.commit()
+    return cast(CursorResult, result).rowcount or 0
+
+
 @router.get("/data-purge/preview", response_model=UserDataPurgePreviewResponse)
 def preview_data_purge(
     current_user: User = Depends(get_current_user),
@@ -64,17 +93,7 @@ def list_history(
     current_user: User = Depends(get_current_user),
     db: Session = Depends(get_db),
 ):
-    records = (
-        db.execute(
-            select(QueryHistory)
-            .where(QueryHistory.user_id == current_user.id)
-            .order_by(QueryHistory.id.desc())
-            .limit(limit)
-            .offset(offset)
-        )
-        .scalars()
-        .all()
-    )
+    records = _list_owned_records(db, QueryHistory, current_user.id, limit, offset)
 
     return [
         HistoryRecord(
@@ -119,15 +138,9 @@ def delete_history(
     current_user: User = Depends(get_current_user),
     db: Session = Depends(get_db),
 ):
-    record = db.execute(
-        select(QueryHistory).where(
-            QueryHistory.id == history_id, QueryHistory.user_id == current_user.id
-        )
-    ).scalar_one_or_none()
-    if record is None:
-        raise HTTPException(
-            status_code=status.HTTP_404_NOT_FOUND, detail="History record not found"
-        )
+    record = _get_owned_record_or_404(
+        db, QueryHistory, history_id, current_user.id, "History record not found"
+    )
 
     db.delete(record)
     db.commit()
@@ -139,11 +152,8 @@ def clear_history(
     current_user: User = Depends(get_current_user),
     db: Session = Depends(get_db),
 ):
-    result = db.execute(
-        delete(QueryHistory).where(QueryHistory.user_id == current_user.id)
-    )
-    db.commit()
-    return {"status": "cleared", "deleted": cast(CursorResult, result).rowcount or 0}
+    deleted = _clear_owned_records(db, QueryHistory, current_user.id)
+    return {"status": "cleared", "deleted": deleted}
 
 
 @router.get("/favorites", response_model=list[FavoriteRecord])
@@ -153,17 +163,7 @@ def list_favorites(
     current_user: User = Depends(get_current_user),
     db: Session = Depends(get_db),
 ):
-    records = (
-        db.execute(
-            select(FavoriteResult)
-            .where(FavoriteResult.user_id == current_user.id)
-            .order_by(FavoriteResult.id.desc())
-            .limit(limit)
-            .offset(offset)
-        )
-        .scalars()
-        .all()
-    )
+    records = _list_owned_records(db, FavoriteResult, current_user.id, limit, offset)
 
     return [
         FavoriteRecord(
@@ -211,15 +211,9 @@ def delete_favorite(
     current_user: User = Depends(get_current_user),
     db: Session = Depends(get_db),
 ):
-    record = db.execute(
-        select(FavoriteResult).where(
-            FavoriteResult.id == favorite_id, FavoriteResult.user_id == current_user.id
-        )
-    ).scalar_one_or_none()
-    if record is None:
-        raise HTTPException(
-            status_code=status.HTTP_404_NOT_FOUND, detail="Favorite not found"
-        )
+    record = _get_owned_record_or_404(
+        db, FavoriteResult, favorite_id, current_user.id, "Favorite not found"
+    )
 
     db.delete(record)
     db.commit()
@@ -231,8 +225,5 @@ def clear_favorites(
     current_user: User = Depends(get_current_user),
     db: Session = Depends(get_db),
 ):
-    result = db.execute(
-        delete(FavoriteResult).where(FavoriteResult.user_id == current_user.id)
-    )
-    db.commit()
-    return {"status": "cleared", "deleted": cast(CursorResult, result).rowcount or 0}
+    deleted = _clear_owned_records(db, FavoriteResult, current_user.id)
+    return {"status": "cleared", "deleted": deleted}

--- a/frontend/tests/e2e/user-data-router.spec.js
+++ b/frontend/tests/e2e/user-data-router.spec.js
@@ -1,0 +1,120 @@
+import { test, expect } from '@playwright/test';
+
+// Exercises backend/app/routers/user_data.py end to end over real HTTP
+// (no mocking) to confirm the shared list/delete/clear helpers behave
+// identically to the pre-refactor per-resource implementations, for both
+// the history and favorites resources, and don't leak data across users.
+
+function uniqueEmail(label) {
+  return `${label}-${Date.now()}-${Math.floor(Math.random() * 1e6)}@example.com`;
+}
+
+async function signup(request, email) {
+  const res = await request.post('/auth/signup', {
+    data: { email, password: 'securepassword123' },
+  });
+  expect(res.ok()).toBeTruthy();
+  const body = await res.json();
+  return { token: body.access_token, headers: { Authorization: `Bearer ${body.access_token}` } };
+}
+
+for (const resource of [
+  {
+    name: 'history',
+    listPath: '/user/history',
+    itemPath: (id) => `/user/history/${id}`,
+    payload: () => ({
+      action: 'analyze',
+      code: 'def hello(): pass',
+      result_json: '{"status": "ok"}',
+    }),
+    notFoundDetail: 'History record not found',
+  },
+  {
+    name: 'favorites',
+    listPath: '/user/favorites',
+    itemPath: (id) => `/user/favorites/${id}`,
+    payload: () => ({
+      title: 'My snippet',
+      action: 'analyze',
+      code: 'def hello(): pass',
+      result_json: '{"status": "ok"}',
+    }),
+    notFoundDetail: 'Favorite not found',
+  },
+]) {
+  test.describe(`${resource.name} router`, () => {
+    test(`create, list (paginated), delete-one and clear-all round trip`, async ({ request }) => {
+      const { headers } = await signup(request, uniqueEmail(`user-${resource.name}`));
+
+      const ids = [];
+      for (let i = 0; i < 3; i++) {
+        const res = await request.post(resource.listPath, { headers, data: resource.payload() });
+        expect(res.status()).toBe(200);
+        ids.push((await res.json()).id);
+      }
+
+      // Pagination: limit=2 should return only the 2 most recent records.
+      const paged = await request.get(`${resource.listPath}?limit=2&offset=0`, { headers });
+      expect(paged.ok()).toBeTruthy();
+      const pagedBody = await paged.json();
+      expect(pagedBody).toHaveLength(2);
+      expect(pagedBody[0].id).toBe(ids[2]);
+      expect(pagedBody[1].id).toBe(ids[1]);
+
+      const full = await request.get(resource.listPath, { headers });
+      expect((await full.json())).toHaveLength(3);
+
+      // Delete one record, then confirm it's gone and the rest remain.
+      const del = await request.delete(resource.itemPath(ids[0]), { headers });
+      expect(del.status()).toBe(200);
+
+      const afterDelete = await request.get(resource.listPath, { headers });
+      const remainingIds = (await afterDelete.json()).map((r) => r.id);
+      expect(remainingIds.sort()).toEqual([ids[1], ids[2]].sort());
+
+      // Deleting the same record again must 404 with the resource's own message.
+      const redelete = await request.delete(resource.itemPath(ids[0]), { headers });
+      expect(redelete.status()).toBe(404);
+      expect((await redelete.json()).detail).toBe(resource.notFoundDetail);
+
+      // Clear-all reports the correct remaining count and empties the list.
+      const clear = await request.delete(resource.listPath, { headers });
+      expect(clear.status()).toBe(200);
+      expect((await clear.json()).deleted).toBe(2);
+
+      const afterClear = await request.get(resource.listPath, { headers });
+      expect(await afterClear.json()).toEqual([]);
+    });
+
+    test('one user cannot read or delete another user\'s records', async ({ request }) => {
+      const owner = await signup(request, uniqueEmail(`owner-${resource.name}`));
+      const intruder = await signup(request, uniqueEmail(`intruder-${resource.name}`));
+
+      const create = await request.post(resource.listPath, {
+        headers: owner.headers,
+        data: resource.payload(),
+      });
+      const ownedId = (await create.json()).id;
+
+      // The intruder's own list must not include the owner's record.
+      const intruderList = await request.get(resource.listPath, { headers: intruder.headers });
+      expect((await intruderList.json()).map((r) => r.id)).not.toContain(ownedId);
+
+      // Deleting by ID cross-user must 404, not succeed or leak existence.
+      const crossDelete = await request.delete(resource.itemPath(ownedId), {
+        headers: intruder.headers,
+      });
+      expect(crossDelete.status()).toBe(404);
+
+      // The record must still exist for its real owner afterwards.
+      const ownerList = await request.get(resource.listPath, { headers: owner.headers });
+      expect((await ownerList.json()).map((r) => r.id)).toContain(ownedId);
+    });
+
+    test('requires authentication', async ({ request }) => {
+      const res = await request.get(resource.listPath);
+      expect(res.status()).toBe(401);
+    });
+  });
+}


### PR DESCRIPTION
Closes #1524

## Summary
`backend/app/routers/user_data.py` had the `history` and `favorites` endpoints each reimplementing the same paginated list, ownership-checked delete, and clear-all query logic. This extracts that duplication into three private helpers (`_list_owned_records`, `_get_owned_record_or_404`, `_clear_owned_records`) shared by both resources.

No route paths, request/response schemas, status codes, or error messages changed.

## Test plan
- [x] Existing targeted tests pass unchanged: `test_auth_and_user_data.py`, `test_user_data_validation.py`, `test_user_data_purge.py` (13/13)
- [x] `flake8` clean on the changed file
- [x] Added `frontend/tests/e2e/user-data-router.spec.js` — a Playwright e2e spec hitting the real running server (no mocks) covering, for both `history` and `favorites`: create/list/pagination, delete-one, 404 on re-delete, clear-all count, and cross-user ownership isolation (a user cannot list, read, or delete another user's records)
- [x] Existing Playwright browser specs (`analyze`, `history-pagination`, `empty-states`) pass unchanged — no regression elsewhere