### PR TITLE
Feat/ai suggested fix preview

### DIFF
--- a/README.md
+++ b/README.md
@@ -50,7 +50,7 @@ QyverixAI is a code analysis workspace. Paste any code - or drop a whole project
 | | What you get |
 |---|---|
 | **Explain** | Language detection, plain-English summary, complexity estimate, function and class inventory |
-| **Debug** | 45+ pattern checks across 5 languages (plus AST-based deep analysis for Python), with exact line numbers, code snippets, and fix suggestions |
+| **Debug** | 45+ pattern checks across 5 languages (plus AST-based deep analysis for Python), with exact line numbers, code snippets, concrete fix suggestions, and before/after diff previews |
 | **Improve** | Documentation gaps, error handling, testing, type safety - plus a 0-100 quality score, letter grade A–F, and a before/after diff view |
 | **Project Mode** | Upload a `.zip`, get one aggregated score across every file inside it |
 | **Ask AI** | Chat about your specific code - answered by an LLM when configured, or a rule-based fallback when not |
@@ -71,7 +71,7 @@ No account required for the core analysis. No API key needed. Works fully offlin
 | Feature | Detail |
 |---|---|
 | **40+ Bug Patterns** | ZeroDivisionError, bare except, hardcoded secrets, eval/exec, memory leaks, XSS, NullPointerException, unsafe `unwrap()`, and more |
-
+| **AI Suggested Fix Preview** | Automatically generates corrected code snippets (`fixed_code`) and color-coded line diffs (`diff`) for fixable issues with copy buttons, leaving original code unmodified |
 | **5 Languages with Dedicated Bug Checks** | Python, JavaScript, TypeScript, Java, and C++ have dedicated bug-pattern checks today |
 | **Project / ZIP Analysis** | `POST /analyze/zip/` scans up to 20 source files in an uploaded archive and returns one aggregated project score plus a per-file breakdown |
 | **Streaming Analysis (SSE)** | `GET/POST /analyze/stream` streams explanation → debugging → suggestions as they complete, instead of waiting for the full response |
@@ -259,7 +259,7 @@ Returns a plain-English breakdown of the code.
 
 ### `POST /debugging/`
 
-Returns detected issues with line numbers, code snippets, and fix suggestions. For Python, this also includes AST-based findings (unused imports, unused arguments, dead code).
+Returns detected issues with line numbers, code snippets, fix suggestions, and **AI Suggested Fix Previews** (`fixed_code` and line-level `diff` data for supported fixable patterns). For Python, this also includes AST-based findings (unused imports, unused arguments, dead code).
 
 ```json
 {
@@ -270,7 +270,13 @@ Returns detected issues with line numbers, code snippets, and fix suggestions. F
       "description": "Potential division by zero - divisor may be 0 at runtime.",
       "suggestion": "Guard the divisor: if b == 0: return None",
       "severity": "error",
-      "code_snippet": "result = a / b"
+      "code_snippet": "result = a / b",
+      "fixed_code": "if b == 0:\n    return None\nresult = a / b",
+      "diff": [
+        { "type": "added", "line": "if b == 0:", "prefix": "+ " },
+        { "type": "added", "line": "    return None", "prefix": "+ " },
+        { "type": "equal", "line": "result = a / b", "prefix": "  " }
+      ]
     }
   ],
   "summary": "Found 1 issue: 1 error, 0 warnings, 0 info.",

--- a/backend/app/schemas.py
+++ b/backend/app/schemas.py
@@ -83,6 +83,15 @@ class Issue(BaseModel):
         description="A few lines of surrounding context to help locate the issue.",
         example="def divide(a, b):\n    return a / b  # issue here",
     )
+    fixed_code: str | None = Field(
+        default=None,
+        description="Suggested corrected version of the offending code snippet.",
+        example="    if b == 0:\n        return None\n    return a / b",
+    )
+    diff: list[dict] | None = Field(
+        default=None,
+        description="Line-level diff between original snippet and fixed code.",
+    )
 
 
 class DebuggingResponse(BaseModel):

--- a/backend/app/services/code_assistant.py
+++ b/backend/app/services/code_assistant.py
@@ -6,10 +6,12 @@ Covers 40+ patterns across Python, JavaScript, TypeScript, Java, C++, PHP and Ru
 from __future__ import annotations
 
 import ast
+import difflib
 import logging
 import re
 import time
 from dataclasses import dataclass, field
+from typing import Any
 
 from .ast_analyzer import analyze as ast_analyze
 from .llm_analysis import LLMAnalysisError, llm_analysis_client
@@ -836,6 +838,293 @@ def _is_multiline_pattern(pattern: str) -> bool:
     return any(token in pattern for token in (r"\n", r"[\s\S]", r"[\d\D]", r"[\w\W]"))
 
 
+def compute_line_diff(original: str, fixed: str) -> list[dict[str, Any]]:
+    """Compute a line-level diff between original and fixed snippets.
+
+    Args:
+        original: The original code snippet.
+        fixed: The suggested fixed code snippet.
+
+    Returns:
+        A list of diff entries, each containing:
+        - `type`: Change type ('equal', 'added', or 'removed')
+        - `line`: Line text content
+        - `content`: Line text content (alias for compatibility)
+        - `prefix`: Diff prefix ('  ', '+ ', or '- ')
+    """
+    orig_lines = original.splitlines()
+    fixed_lines = fixed.splitlines()
+    matcher = difflib.SequenceMatcher(None, orig_lines, fixed_lines)
+    diff: list[dict[str, Any]] = []
+
+    for tag, i1, i2, j1, j2 in matcher.get_opcodes():
+        if tag == "equal":
+            for line in orig_lines[i1:i2]:
+                diff.append(
+                    {"type": "equal", "line": line, "content": line, "prefix": "  "}
+                )
+        elif tag == "delete":
+            for line in orig_lines[i1:i2]:
+                diff.append(
+                    {"type": "removed", "line": line, "content": line, "prefix": "- "}
+                )
+        elif tag == "insert":
+            for line in fixed_lines[j1:j2]:
+                diff.append(
+                    {"type": "added", "line": line, "content": line, "prefix": "+ "}
+                )
+        elif tag == "replace":
+            for line in orig_lines[i1:i2]:
+                diff.append(
+                    {"type": "removed", "line": line, "content": line, "prefix": "- "}
+                )
+            for line in fixed_lines[j1:j2]:
+                diff.append(
+                    {"type": "added", "line": line, "content": line, "prefix": "+ "}
+                )
+
+    return diff
+
+
+def generate_issue_fix(
+    issue_type: str,
+    snippet: str,
+    code: str,
+    line: int | None = None,
+    language: str = "Python",
+) -> str | None:
+    """Generate a corrected version of the code snippet for a detected issue.
+
+    Only generates a fix if there is a reliable, high-confidence correction.
+    If the issue has no reliable automatic fix, returns None.
+
+    Args:
+        issue_type: Name/type of the detected issue.
+        snippet: The offending code snippet.
+        code: The entire source code context.
+        line: The 1-based line number where the issue was detected.
+        language: Programming language of the code.
+
+    Returns:
+        The corrected code snippet string, or None if no reliable fix exists.
+    """
+    if not snippet:
+        return None
+
+    norm_type = (issue_type or "").strip()
+    norm_lang = (language or "").strip().lower()
+
+    # ── Python Fixes ────────────────────────────────────────────────────────
+    if norm_type == "ZeroDivisionError":
+        m = re.search(r"(\w+)\s*/\s*(\w+)", snippet)
+        if m:
+            divisor = m.group(2)
+            leading = snippet[: len(snippet) - len(snippet.lstrip())]
+            return f"{leading}if {divisor} == 0:\n{leading}    return None\n{snippet}"
+
+    elif norm_type == "Bare Except":
+        if re.search(r"except\s*:", snippet):
+            return re.sub(r"except\s*:", "except Exception as e:", snippet)
+
+    elif norm_type in ("Eval Usage", "Eval"):
+        if norm_lang in ("javascript", "typescript", "js", "ts"):
+            if re.search(r"\beval\s*\(", snippet):
+                return re.sub(r"\beval\s*\(", "JSON.parse(", snippet)
+        else:
+            if re.search(r"\beval\s*\(", snippet):
+                return re.sub(r"\beval\s*\(", "ast.literal_eval(", snippet)
+
+    elif norm_type in ("Mutable Default Arg", "Mutable Default Argument"):
+        if re.search(r"=\s*(\[\]|\{\}|\(\))", snippet):
+            return re.sub(r"=\s*(\[\]|\{\}|\(\))", "=None", snippet)
+
+    elif norm_type == "Hardcoded Secret":
+        m = re.search(r"(password|secret|api_key|token|passwd)", snippet, re.IGNORECASE)
+        if m:
+            var_name = m.group(1).upper()
+            if norm_lang in ("javascript", "typescript", "js", "ts"):
+                return re.sub(
+                    r"['\"][^'\"]{4,}['\"]", f"process.env.{var_name}", snippet
+                )
+            elif norm_lang in ("java", "cpp", "c++"):
+                return re.sub(
+                    r"['\"][^'\"]{4,}['\"]", f'System.getenv("{var_name}")', snippet
+                )
+            else:
+                return re.sub(
+                    r"['\"][^'\"]{4,}['\"]", f'os.getenv("{var_name}")', snippet
+                )
+
+    elif norm_type == "Print Debugging":
+        if re.search(r"\bprint\s*\(", snippet):
+            return re.sub(r"\bprint\s*\(", "logging.debug(", snippet)
+
+    elif norm_type == "Comparison to None":
+        fixed = snippet
+        if re.search(r"==\s*None\b", fixed):
+            fixed = re.sub(r"==\s*None\b", "is None", fixed)
+        if re.search(r"!=\s*None\b", fixed):
+            fixed = re.sub(r"!=\s*None\b", "is not None", fixed)
+        if fixed != snippet:
+            return fixed
+
+    elif norm_type == "Assert in Production":
+        m = re.match(r"^(\s*)assert\s+(.+)$", snippet)
+        if m:
+            indent = m.group(1)
+            cond = m.group(2).rstrip(";")
+            return f'{indent}if not ({cond}):\n{indent}    raise AssertionError("Assertion failed")'
+
+    elif norm_type == "Missing __init__":
+        m = re.match(r"^(\s*)class\s+\w+.*:$", snippet)
+        if m:
+            indent = m.group(1)
+            return f"{snippet}\n{indent}    def __init__(self):\n{indent}        pass"
+
+    # ── JavaScript / TypeScript Fixes ────────────────────────────────────────
+    elif norm_type == "Var Usage":
+        if re.search(r"\bvar\s+", snippet):
+            return re.sub(r"\bvar\s+", "const ", snippet)
+
+    elif norm_type == "== Instead of ===":
+        fixed = snippet
+        fixed = re.sub(r"(?<![=!])==(?![=])", "===", fixed)
+        fixed = re.sub(r"(?<![=!])!=(?![=])", "!==", fixed)
+        if fixed != snippet:
+            return fixed
+
+    elif norm_type == "Console.log Left In":
+        leading = snippet[: len(snippet) - len(snippet.lstrip())]
+        return f"{leading}// {snippet.lstrip()}"
+
+    elif norm_type == "Typeof Equality Issue":
+        if re.search(r'typeof\s+\w+\s*==\s*["\']', snippet):
+            return re.sub(r'(typeof\s+\w+\s*)==(\s*["\'])', r"\1===\2", snippet)
+
+    elif norm_type == "setTimeout String Usage":
+        m = re.search(r'setTimeout\s*\(\s*["\'](.*?)["\']\s*,\s*(\d+)\s*\)', snippet)
+        if m:
+            return re.sub(
+                r'setTimeout\s*\(\s*["\'](.*?)["\']\s*,\s*(\d+)\s*\)',
+                r"setTimeout(() => { \1; }, \2)",
+                snippet,
+            )
+
+    elif norm_type == "Any Type":
+        if re.search(r":\s*any\b", snippet):
+            return re.sub(r":\s*any\b", ": unknown", snippet)
+
+    elif norm_type == "Non-null Assertion":
+        if re.search(r"\w+![\.\[;,\s\)\}\]]", snippet):
+            return re.sub(r"(\w+)!([\.\[;,\s\)\}\]])", r"\1\2", snippet)
+
+    elif norm_type == "Promise Not Awaited":
+        if re.search(r"(?<!await\s)\bfetch\s*\(", snippet):
+            return re.sub(r"(?<!await\s)\b(fetch\s*\()", r"await \1", snippet)
+
+    elif norm_type == "InnerHTML XSS":
+        if re.search(r"\.innerHTML\s*=", snippet):
+            return re.sub(r"\.innerHTML\s*=", ".textContent =", snippet)
+
+    # ── Java Fixes ──────────────────────────────────────────────────────────
+    elif norm_type == "String == Comparison":
+        fixed = snippet
+        fixed = re.sub(r'(\w+)\s*==\s*("[^"]+")', r"Objects.equals(\1, \2)", fixed)
+        fixed = re.sub(r'("[^"]+")\s*==\s*(\w+)', r"\1.equals(\2)", fixed)
+        if fixed != snippet:
+            return fixed
+
+    elif norm_type == "Raw Type":
+        if re.search(
+            r"\b(List|Map|Set|Collection)\s+(\w+)\s*=\s*new\s+([\w\.]+)\(\);", snippet
+        ):
+            return re.sub(
+                r"\b(List|Map|Set|Collection)\s+(\w+)\s*=\s*new\s+([\w\.]+)\(\);",
+                r"\1<Object> \2 = new \3<>();",
+                snippet,
+            )
+
+    elif norm_type == "System.exit in Library":
+        if re.search(r"System\.exit\s*\(", snippet):
+            return re.sub(
+                r"System\.exit\s*\([^)]*\)\s*;",
+                'throw new IllegalStateException("Execution terminated");',
+                snippet,
+            )
+
+    # ── C++ Fixes ───────────────────────────────────────────────────────────
+    elif norm_type == "Void Main":
+        if re.search(r"\bvoid\s+main\s*\(", snippet):
+            return re.sub(r"\bvoid\s+main\s*\(", "int main(", snippet)
+
+    elif norm_type == "Single Quotes for String":
+        if re.search(r"'[^'\\]{2,}'", snippet):
+            return re.sub(r"'([^'\\]{2,})'", r'"\1"', snippet)
+
+    elif norm_type == "Missing Semicolon":
+        if not snippet.rstrip().endswith(";"):
+            return snippet.rstrip() + ";"
+
+    elif norm_type == "Missing Hash in Include":
+        if re.search(r"^\s*include\s*[<\"]", snippet):
+            return re.sub(r"^\s*include\s*([<\"])", r"#include \1", snippet)
+
+    elif norm_type == "Semicolon After Loop":
+        if re.search(r"\b(for|while)\s*\([^)]*\)\s*;", snippet):
+            return re.sub(r"(\b(?:for|while)\s*\([^)]*\))\s*;\s*$", r"\1", snippet)
+
+    elif norm_type == "Type Mismatch: String to Int":
+        if re.search(r"\b(int|long|short)\s+[a-zA-Z_]\w*\s*=\s*\"[^\"]*\"", snippet):
+            return re.sub(
+                r"\b(int|long|short)\s+(\w+\s*=\s*\"[^\"]*\")",
+                r"std::string \2",
+                snippet,
+            )
+
+    elif norm_type == "Unsafe gets/scanf":
+        if re.search(r"\bgets\s*\(", snippet):
+            return re.sub(
+                r"\bgets\s*\(\s*(\w+)\s*\);?", r"fgets(\1, sizeof(\1), stdin);", snippet
+            )
+
+    elif norm_type == "Using namespace std":
+        if re.search(r"using\s+namespace\s+std\s*;", snippet):
+            return "// using namespace std; // Prefer explicit std:: prefix"
+
+    # ── PHP Fixes ───────────────────────────────────────────────────────────
+    elif norm_type == "PHP MySQL Deprecated":
+        if re.search(r"\bmysql_\w+\s*\(", snippet):
+            return re.sub(r"\bmysql_(\w+)\s*\(", r"mysqli_\1($conn, ", snippet)
+
+    elif norm_type == "PHP XSS":
+        if re.search(r"echo\s+.*\$_(GET|POST|REQUEST|COOKIE)", snippet):
+            return re.sub(
+                r"echo\s+([^;]+);?",
+                r"echo htmlspecialchars(\1, ENT_QUOTES, 'UTF-8');",
+                snippet,
+            )
+
+    elif norm_type == "PHP Error Suppression":
+        if re.search(r"@\w+\s*\(", snippet):
+            return re.sub(r"@(\w+\s*\()", r"\1", snippet)
+
+    # ── Rust Fixes ──────────────────────────────────────────────────────────
+    elif norm_type == "Unwrap Usage":
+        if re.search(r"\.unwrap\s*\(\s*\)", snippet):
+            return re.sub(r"\.unwrap\s*\(\s*\)", ".unwrap_or_default()", snippet)
+
+    # ── AST Analysis Fixes ──────────────────────────────────────────────────
+    elif norm_type == "Unused Import":
+        leading = snippet[: len(snippet) - len(snippet.lstrip())]
+        return f"{leading}# unused: {snippet.lstrip()}"
+
+    elif norm_type == "Unreachable Code":
+        leading = snippet[: len(snippet) - len(snippet.lstrip())]
+        return f"{leading}# unreachable: {snippet.lstrip()}"
+
+    return None
+
+
 def run_bug_detection(code: str, language: str) -> list[dict]:
     """Run rule-based bug detection for the provided source code.
 
@@ -844,7 +1133,7 @@ def run_bug_detection(code: str, language: str) -> list[dict]:
         language: The detected or selected programming language.
 
     Returns:
-        A list of detected issues with metadata and suggestions.
+        A list of detected issues with metadata, suggestions, fixed_code, and diff.
     """
     from .ast_analyzer import analyze_python_ast
     from .line_utils import format_code_snippet
@@ -937,6 +1226,29 @@ def run_bug_detection(code: str, language: str) -> list[dict]:
                     found.append(issue)
         except SyntaxError:
             pass
+
+    # Enrich issues with fix preview (fixed_code and line-level diff)
+    for item in found:
+        snippet = item.get("code_snippet") or item.get("snippet") or ""
+        if not snippet and item.get("line"):
+            line_idx = item["line"] - 1
+            snippet = lines[line_idx].strip() if 0 <= line_idx < len(lines) else ""
+        if "code_snippet" not in item:
+            item["code_snippet"] = snippet
+
+        fixed = generate_issue_fix(
+            item.get("type", ""),
+            snippet,
+            code,
+            item.get("line"),
+            language,
+        )
+        if fixed is not None and fixed != snippet:
+            item["fixed_code"] = fixed
+            item["diff"] = compute_line_diff(snippet, fixed)
+        else:
+            item["fixed_code"] = None
+            item["diff"] = None
 
     return found
 

--- a/backend/tests/test_endpoints.py
+++ b/backend/tests/test_endpoints.py
@@ -503,6 +503,68 @@ def test_debug_issue_has_required_fields():
         assert "suggestion" in issue
         assert "severity" in issue
         assert issue["severity"] in ("error", "warning", "info")
+        assert "fixed_code" in issue
+        assert "diff" in issue
+
+
+def test_debug_fixable_pattern_returns_fixed_code_and_diff():
+    code = "try:\n    pass\nexcept:\n    pass"
+    r = client.post("/debugging/", json={"code": code, "language": "python"})
+    assert r.status_code == 200
+    d = r.json()
+    assert d["clean"] is False
+    issues = d["issues"]
+    bare_except_issue = next((i for i in issues if i["type"] == "Bare Except"), None)
+    assert bare_except_issue is not None
+    assert bare_except_issue["fixed_code"] is not None
+    assert "except Exception as e:" in bare_except_issue["fixed_code"]
+    assert bare_except_issue["diff"] is not None
+    assert isinstance(bare_except_issue["diff"], list)
+    assert len(bare_except_issue["diff"]) > 0
+    diff_types = [item["type"] for item in bare_except_issue["diff"]]
+    assert "removed" in diff_types or "added" in diff_types
+
+
+def test_debug_unfixable_pattern_returns_null_fixed_code():
+    code = "exec('print(123)')"
+    r = client.post("/debugging/", json={"code": code, "language": "python"})
+    assert r.status_code == 200
+    d = r.json()
+    exec_issue = next((i for i in d["issues"] if i["type"] == "Exec Usage"), None)
+    assert exec_issue is not None
+    assert exec_issue["fixed_code"] is None
+    assert exec_issue["diff"] is None
+
+
+def test_debug_multiple_issues_return_independent_fixes():
+    code = "var x = 1;\nif (x == None) {\n    exec('bad');\n}"
+    r = client.post("/debugging/", json={"code": code, "language": "javascript"})
+    assert r.status_code == 200
+    d = r.json()
+    issues = d["issues"]
+    assert len(issues) >= 2
+
+    # Each issue must have its own independent fixed_code and diff entries
+    for issue in issues:
+        assert "type" in issue
+        assert "fixed_code" in issue
+        assert "diff" in issue
+        if issue["fixed_code"] is not None:
+            assert isinstance(issue["diff"], list)
+            assert len(issue["diff"]) > 0
+            assert any(
+                entry["type"] in ("added", "removed", "equal")
+                for entry in issue["diff"]
+            )
+
+
+def test_debug_fix_preview_does_not_mutate_original_code():
+    orig_code = "try:\n    pass\nexcept:\n    pass"
+    r = client.post("/debugging/", json={"code": orig_code, "language": "python"})
+    assert r.status_code == 200
+    d = r.json()
+    assert d["code"] == orig_code
+    assert d["issues"][0]["fixed_code"] != orig_code
 
 
 def test_js_ts_security_patterns():

--- a/docs/CHANGELOG.md
+++ b/docs/CHANGELOG.md
@@ -39,8 +39,6 @@ All notable changes to QyverixAI are documented in this file.
 - Tightened the `Missing __init__` regex (`[^:]*` → `[^:\n]*`) so the class
   header stays on a single line and classes that do define `__init__` are not
   flagged once multi-line matching is enabled.
-
-### Fixed
 - Improved database service error handling: safer idempotent schema migrations,
   soft-fail invalid FTS search queries to an empty result, and structured
   logging before re-raising unexpected SQLite failures.
@@ -51,7 +49,8 @@ All notable changes to QyverixAI are documented in this file.
   server-side denylist until they expire.
 - Audit-log entries redact sensitive fields (passwords, tokens, secrets, API
   keys) before they are persisted.
-- Prevent resource exhaustion by adding size constraints (max_length=200) and truncation rules on search query parameter q in GET /history/search.
+- Prevent resource exhaustion by adding size constraints (`max_length=200`) and
+  truncation rules on search query parameter `q` in `GET /history/search`.
 
 ## [3.0.0] - 2026-06-06
 

--- a/docs/CHANGELOG.md
+++ b/docs/CHANGELOG.md
@@ -5,6 +5,13 @@ All notable changes to QyverixAI are documented in this file.
 ## [Unreleased]
 
 ### Added
+- Added AI Suggested Fix Preview: automatic generation of scoped, corrected code
+  snippets (`fixed_code`) and structured before/after line-level diff previews
+  (`diff`) for fixable issues across Python, JavaScript, TypeScript, Java, C++,
+  PHP, and Rust in `POST /debugging/` and `POST /analyze/`.
+- Added interactive, independently collapsible before/after diff preview panels
+  in `frontend/index.html` for each detected issue with one-click copy, leaving
+  the user's source code untouched (preview-only).
 - Added hybrid rule+LLM analysis to `POST /analyze/`: LLM enrichment
   (explanation insight, suggestions, `optimized_version`) layered on top of
   deterministic rule-based debugging, with graceful `degraded` fallback on LLM

--- a/frontend/index.html
+++ b/frontend/index.html
@@ -1798,6 +1798,54 @@ details.issue-card[open] {
       flex-shrink: 0;
     }
 
+    /* ── Fix Preview Panel ── */
+    .fix-preview-panel {
+      margin-top: 12px;
+      border-radius: var(--r2);
+      border: 1px solid var(--border);
+      background: var(--bg2);
+      overflow: hidden;
+    }
+
+    .fix-preview-summary {
+      display: flex;
+      align-items: center;
+      gap: 8px;
+      padding: 8px 12px;
+      background: var(--bg3);
+      font-size: 0.75rem;
+      font-weight: 600;
+      color: var(--text);
+      cursor: pointer;
+      user-select: none;
+      transition: background var(--transition);
+      list-style: none;
+    }
+
+    .fix-preview-summary::-webkit-details-marker {
+      display: none;
+    }
+
+    .fix-preview-summary::before {
+      content: '▶';
+      font-size: 0.65rem;
+      color: var(--text3);
+      transition: transform var(--transition);
+    }
+
+    details.fix-preview-panel[open] > .fix-preview-summary::before {
+      transform: rotate(90deg);
+    }
+
+    .fix-preview-summary:hover {
+      background: var(--bg4);
+      color: var(--text);
+    }
+
+    .fix-preview-body {
+      padding: 10px 12px;
+    }
+
     /* ── Clean State ── */
     .clean-state {
       display: flex;
@@ -4553,7 +4601,24 @@ cursor:pointer;
       </div>
     </div>`;
 
-        const cards = dbg.issues.map((issue, i) => `
+        const cards = dbg.issues.map((issue, i) => {
+          let fixPreviewHtml = '';
+          if (issue.fixed_code) {
+            const copyId = `copy-issue-fix-${i}`;
+            const diffHtml = buildDiffHtml(issue.code_snippet || '', issue.fixed_code, copyId);
+            fixPreviewHtml = `
+            <details class="fix-preview-panel" open>
+              <summary class="fix-preview-summary">
+                <svg width="13" height="13" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2"><path d="M14.7 6.3a1 1 0 0 0 0 1.4l1.6 1.6a1 1 0 0 0 1.4 0l3.77-3.77a6 6 0 0 1-7.94 7.94l-6.91 6.91a2.12 2.12 0 0 1-3-3l6.91-6.91a6 6 0 0 1 7.94-7.94l-3.76 3.76z"/></svg>
+                <span>Suggested Fix Preview</span>
+              </summary>
+              <div class="fix-preview-body">
+                ${diffHtml}
+              </div>
+            </details>`;
+          }
+
+          return `
   <details class="issue-card ${issue.severity}"
            style="animation-delay:${i * 0.05}s">
 
@@ -4582,10 +4647,12 @@ cursor:pointer;
       </div>` : ''}
 
       <div class="issue-fix">${issue.suggestion}</div>
+      ${fixPreviewHtml}
     </div>
 
   </details>
-`).join('');
+`;
+        }).join('');
 
         el.innerHTML = statBar + cards;
         el.querySelectorAll('.snippet-copy-btn').forEach(btn => {
@@ -4596,6 +4663,24 @@ cursor:pointer;
             });
           });
         });
+
+        // Wire up "Copy fixed" buttons in issue previews
+        dbg.issues.forEach((issue, i) => {
+          if (!issue.fixed_code) return;
+          const btn = document.getElementById(`copy-issue-fix-${i}`);
+          if (!btn) return;
+          btn.addEventListener('click', () => {
+            navigator.clipboard.writeText(issue.fixed_code).then(() => {
+              btn.textContent = '✓ Copied!';
+              btn.style.background = 'rgba(34,212,123,0.25)';
+              setTimeout(() => {
+                btn.innerHTML = `<svg width="12" height="12" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2"><rect x="9" y="9" width="13" height="13" rx="2"/><path d="M5 15H4a2 2 0 0 1-2-2V4a2 2 0 0 1 2-2h9a2 2 0 0 1 2 2v1"/></svg> Copy fixed`;
+                btn.style.background = '';
+              }, 2000);
+            });
+          });
+        });
+
         if (window.highlightAllCode) window.highlightAllCode();
       }
 

--- a/frontend/script.js
+++ b/frontend/script.js
@@ -571,6 +571,7 @@ function renderResult(data, mode) {
               ${renderComplexityBadge(i)}
               <p style="margin-top:8px">${escHtml(i.description || '')}</p>
               ${i.suggestion ? `<p style="margin-top:6px;color:var(--accent-green)">→ ${escHtml(i.suggestion)}</p>` : ''}
+              ${i.fixed_code ? `<div style="margin-top:8px;padding:8px;background:var(--bg-3);border-radius:4px;font-family:var(--font-mono);font-size:12px"><span style="color:var(--accent-green)">Suggested Fix Preview:</span><pre style="margin-top:4px;white-space:pre-wrap">${escHtml(i.fixed_code)}</pre></div>` : ''}
             </div>`).join('')}
       </div>
     </div>`;


### PR DESCRIPTION
## Description
Adds an AI Suggested Fix Preview to QyverixAI. For every detected issue that has a fix suggestion, the backend (`code_assistant.py`) now generates a scoped, corrected code snippet via a new `generate_issue_fix()` function, covering Python, JavaScript, TypeScript, Java, C++, PHP, and Rust patterns (including AST-based findings). A new `compute_line_diff()` function produces a line-level diff (equal/added/removed) using `difflib.SequenceMatcher`. `run_bug_detection()` enriches each issue with these results without mutating the original submitted code. For ambiguous/unfixable patterns (e.g. `Exec Usage`, `Syntax Error`), `fixed_code` and `diff` are returned as `None` rather than guessing.

The `Issue` schema (`schemas.py`) gains two new optional fields — `fixed_code: str | None` and `diff: list[dict] | None` — keeping the API fully backward compatible.

On the frontend, `index.html` renders an independently expandable/collapsible before/after preview panel for every issue with a `fixed_code`, with color-coded diff lines (`diff-line-removed`, `diff-line-added`, `diff-line-equal`) and a one-click "copy fix" button per preview. Multiple issues in the same analysis each get their own independent panel. `script.js` was updated for renderer parity.

README.md and docs/CHANGELOG.md were updated to document the new feature and API response shape.

## Related Issue


Fixes #1695

## Type of change
- [ ] Bug fix
- [x] New feature / enhancement
- [x] Documentation update
- [x] Test addition
- [ ] Refactor

## Checklist
- [x] I have read [CONTRIBUTING.md](../CONTRIBUTING.md)
- [x] My branch is up to date with `main`
- [x] I have run `pytest -v` and all tests pass
- [x] I have not introduced duplicate issues or features
- [x] My PR title follows the format: `feat/fix/docs/test: short description`
- [x] I have added tests for new features (Level 2 and 3 issues)
- [x] No hardcoded secrets or API keys in my code
- [x] This PR is linked to a relevant issue or clearly states the change being made

## Screenshots (if frontend change)
<!-- Add before/after screenshots of the collapsible diff preview panel here -->

## Test evidence
```bash
pytest -v
# 608 passed, 0 failed in 51.04s

black --check backend/
# clean, 0 diffs

isort --check-only backend/
# clean, 0 diffs

ruff check backend/app --select E,F,W --ignore E501
# All checks passed!

node tests/*.test.js && node --test tests/*.test.mjs
# 82 tests passed, 0 failed
```