### PR TITLE
fix: roll back and report clean 503s on DB failures in user data router

### DIFF
--- a/backend/app/routers/user_data.py
+++ b/backend/app/routers/user_data.py
@@ -3,6 +3,7 @@ from typing import cast
 
 from fastapi import APIRouter, Depends, HTTPException, Path, Query, Request, status
 from sqlalchemy import CursorResult, delete, select
+from sqlalchemy.exc import SQLAlchemyError
 from sqlalchemy.orm import Session
 
 from ..database import get_db
@@ -34,24 +35,45 @@ def _client_ip(request: Request) -> str | None:
     return request.client.host if request.client else None
 
 
-def _list_owned_records(db: Session, model, user_id: int, limit: int, offset: int):
-    return (
-        db.execute(
-            select(model)
-            .where(model.user_id == user_id)
-            .order_by(model.id.desc())
-            .limit(limit)
-            .offset(offset)
-        )
-        .scalars()
-        .all()
+def _db_unavailable(operation: str, user_id: int, exc: Exception) -> HTTPException:
+    logger.error(
+        "user_data_db_operation_failed operation=%s user_id=%s detail=%s",
+        operation,
+        user_id,
+        exc,
+        exc_info=True,
+    )
+    return HTTPException(
+        status_code=status.HTTP_503_SERVICE_UNAVAILABLE,
+        detail="A database error occurred while processing your request",
     )
 
 
+def _list_owned_records(db: Session, model, user_id: int, limit: int, offset: int):
+    try:
+        return (
+            db.execute(
+                select(model)
+                .where(model.user_id == user_id)
+                .order_by(model.id.desc())
+                .limit(limit)
+                .offset(offset)
+            )
+            .scalars()
+            .all()
+        )
+    except SQLAlchemyError as exc:
+        raise _db_unavailable(f"list_{model.__name__}", user_id, exc) from exc
+
+
 def _clear_owned_records(db: Session, model, user_id: int) -> int:
-    result = db.execute(delete(model).where(model.user_id == user_id))
-    db.commit()
-    return cast(CursorResult, result).rowcount or 0
+    try:
+        result = db.execute(delete(model).where(model.user_id == user_id))
+        db.commit()
+        return cast(CursorResult, result).rowcount or 0
+    except SQLAlchemyError as exc:
+        db.rollback()
+        raise _db_unavailable(f"clear_{model.__name__}", user_id, exc) from exc
 
 
 @router.get("/data-purge/preview", response_model=UserDataPurgePreviewResponse)
@@ -98,22 +120,26 @@ def purge_data(
         )
     else:
         USER_DATA_PURGE_ATTEMPTS_TOTAL.labels(result="scheduled").inc()
-        record_audit(
-            db,
-            actor=current_user,
-            action="user.self_delete",
-            target_type="user",
-            target_id=current_user.id,
-            details={
-                "scheduled_for": (
-                    result.deletion_scheduled_for.isoformat()
-                    if result.deletion_scheduled_for
-                    else None
-                )
-            },
-            ip_address=_client_ip(request),
-        )
-        db.commit()
+        try:
+            record_audit(
+                db,
+                actor=current_user,
+                action="user.self_delete",
+                target_type="user",
+                target_id=current_user.id,
+                details={
+                    "scheduled_for": (
+                        result.deletion_scheduled_for.isoformat()
+                        if result.deletion_scheduled_for
+                        else None
+                    )
+                },
+                ip_address=_client_ip(request),
+            )
+            db.commit()
+        except SQLAlchemyError as exc:
+            db.rollback()
+            raise _db_unavailable("purge_audit", current_user.id, exc) from exc
         logger.info(
             "user_data_purge_scheduled user_id=%s scheduled_for=%s",
             current_user.id,
@@ -164,9 +190,13 @@ def create_history(
         code=payload.code,
         result_json=payload.result_json,
     )
-    db.add(record)
-    db.commit()
-    db.refresh(record)
+    try:
+        db.add(record)
+        db.commit()
+        db.refresh(record)
+    except SQLAlchemyError as exc:
+        db.rollback()
+        raise _db_unavailable("create_history", current_user.id, exc) from exc
 
     USER_DATA_HISTORY_OPERATIONS_TOTAL.labels(
         operation="create", result="success"
@@ -192,11 +222,15 @@ def delete_history(
     current_user: User = Depends(get_current_user),
     db: Session = Depends(get_db),
 ):
-    record = db.execute(
-        select(QueryHistory).where(
-            QueryHistory.id == history_id, QueryHistory.user_id == current_user.id
-        )
-    ).scalar_one_or_none()
+    try:
+        record = db.execute(
+            select(QueryHistory).where(
+                QueryHistory.id == history_id, QueryHistory.user_id == current_user.id
+            )
+        ).scalar_one_or_none()
+    except SQLAlchemyError as exc:
+        raise _db_unavailable("delete_history", current_user.id, exc) from exc
+
     if record is None:
         USER_DATA_HISTORY_OPERATIONS_TOTAL.labels(
             operation="delete", result="not_found"
@@ -205,8 +239,12 @@ def delete_history(
             status_code=status.HTTP_404_NOT_FOUND, detail="History record not found"
         )
 
-    db.delete(record)
-    db.commit()
+    try:
+        db.delete(record)
+        db.commit()
+    except SQLAlchemyError as exc:
+        db.rollback()
+        raise _db_unavailable("delete_history", current_user.id, exc) from exc
 
     USER_DATA_HISTORY_OPERATIONS_TOTAL.labels(
         operation="delete", result="success"
@@ -272,9 +310,13 @@ def create_favorite(
         code=payload.code,
         result_json=payload.result_json,
     )
-    db.add(record)
-    db.commit()
-    db.refresh(record)
+    try:
+        db.add(record)
+        db.commit()
+        db.refresh(record)
+    except SQLAlchemyError as exc:
+        db.rollback()
+        raise _db_unavailable("create_favorite", current_user.id, exc) from exc
 
     USER_DATA_FAVORITE_OPERATIONS_TOTAL.labels(
         operation="create", result="success"
@@ -301,11 +343,16 @@ def delete_favorite(
     current_user: User = Depends(get_current_user),
     db: Session = Depends(get_db),
 ):
-    record = db.execute(
-        select(FavoriteResult).where(
-            FavoriteResult.id == favorite_id, FavoriteResult.user_id == current_user.id
-        )
-    ).scalar_one_or_none()
+    try:
+        record = db.execute(
+            select(FavoriteResult).where(
+                FavoriteResult.id == favorite_id,
+                FavoriteResult.user_id == current_user.id,
+            )
+        ).scalar_one_or_none()
+    except SQLAlchemyError as exc:
+        raise _db_unavailable("delete_favorite", current_user.id, exc) from exc
+
     if record is None:
         USER_DATA_FAVORITE_OPERATIONS_TOTAL.labels(
             operation="delete", result="not_found"
@@ -314,8 +361,12 @@ def delete_favorite(
             status_code=status.HTTP_404_NOT_FOUND, detail="Favorite not found"
         )
 
-    db.delete(record)
-    db.commit()
+    try:
+        db.delete(record)
+        db.commit()
+    except SQLAlchemyError as exc:
+        db.rollback()
+        raise _db_unavailable("delete_favorite", current_user.id, exc) from exc
 
     USER_DATA_FAVORITE_OPERATIONS_TOTAL.labels(
         operation="delete", result="success"

--- a/backend/tests/test_user_data_error_handling.py
+++ b/backend/tests/test_user_data_error_handling.py
@@ -1,0 +1,192 @@
+"""Tests verifying that the user data router reports a clean 503 (instead of
+an unhandled 500) and rolls back the session when a database operation fails
+partway through a request."""
+
+from __future__ import annotations
+
+import pytest
+from app.database import Base, get_db
+from app.main import app as fastapi_app
+from app.models import FavoriteResult, QueryHistory, User
+from app.services.user_deletion import CONFIRMATION_PHRASE, DELETION_STATUS_PENDING
+from fastapi.testclient import TestClient
+from sqlalchemy import create_engine, select
+from sqlalchemy.exc import OperationalError
+from sqlalchemy.orm import Session as OrmSession
+from sqlalchemy.orm import sessionmaker
+from sqlalchemy.pool import StaticPool
+
+TEST_ENGINE = create_engine(
+    "sqlite:///:memory:",
+    connect_args={"check_same_thread": False},
+    poolclass=StaticPool,
+)
+TEST_SESSION_LOCAL = sessionmaker(bind=TEST_ENGINE)
+
+_ORIGINAL_ROLLBACK = OrmSession.rollback
+
+
+def _override_db():
+    db = TEST_SESSION_LOCAL()
+    try:
+        yield db
+    finally:
+        db.close()
+
+
+@pytest.fixture
+def client():
+    previous_override = fastapi_app.dependency_overrides.get(get_db)
+    fastapi_app.dependency_overrides[get_db] = _override_db
+
+    with TestClient(fastapi_app) as test_client:
+        yield test_client
+
+    if previous_override is None:
+        fastapi_app.dependency_overrides.pop(get_db, None)
+    else:
+        fastapi_app.dependency_overrides[get_db] = previous_override
+
+
+@pytest.fixture(autouse=True)
+def _recreate_tables():
+    Base.metadata.drop_all(bind=TEST_ENGINE)
+    Base.metadata.create_all(bind=TEST_ENGINE)
+    yield
+    Base.metadata.drop_all(bind=TEST_ENGINE)
+
+
+def _signup(
+    client: TestClient, email: str, password: str = "StrongPass123!"
+) -> dict[str, str]:
+    response = client.post("/auth/signup", json={"email": email, "password": password})
+    assert response.status_code == 200
+    return {"Authorization": f"Bearer {response.json()['access_token']}"}
+
+
+def _simulate_commit_failure(
+    monkeypatch: pytest.MonkeyPatch, fail_after: int = 0
+) -> dict[str, int]:
+    """Make ``Session.commit()`` raise starting from the ``fail_after + 1``-th
+    call (letting earlier, unrelated commits in the same request succeed),
+    and count ``Session.rollback()`` calls so tests can assert the router
+    actually rolls back before reporting the failure."""
+    calls = {"rollback": 0, "commit_attempts": 0}
+    original_commit = OrmSession.commit
+
+    def flaky_commit(self, *args, **kwargs):
+        calls["commit_attempts"] += 1
+        if calls["commit_attempts"] > fail_after:
+            raise OperationalError("COMMIT", {}, Exception("simulated database outage"))
+        return original_commit(self, *args, **kwargs)
+
+    def tracking_rollback(self, *args, **kwargs):
+        calls["rollback"] += 1
+        return _ORIGINAL_ROLLBACK(self, *args, **kwargs)
+
+    monkeypatch.setattr(OrmSession, "commit", flaky_commit)
+    monkeypatch.setattr(OrmSession, "rollback", tracking_rollback)
+    return calls
+
+
+def test_create_history_db_failure_returns_503_and_rolls_back(
+    client: TestClient, monkeypatch: pytest.MonkeyPatch
+):
+    headers = _signup(client, "err_history_create@example.com")
+
+    with monkeypatch.context() as m:
+        calls = _simulate_commit_failure(m)
+        response = client.post(
+            "/user/history",
+            headers=headers,
+            json={"action": "debugging", "code": "print(1)", "result_json": "{}"},
+        )
+
+    assert response.status_code == 503
+    assert "database error" in response.json()["detail"].lower()
+    assert calls["rollback"] == 1
+
+    db = TEST_SESSION_LOCAL()
+    try:
+        assert db.execute(select(QueryHistory)).scalars().all() == []
+    finally:
+        db.close()
+
+
+def test_delete_history_db_failure_returns_503_and_rolls_back(
+    client: TestClient, monkeypatch: pytest.MonkeyPatch
+):
+    headers = _signup(client, "err_history_delete@example.com")
+    created = client.post(
+        "/user/history",
+        headers=headers,
+        json={"action": "debugging", "code": "print(1)", "result_json": "{}"},
+    ).json()
+
+    with monkeypatch.context() as m:
+        calls = _simulate_commit_failure(m)
+        response = client.delete(f"/user/history/{created['id']}", headers=headers)
+
+    assert response.status_code == 503
+    assert calls["rollback"] == 1
+
+    db = TEST_SESSION_LOCAL()
+    try:
+        remaining = db.execute(select(QueryHistory)).scalars().all()
+        assert len(remaining) == 1
+        assert remaining[0].id == created["id"]
+    finally:
+        db.close()
+
+
+def test_clear_favorites_db_failure_returns_503_and_rolls_back(
+    client: TestClient, monkeypatch: pytest.MonkeyPatch
+):
+    headers = _signup(client, "err_favorite_clear@example.com")
+    client.post(
+        "/user/favorites",
+        headers=headers,
+        json={
+            "title": "Saved",
+            "action": "debugging",
+            "code": "print(1)",
+            "result_json": "{}",
+        },
+    )
+
+    with monkeypatch.context() as m:
+        calls = _simulate_commit_failure(m)
+        response = client.delete("/user/favorites", headers=headers)
+
+    assert response.status_code == 503
+    assert calls["rollback"] == 1
+
+    db = TEST_SESSION_LOCAL()
+    try:
+        assert len(db.execute(select(FavoriteResult)).scalars().all()) == 1
+    finally:
+        db.close()
+
+
+def test_purge_audit_db_failure_returns_503_but_keeps_deletion_scheduled(
+    client: TestClient, monkeypatch: pytest.MonkeyPatch
+):
+    headers = _signup(client, "err_purge_audit@example.com")
+
+    with monkeypatch.context() as m:
+        calls = _simulate_commit_failure(m, fail_after=1)
+        response = client.post(
+            "/user/data-purge",
+            headers=headers,
+            json={"confirmation": CONFIRMATION_PHRASE},
+        )
+
+    assert response.status_code == 503
+    assert calls["rollback"] == 1
+
+    db = TEST_SESSION_LOCAL()
+    try:
+        user = db.execute(select(User).where(User.email == "err_purge_audit@example.com")).scalar_one()
+        assert user.deletion_status == DELETION_STATUS_PENDING
+    finally:
+        db.close()

--- a/backend/tests/test_user_data_error_handling.py
+++ b/backend/tests/test_user_data_error_handling.py
@@ -186,7 +186,9 @@ def test_purge_audit_db_failure_returns_503_but_keeps_deletion_scheduled(
 
     db = TEST_SESSION_LOCAL()
     try:
-        user = db.execute(select(User).where(User.email == "err_purge_audit@example.com")).scalar_one()
+        user = db.execute(
+            select(User).where(User.email == "err_purge_audit@example.com")
+        ).scalar_one()
         assert user.deletion_status == DELETION_STATUS_PENDING
     finally:
         db.close()


### PR DESCRIPTION
## Summary
- Every DB-mutating handler in `backend/app/routers/user_data.py` called `db.commit()` / `db.execute()` with no error handling, so a transient DB failure (lock, dropped connection, constraint violation) would leak an unhandled 500 with no rollback and no log line — unlike the rest of the codebase (`services/user_deletion.py`, `services/database.py`), which consistently rolls back and logs before re-raising.
- Wrapped every DB call in the router (including the shared `_list_owned_records` / `_clear_owned_records` helpers) in `try/except SQLAlchemyError`, rolling back and logging with operation context before returning a clean `503 Service Unavailable` instead of a raw traceback.
- Existing 404/validation behavior is unchanged — only unexpected DB failures are affected.

Fixes #1520

## Test plan
- [x] Added `backend/tests/test_user_data_error_handling.py`: 4 new tests that monkeypatch `Session.commit` to simulate a DB outage and assert a 503 response, that `rollback()` is actually invoked, and that no partial writes are left committed (including a case where the purge's deletion-scheduling commit succeeds but the audit-log commit fails).
- [x] `pytest backend/tests/test_user_data_error_handling.py backend/tests/test_user_data_observability.py backend/tests/test_auth_and_user_data.py backend/tests/test_user_data_purge.py backend/tests/test_user_data_validation.py` — 26 passed.
