### PR TITLE
fix: handle extension API failures consistently

### DIFF
--- a/.github/workflows/vscode-extension-tests.yml
+++ b/.github/workflows/vscode-extension-tests.yml
@@ -1,0 +1,32 @@
+name: VS Code Extension Tests
+
+on:
+  pull_request:
+    paths:
+      - "vscode-extension/**"
+      - ".github/workflows/vscode-extension-tests.yml"
+  push:
+    branches: [main]
+    paths:
+      - "vscode-extension/**"
+      - ".github/workflows/vscode-extension-tests.yml"
+
+permissions:
+  contents: read
+
+jobs:
+  test:
+    runs-on: ubuntu-latest
+    timeout-minutes: 5
+    defaults:
+      run:
+        working-directory: vscode-extension
+    steps:
+      - uses: actions/checkout@v4
+      - uses: actions/setup-node@v4
+        with:
+          node-version: "20"
+          cache: npm
+          cache-dependency-path: vscode-extension/package-lock.json
+      - run: npm ci --ignore-scripts
+      - run: npm test

--- a/README.md
+++ b/README.md
@@ -94,7 +94,7 @@ No account required for the core analysis. No API key needed. Works fully offlin
 | **Observability** | `/healthz/live`, `/healthz/ready`, and Prometheus-format `/metrics` - see [Observability](#observability) below |
 | **Swagger Docs** | Interactive API docs at `/docs` |
 | **Gzip Compression** | Automatic response compression |
-| **VS Code Extension** | In-editor analysis via a TypeScript extension (`v0.1.0`) that talks to the same API - see [`vscode-extension/`](vscode-extension/) |
+| **VS Code Extension** | In-editor analysis via a TypeScript extension (`v0.1.0`) with consistent API failure messages and bounded request timeouts - see [`vscode-extension/`](vscode-extension/) |
 
 ### Languages and patterns
 

--- a/docs/CHANGELOG.md
+++ b/docs/CHANGELOG.md
@@ -25,6 +25,8 @@ All notable changes to QyverixAI are documented in this file.
   parse failures.
 
 ### Fixed
+- VS Code commands now show consistent API failure messages without exposing
+  response bodies or transport internals, and reject interrupted or timed-out requests.
 - Multi-line `BUG_PATTERNS` (`String Concatenation in Loop`, `Missing __init__`,
   `Callback Hell`) now fire correctly. `run_bug_detection` previously matched
   each regex against a single line, which silently killed patterns that span

--- a/vscode-extension/.vscodeignore
+++ b/vscode-extension/.vscodeignore
@@ -6,3 +6,4 @@ tsconfig.json
 .gitignore
 **/*.ts
 **/*.map
+tests/**

--- a/vscode-extension/README.md
+++ b/vscode-extension/README.md
@@ -52,6 +52,7 @@ This extension contributes the following settings:
 cd vscode-extension
 npm install
 npm run compile
+npm test
 ```
 
 The compile step emits `extension.js`, which matches the package entrypoint declared in `package.json`.
@@ -156,3 +157,20 @@ code --install-extension qyverixai-vscode-*.vsix
 ## License
 
 MIT
+
+## API failure handling
+
+All four API commands use the same request boundary. Connection failures,
+request deadlines, HTTP failures, and invalid responses produce stable messages
+in both notifications and WebViews. Raw response bodies, configured credentials,
+and transport exception details are never included in those messages or logs.
+The debug console records only the failure category and HTTP status when present.
+
+The timeout is a positive, finite number of seconds and bounds the complete
+request, including a stalled or trickling response. API URLs must use HTTP or
+HTTPS and must not include embedded credentials.
+
+`npm test` compiles the extension and exercises its registered commands against
+a local HTTP server with a small VS Code API stub. It covers failures and a
+successful UTF-8 response without calling the hosted API or requiring VS Code.
+The extension CI workflow runs these tests for changes to this directory.

--- a/vscode-extension/package.json
+++ b/vscode-extension/package.json
@@ -27,7 +27,8 @@
   "main": "./extension.js",
   "scripts": {
     "compile": "tsc -p ./",
-    "watch": "tsc -watch -p ./"
+    "watch": "tsc -watch -p ./",
+    "test": "npm run compile && node --test tests/*.test.cjs"
   },
   "devDependencies": {
     "@types/node": "^20.11.30",

--- a/vscode-extension/src/extension.ts
+++ b/vscode-extension/src/extension.ts
@@ -69,51 +69,99 @@ let diagnosticCollection: vscode.DiagnosticCollection;
 // HTTP helper
 // ---------------------------------------------------------------------------
 
+type ApiFailureCode = 'configuration' | 'connection' | 'timeout' | 'http' | 'invalid_response';
+
+/** Only locally defined messages may cross the API-to-UI error boundary. */
+class ApiRequestError extends Error {
+  constructor(readonly code: ApiFailureCode, readonly statusCode?: number) {
+    const messages: Record<ApiFailureCode, string> = {
+      configuration: 'Check the QyverixAI API URL and request timeout in Settings.',
+      connection: 'Could not connect to the QyverixAI API. Check your connection and API URL.',
+      timeout: 'The QyverixAI request timed out. Try again or increase the timeout in Settings.',
+      http: `The QyverixAI API returned HTTP ${statusCode}. Please try again later.`,
+      invalid_response: 'The QyverixAI API returned an invalid response. Please try again.',
+    };
+    super(messages[code]);
+    this.name = 'ApiRequestError';
+  }
+}
+
+/** Keep response bodies, transport details, and unexpected exceptions out of UI/logs. */
+function safeApiErrorMessage(error: unknown): string {
+  const failure = error instanceof ApiRequestError ? error : new ApiRequestError('invalid_response');
+  console.warn(`[QyverixAI] API failure: ${failure.code}${failure.statusCode ? ` (HTTP ${failure.statusCode})` : ''}`);
+  return failure.message;
+}
+
 function postToApi<T>(endpoint: string, body: object, timeoutS: number): Promise<T> {
   const cfg = vscode.workspace.getConfiguration('qyverixai');
   const baseUrl = cfg.get<string>('apiUrl', 'https://qyverixai.onrender.com').replace(/\/+$/, '');
-  const url = `${baseUrl}${endpoint}`;
 
   return new Promise<T>((resolve, reject) => {
-    const isHttps = url.startsWith('https');
-    const mod = isHttps ? require('https') : require('http');
+    let parsed: URL;
+    try {
+      parsed = new URL(`${baseUrl}${endpoint}`);
+      if (!['http:', 'https:'].includes(parsed.protocol) || parsed.username || parsed.password ||
+          !Number.isFinite(timeoutS) || timeoutS <= 0 || timeoutS * 1000 > 2_147_483_647) {
+        throw new Error('Invalid configuration');
+      }
+    } catch {
+      reject(new ApiRequestError('configuration'));
+      return;
+    }
 
+    const mod: typeof import('http') = parsed.protocol === 'https:' ? require('https') : require('http');
     const payload = JSON.stringify(body);
-    const parsed = new URL(url);
+    let settled = false;
+    let deadline: ReturnType<typeof setTimeout> | undefined;
+    const fail = (error: ApiRequestError) => {
+      if (settled) return;
+      settled = true;
+      clearTimeout(deadline);
+      reject(error);
+    };
 
-    const opts = {
-      hostname: parsed.hostname,
-      port: parsed.port || (isHttps ? 443 : 80),
-      path: parsed.pathname,
+    const req = mod.request(parsed, {
       method: 'POST',
       headers: {
         'Content-Type': 'application/json',
         'Content-Length': Buffer.byteLength(payload),
       },
-      timeout: timeoutS * 1000,
-    };
-
-    const req = mod.request(opts, (res: any) => {
+    }, res => {
+      // Do not collect or expose upstream error bodies, including provider/DB errors.
+      if (!res.statusCode || res.statusCode < 200 || res.statusCode >= 300) {
+        fail(new ApiRequestError('http', res.statusCode));
+        res.destroy();
+        return;
+      }
       let data = '';
-      res.on('data', (chunk: string) => (data += chunk));
+      res.setEncoding('utf8');
+      res.on('data', (chunk: string) => { data += chunk; });
+      res.on('error', () => fail(new ApiRequestError('connection')));
+      res.on('aborted', () => fail(new ApiRequestError('connection')));
       res.on('end', () => {
-        if (res.statusCode && res.statusCode >= 200 && res.statusCode < 300) {
-          try {
-            resolve(JSON.parse(data) as T);
-          } catch {
-            reject(new Error(`Invalid JSON response: ${data.slice(0, 200)}`));
+        if (settled) return;
+        try {
+          const result: unknown = JSON.parse(data);
+          if (result === null || typeof result !== 'object' || Array.isArray(result)) {
+            throw new Error('Expected an API response object');
           }
-        } else {
-          reject(new Error(`API error ${res.statusCode}: ${data.slice(0, 500)}`));
+          settled = true;
+          clearTimeout(deadline);
+          resolve(result as T);
+        } catch {
+          fail(new ApiRequestError('invalid_response'));
         }
       });
     });
 
-    req.on('error', (err: Error) => reject(new Error(`Request failed: ${err.message}`)));
-    req.on('timeout', () => { req.destroy(); reject(new Error('Request timed out')); });
-
-    req.write(payload);
-    req.end();
+    req.on('error', () => fail(new ApiRequestError('connection')));
+    // A wall-clock deadline also bounds stalled/trickling response bodies.
+    deadline = setTimeout(() => {
+      fail(new ApiRequestError('timeout'));
+      req.destroy();
+    }, timeoutS * 1000);
+    req.end(payload);
   });
 }
 
@@ -392,9 +440,10 @@ async function handleAnalyze(): Promise<void> {
     vscode.window.showInformationMessage(
       `QyverixAI: ${res.debugging.error_count} errors, ${res.debugging.warning_count} warnings — grade ${res.suggestions.grade}`,
     );
-  } catch (err: any) {
-    panel.webview.html = errorHtml(err.message);
-    vscode.window.showErrorMessage(`QyverixAI analysis failed: ${err.message}`);
+  } catch (err: unknown) {
+    const message = safeApiErrorMessage(err);
+    panel.webview.html = errorHtml(message);
+    vscode.window.showErrorMessage(`QyverixAI analysis failed: ${message}`);
   }
 }
 
@@ -429,9 +478,10 @@ async function handleDebug(): Promise<void> {
         `QyverixAI: ${res.error_count} errors, ${res.warning_count} warnings found`,
       );
     }
-  } catch (err: any) {
-    panel.webview.html = errorHtml(err.message);
-    vscode.window.showErrorMessage(`QyverixAI debug failed: ${err.message}`);
+  } catch (err: unknown) {
+    const message = safeApiErrorMessage(err);
+    panel.webview.html = errorHtml(message);
+    vscode.window.showErrorMessage(`QyverixAI debug failed: ${message}`);
   }
 }
 
@@ -457,9 +507,10 @@ async function handleExplain(): Promise<void> {
   try {
     const res = await postToApi<ExplanationResponse>('/explanation/', { code, language: lang }, timeout);
     panel.webview.html = renderExplainHtml(res);
-  } catch (err: any) {
-    panel.webview.html = errorHtml(err.message);
-    vscode.window.showErrorMessage(`QyverixAI explanation failed: ${err.message}`);
+  } catch (err: unknown) {
+    const message = safeApiErrorMessage(err);
+    panel.webview.html = errorHtml(message);
+    vscode.window.showErrorMessage(`QyverixAI explanation failed: ${message}`);
   }
 }
 
@@ -486,9 +537,10 @@ async function handleSuggest(): Promise<void> {
     const res = await postToApi<SuggestionsResponse>('/suggestions/', { code, language: lang }, timeout);
     panel.webview.html = renderSuggestHtml(res);
     vscode.window.showInformationMessage(`QyverixAI: grade ${res.grade} (${res.overall_score}/100)`);
-  } catch (err: any) {
-    panel.webview.html = errorHtml(err.message);
-    vscode.window.showErrorMessage(`QyverixAI suggestions failed: ${err.message}`);
+  } catch (err: unknown) {
+    const message = safeApiErrorMessage(err);
+    panel.webview.html = errorHtml(message);
+    vscode.window.showErrorMessage(`QyverixAI suggestions failed: ${message}`);
   }
 }
 

--- a/vscode-extension/tests/api-errors.test.cjs
+++ b/vscode-extension/tests/api-errors.test.cjs
@@ -1,0 +1,164 @@
+const assert = require('node:assert/strict');
+const http = require('node:http');
+const Module = require('node:module');
+const { test } = require('node:test');
+
+const commands = new Map();
+const messages = [];
+const panels = [];
+const logs = [];
+const originalWarn = console.warn;
+console.warn = (...args) => logs.push(args.join(' '));
+require('node:test').after(() => { console.warn = originalWarn; });
+let apiUrl;
+let timeout = 1;
+const vscode = {
+  workspace: { getConfiguration: () => ({ get: (key, fallback) => ({ apiUrl, timeout })[key] ?? fallback }) },
+  window: {
+    activeTextEditor: { document: { getText: () => 'print(1)', languageId: 'python', fileName: 'example.py', uri: 'test:example' } },
+    createWebviewPanel: () => { const panel = { webview: { html: '' } }; panels.push(panel); return panel; },
+    showErrorMessage: message => messages.push(message),
+    showWarningMessage: () => {},
+    showInformationMessage: () => {},
+  },
+  ViewColumn: { Beside: 2 },
+  languages: { createDiagnosticCollection: () => ({ set() {}, dispose() {} }) },
+  commands: { registerCommand: (name, callback) => { commands.set(name, callback); return { dispose() {} }; } },
+};
+const originalLoad = Module._load;
+Module._load = function (id, ...args) {
+  return id === 'vscode' ? vscode : originalLoad.call(this, id, ...args);
+};
+try {
+  require('../extension.js').activate({ subscriptions: [] });
+} finally {
+  Module._load = originalLoad;
+}
+
+async function serve(t, handler) {
+  const server = http.createServer(handler);
+  await new Promise(resolve => server.listen(0, '127.0.0.1', resolve));
+  apiUrl = `http://127.0.0.1:${server.address().port}`;
+  timeout = 1;
+  t.after(() => new Promise(resolve => {
+    server.close(resolve);
+    server.closeAllConnections();
+  }));
+  return server;
+}
+
+const sentinel = 'PRIVATE_RESPONSE_SENTINEL';
+for (const command of ['analyze', 'debug', 'explain', 'suggest']) {
+  test(`${command} never displays server error bodies`, async t => {
+    await serve(t, (_, res) => { res.writeHead(503); res.end(sentinel); });
+    await commands.get(`qyverixai.${command}`)();
+    assert.doesNotMatch(messages.at(-1), new RegExp(sentinel));
+    assert.doesNotMatch(panels.at(-1).webview.html, new RegExp(sentinel));
+    assert.match(messages.at(-1), /503/);
+    assert.match(logs.at(-1), /http.*503/);
+    assert.doesNotMatch(logs.at(-1), new RegExp(sentinel));
+  });
+}
+
+test('invalid JSON does not expose response contents', async t => {
+  await serve(t, (_, res) => res.end(sentinel));
+  await commands.get('qyverixai.explain')();
+  assert.doesNotMatch(messages.at(-1), new RegExp(sentinel));
+  assert.match(messages.at(-1), /invalid response/i);
+});
+
+for (const status of [400, 401, 403, 404, 429, 500, 502]) {
+  test(`HTTP ${status} reports only the status, not upstream details`, async t => {
+    await serve(t, (_, res) => { res.writeHead(status); res.end(JSON.stringify({ detail: sentinel })); });
+    await commands.get('qyverixai.explain')();
+    assert.match(messages.at(-1), new RegExp(`HTTP ${status}`));
+    assert.doesNotMatch(messages.at(-1), new RegExp(sentinel));
+  });
+}
+
+for (const body of ['null', '[]', '42', '"unexpected"', '{}']) {
+  test(`unexpected response shape ${body} has a stable error`, async t => {
+    await serve(t, (_, res) => res.end(body));
+    await commands.get('qyverixai.explain')();
+    assert.match(messages.at(-1), /invalid response/i);
+    assert.doesNotMatch(messages.at(-1), /TypeError|Cannot read/);
+  });
+}
+
+test('connection reset has a stable error', async t => {
+  await serve(t, req => req.socket.destroy());
+  await commands.get('qyverixai.explain')();
+  assert.match(messages.at(-1), /Could not connect/);
+  assert.doesNotMatch(messages.at(-1), /ECONNRESET|socket hang up|127\.0\.0\.1/);
+});
+
+test('a truncated response rejects instead of leaving the command pending', { timeout: 2000 }, async t => {
+  await serve(t, (_, res) => {
+    res.writeHead(200, { 'Content-Length': 1000 });
+    res.write('{');
+    setTimeout(() => res.destroy(), 10);
+  });
+  await commands.get('qyverixai.explain')();
+  assert.match(messages.at(-1), /Could not connect/);
+});
+
+test('a stalled request reaches its deadline', { timeout: 2000 }, async t => {
+  await serve(t, () => {});
+  timeout = 0.05;
+  await commands.get('qyverixai.explain')();
+  assert.match(messages.at(-1), /timed out/);
+});
+
+test('response activity cannot postpone the request deadline indefinitely', { timeout: 2000 }, async t => {
+  await serve(t, (_, res) => {
+    res.writeHead(200);
+    res.write('{');
+    const timer = setInterval(() => res.write(' '), 10);
+    res.on('close', () => clearInterval(timer));
+  });
+  timeout = 0.05;
+  await commands.get('qyverixai.explain')();
+  assert.match(messages.at(-1), /timed out/);
+});
+
+for (const invalidUrl of ['not-a-url', 'ftp://localhost', `http://user:${sentinel}@localhost`]) {
+  test('invalid URL configuration does not expose its value', async () => {
+    apiUrl = invalidUrl;
+    await commands.get('qyverixai.explain')();
+    assert.match(messages.at(-1), /Settings/);
+    assert.doesNotMatch(messages.at(-1), new RegExp(sentinel));
+  });
+}
+
+for (const invalidTimeout of [0, -1, Infinity, NaN, 2147484]) {
+  test(`invalid timeout ${invalidTimeout} is rejected`, async t => {
+    await serve(t, (_, res) => res.end('{}'));
+    timeout = invalidTimeout;
+    await commands.get('qyverixai.explain')();
+    assert.match(messages.at(-1), /Settings/);
+  });
+}
+
+test('successful requests preserve payloads and split UTF-8 response characters', async t => {
+  const explanation = {
+    language: 'python', summary: 'Résumé: café', key_points: ['Prints a number'],
+    complexity: 'O(1)', line_count: 1, function_count: 0, class_count: 0,
+  };
+  let received;
+  await serve(t, (req, res) => {
+    let body = '';
+    req.on('data', chunk => { body += chunk; });
+    req.on('end', () => {
+      received = JSON.parse(body);
+      const bytes = Buffer.from(JSON.stringify(explanation));
+      const split = bytes.indexOf(Buffer.from('é')) + 1;
+      res.write(bytes.subarray(0, split));
+      setImmediate(() => res.end(bytes.subarray(split)));
+    });
+  });
+  const errorCount = messages.length;
+  await commands.get('qyverixai.explain')();
+  assert.equal(messages.length, errorCount);
+  assert.deepEqual(received, { code: 'print(1)', language: 'python' });
+  assert.match(panels.at(-1).webview.html, /Résumé: café/);
+});


### PR DESCRIPTION
## Summary

When an API request fails, all four VS Code commands currently display raw server response bodies or transport exception text in notifications and WebViews. This change maps those failures to locally defined messages, retaining only the failure category and HTTP status in diagnostic logs.

The shared request helper also handles interrupted responses, preserves UTF-8 across response chunks, and bounds the complete request with a deadline so a trickling response cannot keep a command pending indefinitely.

Closes #1371.

## Validation

- `npm --prefix vscode-extension test`: 30 tests pass, including the registered command handlers against a local HTTP server and a VS Code API stub. The five original regression cases failed before the fix.
- `ruff check backend/app --select E,F,W --ignore E501`: passes.
- Added an extension CI workflow and excluded test fixtures from the VSIX package. Updated extension documentation and the changelog.
- Full backend suite attempted on macOS/Python 3.12. With FastAPI 0.115.0 / Starlette 0.38.6: **639 passed, 1 failed** (`test_large_file` uses `HTTP_413_CONTENT_TOO_LARGE`, absent from that Starlette version). With the initially resolved FastAPI 0.141.1 / Starlette 1.6.0: 108 tests passed before the existing WebSocket broadcast test stalled; the run was interrupted. The same targeted stall occurred with Starlette 0.47.3. Backend source, tests, and dependency requirements are unchanged in this PR. I am not claiming a green full backend suite.

Implemented and validated with Codex. The extension tests use a stubbed VS Code API; a VS Code Extension Development Host session was not run.
