### PR TITLE
Refactor shared logic in admin router

### DIFF
--- a/backend/app/routers/admin.py
+++ b/backend/app/routers/admin.py
@@ -24,6 +24,15 @@ def _client_ip(request: Request) -> str | None:
     return request.client.host if request.client else None
 
 
+def _get_user_or_404(db: Session, user_id: int) -> User:
+    user = db.get(User, user_id)
+    if user is None:
+        raise HTTPException(
+            status_code=status.HTTP_404_NOT_FOUND, detail="User not found"
+        )
+    return user
+
+
 def _to_record(entry: AuditLog) -> AuditLogRecord:
     return AuditLogRecord(
         id=entry.id,
@@ -67,11 +76,7 @@ def update_user_role(
     db: Session = Depends(get_db),
 ):
     """Grant or revoke a user's admin role, recording the change in the audit log."""
-    user = db.get(User, user_id)
-    if user is None:
-        raise HTTPException(
-            status_code=status.HTTP_404_NOT_FOUND, detail="User not found"
-        )
+    user = _get_user_or_404(db, user_id)
 
     previous = user.is_admin
     user.is_admin = payload.is_admin
@@ -104,11 +109,7 @@ def delete_user(
             detail="Admins cannot delete their own account",
         )
 
-    user = db.get(User, user_id)
-    if user is None:
-        raise HTTPException(
-            status_code=status.HTTP_404_NOT_FOUND, detail="User not found"
-        )
+    user = _get_user_or_404(db, user_id)
 
     email = user.email
     db.delete(user)

--- a/backend/tests/test_admin_audit.py
+++ b/backend/tests/test_admin_audit.py
@@ -164,9 +164,7 @@ def test_role_update_for_unknown_user_is_404():
 def test_delete_unknown_user_is_404():
     admin = _signup("admin6@example.com")
     _make_admin(admin["user_id"])
-    r = client.delete(
-        "/admin/users/999999", headers=_auth(admin["access_token"])
-    )
+    r = client.delete("/admin/users/999999", headers=_auth(admin["access_token"]))
     assert r.status_code == 404
 
 

--- a/backend/tests/test_admin_audit.py
+++ b/backend/tests/test_admin_audit.py
@@ -150,6 +150,26 @@ def test_admin_cannot_delete_self():
     assert r.status_code == 400
 
 
+def test_role_update_for_unknown_user_is_404():
+    admin = _signup("admin5@example.com")
+    _make_admin(admin["user_id"])
+    r = client.put(
+        "/admin/users/999999/role",
+        json={"is_admin": True},
+        headers=_auth(admin["access_token"]),
+    )
+    assert r.status_code == 404
+
+
+def test_delete_unknown_user_is_404():
+    admin = _signup("admin6@example.com")
+    _make_admin(admin["user_id"])
+    r = client.delete(
+        "/admin/users/999999", headers=_auth(admin["access_token"])
+    )
+    assert r.status_code == 404
+
+
 def test_audit_entries_are_append_only():
     """Deleting the acting user must not cascade-remove their audit rows."""
     admin = _signup("admin4@example.com")


### PR DESCRIPTION
## Summary
- `update_user_role` and `delete_user` in `backend/app/routers/admin.py` each duplicated the same "look up user by id, 404 if missing" block.
- Extracted the shared logic into `_get_user_or_404(db, user_id)` and used it in both endpoints. No behavior change — same status codes, same error detail.
- Added tests covering the 404 path for both endpoints, since it previously had no direct coverage.

Closes #1518

## Test plan
- [x] `pytest tests/test_admin_audit.py -q` — 9 passed (7 existing + 2 new)